### PR TITLE
Build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ map (1+) $ map (2*) [0..9]
 ```ijs
 1+2*i.10
 ```
+
+### Getting started & Building:
+1. Checkout the repository:
+    
+    `https://github.com/codereport/jsource.git`
+2. Build jconsole:
+    
+    `cd jsource`
+
+    `mkdir build && cmake -G "Ninja Multi-Config" -B build`
+
+    `ninja -C build` or `ninja -C build -f build-Release.ninja` if you are building for release.
+
+    To run the debug build: `./build/jsrc/Debug/jconsole` 
+
+    To run the release build: `./build/jsrc/Release/jconsole`


### PR DESCRIPTION
Instructions to get started and to build jconsole, in the README.md file.