### PR TITLE
remove clion's build and settings via .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ make2/
 /jlibrary/system/config
 /jlibrary/system/main
 /jlibrary/tools
+
+# clion's cmake creates cmake-build-release, cmake-build-debug, etc...
+cmake-build-*/
+# clion's settings folder. keep or not up to you. can be useful for spellcheck etc.
+.idea


### PR DESCRIPTION
This is just a minor pull request. For those that use clion this keeps the build directories and settings out of the repo.