### PR TITLE
Removing even more SYS stuff

### DIFF
--- a/jsrc/f2.c
+++ b/jsrc/f2.c
@@ -247,7 +247,7 @@ static B jtth2ctrl(J jt,A a,A*ep,A*mp,A*dp,A*sp,I*zkp){A da,ea,ma,s;B b=1,*ev,r,
   if(0>m)m=-m; if(0>d)d=-d; ASSERT(0<=(m|d),EVLIMIT);  // verify no overflow
   // Create sprintf format string for the field, depending on decimal/exponential form
   if(!x)sprintf(sv, "%%"FMTI"."FMTI"f",  m,d);  // %m.df
-  else  sprintf(sv, m?"%%- "FMTI"."FMTI"e" :"%%-"FMTI"."FMTI"e", m?m-1:0,d+!!(SYS&0));  // %- m.de (m=0)  or %-m.de (m!=0)
+  else  sprintf(sv, m?"%%- "FMTI"."FMTI"e" :"%%-"FMTI"."FMTI"e", m?m-1:0,d);  // %- m.de (m=0)  or %-m.de (m!=0)
   // store results in output areas; advance sprintf pointer; count # bytes in fields; see if there are any unknown widths
   sv+=sk; ev[i]=x; mv[i]=m; dv[i]=d; zk+=m; b=b&&m; 
   // keep the size of the conversion buffer to a minimum of the given field width or 500+the number of decimal places (in case the values overflows the field)

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -912,7 +912,6 @@ extern J gjt; // global for JPF (procs without jt)
 #define CCBLOCK
 #endif
 
-#if SYS & SYS_UNIX
 #include <fenv.h>
 // bug clang isnan(x) set NaN flag if x is NaN
 
@@ -925,7 +924,6 @@ static inline UINT _clearfp(void){
   feclearexcept(FE_ALL_EXCEPT); 
   return r;
 }
-#endif
 
 // Define integer multiply, *z=x*y but do something else if integer overflow.
 // Depending on the compiler, the overflowed result may or may not have been stored

--- a/jsrc/jdlllic.c
+++ b/jsrc/jdlllic.c
@@ -19,14 +19,12 @@
 #define SERIALNUMSIZE 32
 #define lobyte(w)  ((UC)(w))
 
-#if !(SYS & SYS_LILENDIAN)
 int swapint(int n){C* p,c;
  p=(C*)&n;
  c=p[3];p[3]=p[0];p[0]=c;
  c=p[2];p[2]=p[1];p[1]=c;
  return n;
 }
-#endif
 
 F1(jtlock1){A z; C* p; C* src;
  UC c,c1,c2,k1[SK],k2[SK];    
@@ -46,9 +44,6 @@ F1(jtlock1){A z; C* p; C* src;
  r=4+4+SK+LOCKEXTRA+maxc1+len+SK+maxc2+2*SERIALNUMSIZE; /* result len */
  GATV0(z,LIT,r,1);
  p=CAV(z);
-#if !(SYS & SYS_LILENDIAN)
- xlen=swapint(len);
-#endif
  for(i=0;i<SK;++i) k1[i] = lobyte(rand());
  for(i=0;i<SK;++i) k2[i] = lobyte(rand());
  *p++=(UC)255; *p++=0; *p++=c1; *p++=c2;
@@ -83,9 +78,6 @@ F2(jtunlock2){int i,j,len,tlen;UC c1,c2,k1[SK],*lp,*sp,*d;
  if(!tlen || 255!=d[0] || 0 != d[1] || tlen<8+SK) return w; /* not jl */
  MC(k1, d+8, SK);
  for(i=0;i<(int)sizeof(int);++i) *(i+(UC*)&len) = k1[i] ^ d[4+i];
-#if !(SYS & SYS_LILENDIAN)
- len=swapint(len);
-#endif
  c1 = max(33,d[2]);
  c2 = max(33,d[3]);
  if(!tlen == (8+LOCKEXTRA+c1+c2+len+ 2*SK + 2*SERIALNUMSIZE)) return w; /* not jl */

--- a/jsrc/js.h
+++ b/jsrc/js.h
@@ -10,8 +10,7 @@
 #define SYS_MACOSX          4194304L        /* GCC (CC)                    */
 
 #define SY_LINUX            0    /* any linux intel version                */
-#define SY_MAC              0    /* any macosx intel (once included ppc)   */
-#define SY_MACPPC           0    /* macosx powerpc                         */
+#define SY_MAC              0    /* any macosx intel                       */
 
 #define SYS_UNIX            (SYS_LINUX + SYS_MACOSX)
 
@@ -22,25 +21,10 @@
 #endif
 
 #ifdef __MACH__
-#ifdef __ppc__
 #ifdef __GNUC__
-#define SYS SYS_MACOSX // powerpc
+#define SYS SYS_MACOSX
 #undef SY_MAC
 #define SY_MAC 1
-#undef SY_MACPPC
-#def SY_MACPPC 1
-#endif
-#endif
-#endif
-
-#ifdef __MACH__
-#ifndef __ppc__
-#ifdef __GNUC__
-#define SYS SYS_MACOSX // intel
-#undef SY_MAC
-#define SY_MAC 1
-
-#endif
 #endif
 #endif
 

--- a/jsrc/js.h
+++ b/jsrc/js.h
@@ -8,7 +8,6 @@
 
 #define SYS_LINUX           262144L         /* GCC                         */
 #define SYS_MACOSX          4194304L        /* GCC (CC)                    */
-#define SYS_UNIX            (SYS_LINUX + SYS_MACOSX)
 
 #ifdef __linux__
 #define SYS SYS_LINUX

--- a/jsrc/js.h
+++ b/jsrc/js.h
@@ -10,7 +10,6 @@
 #define SYS_MACOSX          4194304L        /* GCC (CC)                    */
 
 #define SY_LINUX            0    /* any linux intel version                */
-#define SY_MAC              0    /* any macosx intel                       */
 
 #define SYS_UNIX            (SYS_LINUX + SYS_MACOSX)
 
@@ -23,8 +22,6 @@
 #ifdef __MACH__
 #ifdef __GNUC__
 #define SYS SYS_MACOSX
-#undef SY_MAC
-#define SY_MAC 1
 #endif
 #endif
 

--- a/jsrc/js.h
+++ b/jsrc/js.h
@@ -8,15 +8,10 @@
 
 #define SYS_LINUX           262144L         /* GCC                         */
 #define SYS_MACOSX          4194304L        /* GCC (CC)                    */
-
-#define SY_LINUX            0    /* any linux intel version                */
-
 #define SYS_UNIX            (SYS_LINUX + SYS_MACOSX)
 
 #ifdef __linux__
 #define SYS SYS_LINUX
-#undef SY_LINUX
-#define SY_LINUX 1
 #endif
 
 #ifdef __MACH__

--- a/jsrc/jtype.h
+++ b/jsrc/jtype.h
@@ -5,9 +5,7 @@
 
 #define U unsigned
 
-#if (SYS & SYS_UNIX)
-#define _stdcall      
-#endif
+#define _stdcall
 
 #if defined(__GNUC__)
 #define CDPROC __attribute__ ((visibility ("default")))

--- a/jsrc/m.h
+++ b/jsrc/m.h
@@ -3,11 +3,6 @@
 /*                                                                         */
 /* Memory Management                                                       */
 
-/* ANSI C already has malloc by j.h include of stdlib.h                    */
-#if !(SYS+SYS_ANSI)
-#include <malloc.h>
-#endif
-
 #define FREE(a) free(a)
 #define MALLOC(n) malloc(n)
 #define REALLOC(a,n) realloc(a,n)

--- a/jsrc/m.h
+++ b/jsrc/m.h
@@ -4,7 +4,7 @@
 /* Memory Management                                                       */
 
 /* ANSI C already has malloc by j.h include of stdlib.h                    */
-#if (SYS & SYS_UNIX) && !(SYS+SYS_ANSI)
+#if !(SYS+SYS_ANSI)
 #include <malloc.h>
 #endif
 
@@ -40,5 +40,3 @@
 #define bplg(i) (((I)0x008bb6db408dc6c0>>3*CTTZ(i))&(I)7)  // 010 001 011   101 101 101 101 101 101 000 000   100 011 011 100 011 011 000 000 = 0 1000 1011 1011 0110 1101 1011   0100 0000 1000 1101 1100 0110 1100 0000
 // bpnoun is like bp but for NOUN types
 #define bpnoun(i) ((I)1<<bplg(i))
-
-

--- a/jsrc/x15.c
+++ b/jsrc/x15.c
@@ -62,8 +62,6 @@ typedef double complex double_complex;
 /*  LoadLibrary, GetProcAddress, FreeLibrary routines           */
 /*  GetLastError and FormatMessage                              */
 
-#if (SYS & SYS_UNIX)
-
 #include <dlfcn.h>
 
 #undef MAX     /* defined in sys/param.h */
@@ -76,7 +74,6 @@ typedef char *LPSTR;
 typedef I (*FARPROC)();
 #define __stdcall
 #define _cdecl
-#endif
 
 /* windows has 2 dll calling conventions - __stdcall and _cdecl */
 /* __stdcall is used by most DLLs, including all system APIs    */
@@ -640,15 +637,11 @@ static CCT*jtcdload(J jt,CCT*cc,C*lib,C*proc){B ha=0;FARPROC f;HMODULE h;
  else{
   CDASSERT(AM(jt->cdhashl)<NLIBS,DETOOMANY);    /* too many dlls loaded */
 
-#if SYS & SYS_UNIX
   CDASSERT(h=dlopen((*lib)?lib:0,RTLD_LAZY),DEBADLIB);
-#endif
   cc->h=h; ha=1;
  }
 
-#if (SYS & SYS_UNIX)
  f=(FARPROC)dlsym(h,proc);
-#endif
  CDASSERT(f!=0,DEBADFN);
  cc->fp=f;
  /* assumes the hash table for libraries (jt->cdhashl) is fixed sized */
@@ -884,9 +877,7 @@ static B jtcdexec1(J jt,CCT*cc,C*zv0,C*wu,I wk,I wt,I wd){A*wv=(A*)wu,x,y,*zv;B 
 
  DO(cipcount, convertup(cipv[i],cipn[i],cipt[i]);); /* convert s and int to I and f to d as required */
 
-#if SYS&SYS_UNIX
  t=errno;
-#endif
  if(t!=0)jt->getlasterror=t;
  return 1;
 }
@@ -919,9 +910,7 @@ F2(jtcd){A z;C*tv,*wv,*zv;CCT*cc;I k,m,n,p,q,t,wr,*ws,wt;
 
 
 
-#if (SYS & SYS_UNIX)
 #define FREELIB dlclose
-#endif
 
 void dllquit(J jt){CCT*av;I j,*v;
  if(!jt->cdarg)return;
@@ -944,9 +933,7 @@ F1(jtcder){I t; ASSERTMTV(w); t=jt->dlllasterror; jt->dlllasterror=DEOK; return 
 F1(jtcderx){I t;C buf[1024];
  ASSERTMTV(w); t=jt->getlasterror; jt->getlasterror=0;
 
-#if SYS&SYS_UNIX
  {const char *e = dlerror(); strcpy (buf, e?e:"");}
-#endif
  return link(sc(t),cstr(buf));
 }    /* 15!:11  GetLastError information */
 
@@ -1188,9 +1175,7 @@ F2(jtcdproc2){C*proc;FARPROC f;HMODULE h;
   f=(k==-1)?(FARPROC)0:(FARPROC)jfntaddr[k];
  }else{
 
-#if (SYS & SYS_UNIX)
   f=(FARPROC)dlsym(h,proc);
-#endif
  }
  CDASSERT(f!=0,DEBADFN);
  return sc((I)f);

--- a/jsrc/x15.c
+++ b/jsrc/x15.c
@@ -130,9 +130,7 @@ typedef struct {
 
 
 
-#if (SYS & SYS_MACOSX) | (SYS & SYS_LINUX)
 extern void double_trick(D,D,D,D,D,D,D,D);
-#endif
 
 #if defined(__x86_64__)
 /* might be faster */

--- a/jsrc/x15.c
+++ b/jsrc/x15.c
@@ -134,16 +134,10 @@ typedef struct {
 
 
 #if (SYS & SYS_MACOSX) | (SYS & SYS_LINUX)
-#ifdef __PPC64__
-extern void double_trick(D,D,D,D,D,D,D,D,D,D,D,D,D);
-#else
 extern void double_trick(D,D,D,D,D,D,D,D);
 #endif
-#endif
 
-#ifdef __PPC64__
-  #define dtrick double_trick(dd[0],dd[1],dd[2],dd[3],dd[4],dd[5],dd[6],dd[7],dd[8],dd[9],dd[10],dd[11],dd[12]);
-#elif defined(__x86_64__)
+#if defined(__x86_64__)
 /* might be faster */
   #define dtrick \
 __asm__ ("movq (%0),%%xmm0\n\t"       \
@@ -850,11 +844,7 @@ static B jtcdexec1(J jt,CCT*cc,C*zv0,C*wu,I wk,I wt,I wd){A*wv=(A*)wu,x,y,*zv;B 
    case 'i': *dv++=(int)*xv; break;
    case 'x': *dv++=*xv;      break;
    case 'f':
-  #if defined(__PPC64__)
-     /* +1 put the float in low bits in dv, but dd has to be D */
-     *dv=0; *(((float*)dv++))=(float)(dd[dcnt++]=*(D*)xv);
-     /* *dv=0; *(((float*)dv++)+1)=dd[dcnt++]=(float)*(D*)xv; */
-  #elif defined(__aarch64__)
+  #if defined(__aarch64__)
      {f=(float)*(D*)xv; dd[dcnt]=0; *(float*)(dd+dcnt++)=f;
       if(dcnt>8){
         if(dv-data>=8)*(float*)(dv++)=f;else *(float*)(data+dcnt-1)=f;}}
@@ -865,10 +855,7 @@ static B jtcdexec1(J jt,CCT*cc,C*zv0,C*wu,I wk,I wt,I wd){A*wv=(A*)wu,x,y,*zv;B 
   #endif
              break;
    case 'd':
-#if defined(__PPC64__)
-             /* always need to increment dv, the contents get used from the 14th D */
-             *(D*)dv++=dd[dcnt++]=*(D*)xv;
-#elif defined(__aarch64__)
+#if defined(__aarch64__)
              dd[dcnt++]=*(D*)xv;
              if(dcnt>8){
                if(dv-data>=8)*dv++=*xv;else *(data+dcnt-1)=*xv;}

--- a/jsrc/x15.c
+++ b/jsrc/x15.c
@@ -140,28 +140,6 @@ extern void double_trick(D,D,D,D,D,D,D,D,D,D,D,D,D);
 extern void double_trick(D,D,D,D,D,D,D,D);
 #endif
 #endif
-#if SY_MACPPC
-static void double_trick(double*v, I n){I i=0;
- for(;i<n;i++)
-#define l(a) case (a-1): asm volatile ( "mr r14, %0\nlfd f" #a ", 0(r14)" : : "r" (v+a-1 ) : "f" #a , "r14" ); break;
-  switch(i) {
-   l(1)
-   l(2)
-   l(3)
-   l(4)
-   l(5)
-   l(6)
-   l(7)
-   l(8)
-   l(9)
-   l(10)
-   l(11)
-   l(12)
-   l(13)
-  }
-#undef l
-}
-#endif
 
 #ifdef __PPC64__
   #define dtrick double_trick(dd[0],dd[1],dd[2],dd[3],dd[4],dd[5],dd[6],dd[7],dd[8],dd[9],dd[10],dd[11],dd[12]);
@@ -872,9 +850,6 @@ static B jtcdexec1(J jt,CCT*cc,C*zv0,C*wu,I wk,I wt,I wd){A*wv=(A*)wu,x,y,*zv;B 
    case 'i': *dv++=(int)*xv; break;
    case 'x': *dv++=*xv;      break;
    case 'f':
-#if SY_MACPPC
-          dd[dcnt++]=(float)*(D*)xv;
-#endif
   #if defined(__PPC64__)
      /* +1 put the float in low bits in dv, but dd has to be D */
      *dv=0; *(((float*)dv++))=(float)(dd[dcnt++]=*(D*)xv);
@@ -890,9 +865,6 @@ static B jtcdexec1(J jt,CCT*cc,C*zv0,C*wu,I wk,I wt,I wd){A*wv=(A*)wu,x,y,*zv;B 
   #endif
              break;
    case 'd':
-#if SY_MACPPC
-             dd[dcnt++]=*(D*)xv;
-#endif
 #if defined(__PPC64__)
              /* always need to increment dv, the contents get used from the 14th D */
              *(D*)dv++=dd[dcnt++]=*(D*)xv;
@@ -1236,4 +1208,3 @@ F2(jtcdproc2){C*proc;FARPROC f;HMODULE h;
  CDASSERT(f!=0,DEBADFN);
  return sc((I)f);
 }    /* 15!:21 return proc address */
-

--- a/jsrc/xa.c
+++ b/jsrc/xa.c
@@ -168,7 +168,7 @@ F1(jtseclevs){I k;
 
 F1(jtsysq){I j;
  ASSERTMTV(w);
- j=SYS&SYS_UNIX ? 5 : -1;
+ j=5;
  return sc(j);
 }
 

--- a/jsrc/xd.c
+++ b/jsrc/xd.c
@@ -48,9 +48,6 @@ static C*modebuf(mode_t m,C* b){C c;I t=m;
   case S_IFBLK:  b[0]='b'; break;
   case S_IFCHR:  b[0]='c'; break;
   case S_IFDIR:  b[0]='d'; break;
-#if !(SYS & SYS_UNIX)
-  case S_IFFIFO: b[0]='f'; break;    /*IVL */
-#endif
   case S_IFLNK:  b[0]='l'; break;
   case S_IFSOCK: b[0]='s'; break;
   case S_IFREG:  b[0]='-'; break;

--- a/jsrc/xh.c
+++ b/jsrc/xh.c
@@ -77,15 +77,6 @@ F1(jthostne){
  return mtv;
 }
 
-
-
-#if !(SYS & SYS_UNIX)
-
-F1(jthostio){ASSERT(0,EVDOMAIN);}
-F1(jtjwait ){ASSERT(0,EVDOMAIN);}
-
-#else
-
 #define CL(f) {close(f[0]);close(f[1]);}
 
 F1(jthostio){C*s;A z;F*pz;int fi[2],fo[2],r;int fii[2],foi[2];
@@ -113,8 +104,6 @@ F1(jthostio){C*s;A z;F*pz;int fi[2],fo[2],r;int fii[2],foi[2];
 
 F1(jtjwait){I k;int s; RE(k=i0(w)); if(-1==waitpid(k,&s,0))jerrno(); return sc(s);}
 
-#endif
-
 /* return errno info from c library */
 F1(jtcerrno){C buf[1024],ermsg[1024];
  ASSERTMTV(w);
@@ -122,4 +111,3 @@ F1(jtcerrno){C buf[1024],ermsg[1024];
  if(errno&&!strerror_r(errno,ermsg,1024)) strcpy (buf, ermsg); else strcpy (buf, "");
  return link(sc(errno),cstr(buf));
 }    /* 2!:8  errno information */
-

--- a/jsrc/xl.c
+++ b/jsrc/xl.c
@@ -9,19 +9,13 @@
 #endif
 #include "x.h"
 
-#if (SYS & SYS_UNIX)
 typedef long long INT64;
 #include <stdint.h>
 #include <stdio.h>
 #define LOCK 1
-#if (SYS & SYS_UNIX)
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/file.h>
-#else
-#include <sys/locking.h>
-#include <io.h>
-#endif
 
 // extern int _locking(int,int,long);
 
@@ -36,7 +30,6 @@ static B jtdolock(J jt,B lk,F f,I i,I n){I e;long c;fpos_t v; fpos_t q;
  fsetpos(f,(fpos_t*)&q);
  return !e?1:errno==EACCES?0:(B)(intptr_t)jerrno();
 }
-#endif
 
 #ifndef LOCK
 static B jtdolock(J jt,B lk,F f,I i,I n){I e;

--- a/jsrc/xo.c
+++ b/jsrc/xo.c
@@ -47,25 +47,12 @@ F jtjope(J jt,A w,C*mode){A t;F f;I n;static I nf=25; A z;
  RZ(t=str0(vslit(AAV(w)[0])));
  n=AN(t)-1;
  ASSERT(n!=0,EVLENGTH);
-#if (SYS&SYS_UNIX)
 {
  C* cs=CAV(t);
  f=fopen(cs,mode);
  if(!f&&errno==ENOENT&&!strcmp(mode,FUPDATE_O))f=fopen(cs,FUPDATEC_O);
  if(!f&&errno==EACCES&& strcmp(mode,FREAD_O  ))f=fopen(cs,FREAD_O);
 }
-#else
-{
- US usmode[10]; US*s; I i;
- RZ(z=jttoutf16x(jt,t));
- s=USAV(z);
- for(i=0;i<(I)strlen(mode);++i){usmode[i]=(US)mode[i];}
- usmode[i]=0;
- f=_wfopen(s,usmode);
- if(!f&&errno==ENOENT&&!wcscmp(usmode,FLUPDATE_O))f=_wfopen(s,FLUPDATEC_O);
- if(!f&&errno==EACCES&& wcscmp(usmode,FLREAD_O  ))f=_wfopen(s,FLREAD_O);
-}
-#endif
  return f?f:(F)jerrno();
 }
 

--- a/jsrc/xt.c
+++ b/jsrc/xt.c
@@ -13,15 +13,11 @@
 #if (SYS & SYS_LINUX)
 #include <time.h>
 #else
-#if SYS & SYS_UNIX
 #include <sys/time.h>
-#endif
 #endif
 
 #ifndef CLOCKS_PER_SEC
-#if (SYS & SYS_UNIX)
 #define CLOCKS_PER_SEC  1000000
-#endif
 #ifdef  CLK_TCK
 #define CLOCKS_PER_SEC  CLK_TCK
 #endif


### PR DESCRIPTION
 - Removes macros for Power PC.
 - Both mac and linux are unix, so `SYS & UNIX` is always true, so some stuff could be removed.
 - `SY_MAC` and `SY_LINUX` were not used.
 - `SYS_LILENDIAN` and `SYS_ANSI` are not defined, so they are interpreted as 0. Some stuff could be removed.

We probably want someone with a mac to build and test this aswell since I can't test the mac macros locally.

`SYS_LINUX` and `SYS_MACOSX` remain. They seem to be used in a more functional way and require more thought to remove.