### PR TITLE
Remove return macros

### DIFF
--- a/jsrc/adverbs/a.c
+++ b/jsrc/adverbs/a.c
@@ -74,7 +74,7 @@ F1(jtbdot){A b,h=0;I j=0,n,*v;
   case 34: return fdef(0,CBDOT,VERB, jtbitwise1,jtbitwiseshifta, 0L,w,0L, VASGSAFE|VJTFLGOK2, 0L,0L,0L);
   // The code uses a VERB with id CBDOT to stand for the derived verb of m b. .  This is used for spellout and for inverses, so we retain it.
   // We copy the other information from the verb that executes the function.  This contains pointers to the routines, and to the function table
-  default: {A z=ca(ds(j-16+CBW0000)); RZ(z); RZ(FAV(z)->fgh[1]=rifvs(w)); FAV(z)->id=CBDOT; RETF(z);}  // use g field not f to avoid interfering with atomic2
+  default: {A z=ca(ds(j-16+CBW0000)); RZ(z); RZ(FAV(z)->fgh[1]=rifvs(w)); FAV(z)->id=CBDOT; return z;}  // use g field not f to avoid interfering with atomic2
  }
 }
 

--- a/jsrc/adverbs/ab.c
+++ b/jsrc/adverbs/ab.c
@@ -77,7 +77,7 @@ static AHDRR(bw1010insC,UC,UC){I k=d*(n-1);UC t=(UC)((n&1)-1); x+=k; DQ(m, DQ(d,
   if     (AR(a)==AR(w))DQ(AN(a), x=*av++;           y=*wv++; *zv++=op(x,y);  )  \
   else if(AR(a)< AR(w))DQ(AN(a), x=*av++; DQ(AN(w)/AN(a), y=*wv++; *zv++=op(x,y););)  \
   else           DQ(AN(w), y=*wv++; DQ(AN(a)/AN(w), x=*av++; *zv++=op(x,y););); \
-  RE(0); RETF(z);                                                          \
+  RE(0); return z;                                                          \
  }
 
 #define BWROT(x,y)      ((y<<(x&(BW-1)))|(y>>(BW-(x&(BW-1)))))
@@ -116,7 +116,7 @@ DF2(jtbitwisechar){DECLFG;A*p,x,y,z;B b;I j,m,n,zn;AHDR2FN* ado;
  n^=-b; n=(n==~1)?1:n;  // encode b flag in sign of n
  ado(n,m,AV(x),AV(y),AV(z),jt); 
  *(zn+CAV(z))=0;
- RETF(z);
+ return z;
 }
 
 /* compute z=: t{~ a.i.w if t=: c&(m b.) a.                             */

--- a/jsrc/adverbs/af.c
+++ b/jsrc/adverbs/af.c
@@ -10,7 +10,7 @@ F1(jtunname){A x;V*v;
  ARGCHK1(w); 
  v=VAV(w);
  if(CTILDE==v->id&&!jt->uflags.us.cx.cx_c.glock&&!(VLOCK&v->flag)){x=v->fgh[0]; if(NAME&AT(x))return symbrd(x);}
- RETF(w);
+ return w;
 }
 
 static B jtselfq(J jt,A w){A hs,*u;V*v;

--- a/jsrc/adverbs/ai.c
+++ b/jsrc/adverbs/ai.c
@@ -92,7 +92,7 @@ static F1(jtbminv){A*wv,x,z=w;I i,j,m,r,*s,t=0,*u,**v,*y,wn,wr,*ws;
    j=wr-1; while(1){--j; ++u[j]; if(ws[j]>u[j])break; u[j]=0;}
  }}
  DO(wr, A t=z; RZ(df1(z,t,slash(under(qq(ds(CCOMMA),sc(wr-i)),ds(COPE))))););
- RETF(ope(z));
+ return ope(z);
 }    /* <;.1 or <;.2 inverse on matrix argument */
 
 

--- a/jsrc/adverbs/am.c
+++ b/jsrc/adverbs/am.c
@@ -123,7 +123,7 @@ static A jtmerge2(J jt,A a,A w,A ind,I cellframelen){F2PREFIP;A z;I t;
  // <---a   a a
  ASSERTAGREE(AS(a),AS(ind)+AR(ind)-MAX(0,AR(a)-(AR(w)-cellframelen)),MAX(0,AR(a)-(AR(w)-cellframelen)));  // shape of m{y is the shape of m, as far as it goes.  The first part of a may overlap with m
  ASSERTAGREE(AS(a)+MAX(0,AR(a)-(AR(w)-cellframelen)),AS(w)+AR(w)-(AR(a)-MAX(0,AR(a)-(AR(w)-cellframelen))),AR(a)-MAX(0,AR(a)-(AR(w)-cellframelen)));  // the rest of the shape of m{y comes from shape of y
- if(!AN(w))RCA(w);  // if y empty, return.  It's small.  Ignore inplacing
+ if(!AN(w))return w;  // if y empty, return.  It's small.  Ignore inplacing
  t=AN(a)?maxtyped(AT(a),AT(w)):AT(w);  // get the type of the result: max of types, but if x empty, leave y as is
  if((-AN(a)&-TYPESXOR(t,AT(a)))<0)RZ(a=cvt(t,a));  // if a must change precision, do so
  // Keep the original address if the caller allowed it, precision of y is OK, the usecount allows inplacing, and the type is either

--- a/jsrc/adverbs/am.c
+++ b/jsrc/adverbs/am.c
@@ -109,7 +109,7 @@ F1(jtcasev){A b,*u,*v,w1,x,y,z;B*bv,p,q;I*aa,c,*iv,j,m,n,r,*s,t;
  }
  // Mark all the inputs as nonpristine
  DO(m, w=u[i]; PRISTCLRF(w))
- RETF(z);
+ return z;
 }   /* z=:b}x0,x1,x2,...,x(m-2),:x(m-1) */
 
 // Handle a ind} w after indices have been converted to integer atoms, dense
@@ -177,7 +177,7 @@ static A jtmerge2(J jt,A a,A w,A ind,I cellframelen){F2PREFIP;A z;I t;
    C* RESTRICT zv=CAV(z); DO(AN(ind), mvc(cellsize,zv+iv[i]*cellsize,abytes,av0); )  // scatter-copy the data, with repeat
   }
  }
- RETF(z);
+ return z;
 }
 
 // Convert list/table of indexes to a list of cell offsets (the number of the atom starting the cell)
@@ -326,7 +326,7 @@ static DF2(amccv2){F2PREFIP;DECLF;
  A z=jtmerge2(jtinplace,a,w,x,AR(w));   // The atoms of x include all axes of w, since we are addressing atoms
  // We modified w which is now not pristine.
  PRISTCLRF(w)
- RETF(z);
+ return z;
 }
 
 

--- a/jsrc/adverbs/ao.c
+++ b/jsrc/adverbs/ao.c
@@ -20,7 +20,7 @@ static DF1(jtoblique){A x,y,z;I m,n,r;D rkblk[16];
  // m and n are both non0: when one is 0, result has 0 cells (but that cell is the correct result
  // of execution on a fill-cell).  Correct the length of the 0 case, when the result length should be nonzero
 // if((m==0 || n==0) && (m+n>0)){return reitem(sc(m+n-1),x);}  This change withdrawn pending further deliberation
- RETF(z);
+ return z;
 }
 
 
@@ -150,7 +150,7 @@ DF2(jtpolymult){A f,g,z;B b=0;C*av,c,d,*wv;I at,i,j,k,m,m1,n,p,t,wt,zn;V*v;
  }
  if(t&FL+CMPX)NAN1; RE(0);
  if(!b)return obqfslash(df2(z,a,w,g),f);
- RETF(z);
+ return z;
 }    /* f//.@(g/) for atomic f, g */
 
 // start of x f/. y (Key)
@@ -524,7 +524,7 @@ DF2(jtkeybox){F2PREFIP;PROLOG(0009);A ai,z=0;I nitems;
   I nboxes=AM(ai);  //fetch # frets before we possibly clone ai
   makewritable(ai);  // we modify the size+index info to be running endptrs into the reorder area
   // allocate the result, which will be recursive, and set up to fill it with blocks off the tstack
-  GATV0(z,BOX,nboxes,1); if(nboxes==0){RETF(z);} // allocate result, and exit if empty for comp ease below
+  GATV0(z,BOX,nboxes,1); if(nboxes==0){return z;} // allocate result, and exit if empty for comp ease below
   // boxes will be in AAV(z), in order.  Details of hijacking tnextpushp are discussed in jtbox().
   // We have to do it a little differently here, because when we allocate a block the contents come in piecemeal and we have no
   // convenient time to INCORPRA the new contents.  So instead we leave the outer box non-recursive, and rely on the EPILOG to make
@@ -582,7 +582,7 @@ DF2(jtkeybox){F2PREFIP;PROLOG(0009);A ai,z=0;I nitems;
   I nboxes=0;  // initialize fret counter, incremented for each fret
   av=IAV(a); DQ(nitems, I tval=ftblv[*av&valmsk]; ftblv[*av&valmsk]=++tval; nboxes+=tval==freqminval; av=(I*)((I)av+k);)   // build (negative) frequency table; sub 1 for each non-fret
   // allocate the result, which will be recursive, and set up to fill it with blocks off the tstack
-  GATV0(z,BOX,nboxes,1); if(nboxes==0){RETF(z);} // allocate result, and exit if empty for comp ease below
+  GATV0(z,BOX,nboxes,1); if(nboxes==0){return z;} // allocate result, and exit if empty for comp ease below
   // boxes will be in AAV(z), in order.  Details discussed in jtbox().
   // We will later make the block recursive usecount, and we will set all the initial usecounts to 1 since they are not on the tpop stack
   pushxsave = jt->tnextpushp; jt->tnextpushp=AAV(z);  // save tstack info before allocation

--- a/jsrc/adverbs/ap.c
+++ b/jsrc/adverbs/ap.c
@@ -607,7 +607,7 @@ static DF2(jtinfixd){A fs,z;C*x,*y;I c=0,d,k,m,n,p,q,r,*s,wr,*ws,wt,zc;
   }else{ MC(x,y,n*k);  if(q=d*p-n)fillv(wt,q*c,x+n*k);
   }
  }
- RETF(z);
+ return z;
 }    /* a[\w and a]\w and a,\w */
 
 
@@ -643,7 +643,7 @@ static A jtmovsumavg1(J jt,I m,A w,A fs,B avg){A y,z;D d=(D)m;I c,p,wt;
   case 4: NAN0; MOVSUMAVG(D,D,FL, D,FL, x,  SETZ ); NAN1; break;
   case 5: NAN0; MOVSUMAVG(D,D,FL, D,FL, x/d,SETZD); NAN1; break;
  }
- RETF(z);
+ return z;
 }    /* m +/\w or (if 0=avg) m (+/%#)\w (if 1=avg); bool or integer or float; 0<m */
 
 static A jtmovsumavg(J jt,I m,A w,A fs,B avg){A z;
@@ -712,7 +712,7 @@ static A jtmovminmax(J jt,I m,A w,A fs,B max){A y,z;I c,i,j,p,wt;
   case 4: MOVMINMAX(D,FL, inf ,<=); break;
   case 5: MOVMINMAX(D,FL, infm,>=); break;
  }
- RETF(z);
+ return z;
 }    /* a <./\w (0=max) or a >./\ (1=max); vector w; integer/float/symbol; 0<m */
 
 static A jtmovandor(J jt,I m,A w,A fs,B or){A y,z;B b0,b1,d,e,*s,*t,*u,*v,x,*yv,*zv;I c,i,j,p;
@@ -736,7 +736,7 @@ static A jtmovandor(J jt,I m,A w,A fs,B or){A y,z;B b0,b1,d,e,*s,*t,*u,*v,x,*yv,
    }
    SETZ;
  }}
- RETF(z);
+ return z;
 }    /* a *./\w (0=or) or a +./\ (1=or); boolean w; 0<m */
 
 static A jtmovbwandor(J jt,I m,A w,A fs,B or){A z;I c,p,*s,*t,*u,x,*zv;
@@ -749,7 +749,7 @@ static A jtmovbwandor(J jt,I m,A w,A fs,B or){A z;I c,p,*s,*t,*u,x,*zv;
   case 2: DQ(1+p, ICPY(zv,u,c); t=u+=c; DQ(m-1, s=zv; DQ(c, *s++&=*t++;);); zv+=c;); break;
   case 3: DQ(1+p, ICPY(zv,u,c); t=u+=c; DQ(m-1, s=zv; DQ(c, *s++|=*t++;);); zv+=c;); break;
  }
- RETF(z);
+ return z;
 }    /* a 17 b./\w (0=or) or a 23 b./\ (1=or); integer w; 0<m */
 
 static A jtmovneeq(J jt,I m,A w,A fs,B eq){A y,z;B*s,*u,*v,x,*yv,*zv;I c,p;
@@ -763,7 +763,7 @@ static A jtmovneeq(J jt,I m,A w,A fs,B eq){A y,z;B*s,*u,*v,x,*yv,*zv;I c,p;
   case 2: DQ(m, s=yv; DQ(c,       *s++^=   *v++;);); SETZ;    DQ(p, s=yv; DQ(c,       *zv++=*s++^=   *u++^ *v++;);); break;
   case 3: DQ(m, s=yv; DQ(c, x=*s; *s++ =x==*v++;);); SETZ;    DQ(p, s=yv; DQ(c, x=*s; *zv++=*s++ =x==*u++==*v++;););
  }
- RETF(z);
+ return z;
 }    /* m ~:/\w (0=eq) or m =/\ (1=eq); boolean w; 0<m */
 
 static A jtmovbwneeq(J jt,I m,A w,A fs,B eq){A y,z;I c,p,*s,*u,*v,x,*yv,*zv;
@@ -777,7 +777,7 @@ static A jtmovbwneeq(J jt,I m,A w,A fs,B eq){A y,z;I c,p,*s,*u,*v,x,*yv,*zv;
   case 2: DQ(m, s=yv; DQ(c,       *s++^=    *v++ ;);); SETZ;    DQ(p, s=yv; DQ(c,       *zv++=*s++^=      *u++^*v++  ;);); break;
   case 3: DQ(m, s=yv; DQ(c, x=*s; *s++ =~(x^*v++););); SETZ;    DQ(p, s=yv; DQ(c, x=*s; *zv++=*s++ =~(x^~(*u++^*v++));););
  }
- RETF(z);
+ return z;
 }    /* m 22 b./\w (0=eq) or m 25 b./\ (1=eq); integer w; 0<m */
 
 static DF2(jtmovfslash){A x,z;B b;C id,*wv,*zv;I d,m,m0,p,t,wk,wt,zi,zk,zt;
@@ -807,7 +807,7 @@ static DF2(jtmovfslash){A x,z;B b;C id,*wv,*zv;I d,m,m0,p,t,wk,wt,zi,zk,zt;
  PROD(d,AR(w)-1,AS(w)+1) b=0>m0&&zi*m!=p;   // b='has shard'
  zt=rtype(adocv.cv); RESETRANK;
  GA(z,zt,d*zi,MAX(1,AR(w)),AS(w)); AS(z)[0]=zi;
- if(d*zi==0){RETF(z);}  // mustn't call adocv on empty arg!
+ if(d*zi==0){return z;}  // mustn't call adocv on empty arg!
  if((t=atype(adocv.cv))&&TYPESNE(t,wt)){RZ(w=cvt(t,w)); wt=AT(w);}
  zv=CAV(z); zk=d<<bplg(zt); 
  wv=CAV(w); wk=(0<=m0?d:d*m)<<bplg(wt);

--- a/jsrc/adverbs/ap.c
+++ b/jsrc/adverbs/ap.c
@@ -814,7 +814,7 @@ static DF2(jtmovfslash){A x,z;B b;C id,*wv,*zv;I d,m,m0,p,t,wk,wt,zi,zk,zt;
  I rc=EVOK;
  DQ(zi-b, I lrc=((AHDRPFN*)adocv.f)(d,m,(I)1,wv,zv,jt); rc=lrc<rc?lrc:rc; zv+=zk; wv+=wk;);
  if(b){m=p-m*(zi-1); if(m>1){I lrc=((AHDRPFN*)adocv.f)(d,m,(I)1,wv,zv,jt); rc=lrc<rc?lrc:rc;}else{copyTT(zv,wv,d,zt,wt);}}
- if(255&rc){jsignal(rc); if(rc>=EWOV){RESETERR; return movfslash(a,cvt(FL,w),self);}R0;}else return z;
+ if(255&rc){jsignal(rc); if(rc>=EWOV){RESETERR; return movfslash(a,cvt(FL,w),self);}return 0;}else return z;
 }    /* a f/\w */
 
 static DF1(jtiota1){I j; return apv(SETIC(w,j),1L,1L);}

--- a/jsrc/adverbs/ar.c
+++ b/jsrc/adverbs/ar.c
@@ -454,7 +454,7 @@ static DF1(jtreduce){A z;I d,f,m,n,r,t,wr,*ws,zt;
   // Allocate the result area
   zt=rtype(adocv.cv);
   GA(z,zt,m*d,MAX(0,wr-1),ws); if(1<r)MCISH(f+AS(z),f+1+ws,r-1);  // allocate, and install shape
-  if(m*d==0){RETF(z);}  // mustn't call the function on an empty argument!
+  if(m*d==0){return z;}  // mustn't call the function on an empty argument!
   // Convert inputs if needed 
   if((t=atype(adocv.cv))&&TYPESNE(t,wt))RZ(w=cvt(t,w));
   // call the selected reduce routine.
@@ -462,7 +462,7 @@ static DF1(jtreduce){A z;I d,f,m,n,r,t,wr,*ws,zt;
   // if return is EWOV, it's an integer overflow and we must restart, after restoring the ranks
   // EWOV1 means that there was an overflow on a single result, which was calculated accurately and stored as a D.  So in that case all we
   // have to do is change the type of the result.
-  if(255&rc){if(jt->jerr==EWOV1){AT(z)=FL;RETF(z);}else {jsignal(rc); RETF(rc>=EWOV?IRS1(w,self,r,jtreduce,z):0);}} else {RETF(adocv.cv&VRI+VRD?cvz(adocv.cv,z):z);}
+  if(255&rc){if(jt->jerr==EWOV1){AT(z)=FL;return z;}else {jsignal(rc); return rc>=EWOV?IRS1(w,self,r,jtreduce,z):0;}} else {return adocv.cv&VRI+VRD?cvz(adocv.cv,z):z;}
 
   // special cases:
  }else if(n==1)return head(w);    // reduce on single items - ranks are still set
@@ -561,12 +561,12 @@ static DF1(jtredstitch){A c,y;I f,n,r,*s,*v,wr;
  if((SPARSE&AT(w))!=0){A x;
   GATV0(x,INT,f+r-1,1); v=AV(x); MCISH(v,AS(y),f+1);
   DPMULDE(s[f],s[f+2],v[f+1]); MCISH(v+f+2,s+3+f,r-3);
-  RETF(reshape(x,y));
+  return reshape(x,y);
  }else{
   v=AS(y); 
   DPMULDE(s[f],s[f+2],v[f+1]); MCISH(v+f+2,s+3+f,r-3);
   --AR(y); 
-  RETF(y);
+  return y;
 }}   /* ,./"r w */
 
 static DF1(jtredstiteach){A*wv,y;I n,p,r,t;
@@ -591,7 +591,7 @@ static DF1(jtredcateach){A*u,*v,*wv,x,*xv,z,*zv;I f,m,mn,n,r,wr,*ws,zm,zn;I n1=0
  GATV0(x,BOX,n,1); xv=AAV(x);
  zv=AAV(z); wv=AAV(w); 
  DO(zm, u=wv; DO(m, v=u++; DO(n, xv[i]=*v; v+=m;); A Zz; RZ(Zz=raze(x)); INCORP(Zz); *zv++ = Zz;); wv+=mn;);  // no need to incorp *v since it's already boxed
- RETF(z);
+ return z;
 }    /* ,&.>/"r w */
 
 static DF2(jtoprod){A z; return df2(z,a,w,FAV(self)->fgh[2]);}  // x u/ y - transfer to the u"lr,_ verb (precalculated)
@@ -628,7 +628,7 @@ A sum=reduce(w,FAV(self)->fgh[0]);  // calculate +/"r
  RESETRANK;  // back to infinite rank for the divide
  RZ(sum);
  RZ(w=jtatomic2(JTIPA,sum,sc(n),ds(CDIV)));  // take quotient inplace and return it
- RETF(w);
+ return w;
 }    // (+/%#)"r w, implemented as +/"r % cell-length
 
 // entry point to execute monad/dyad Fold after the noun arguments are supplied

--- a/jsrc/adverbs/ar.c
+++ b/jsrc/adverbs/ar.c
@@ -221,7 +221,7 @@ DF1(jtredravel){A f,x,z;I n;P*wp;
   ASSERT(adocv.f,EVNONCE);
   GA(z,rtype(adocv.cv),1,0,0);
   if(n)rc=((AHDRRFN*)adocv.f)((I)1,n,(I)1,AV(x),AV(z),jt);  // mustn't adocv on empty
-  rc&=255; if(rc)jsignal(rc); if(rc<EWOV){if(rc)R0; return redsp1a(FAV(FAV(f)->fgh[0])->id,z,SPA(wp,e),n,AR(w),AS(w));}  // since f has an insert fn, its id must be OK
+  rc&=255; if(rc)jsignal(rc); if(rc<EWOV){if(rc)return 0; return redsp1a(FAV(FAV(f)->fgh[0])->id,z,SPA(wp,e),n,AR(w),AS(w));}  // since f has an insert fn, its id must be OK
  }
 }  /* f/@, w */
 

--- a/jsrc/adverbs/ar.c
+++ b/jsrc/adverbs/ar.c
@@ -528,7 +528,7 @@ DF1(jtredcat){A z;B b;I f,r,*s,*v,wr;
  F1PREFIP;ARGCHK1(w);
  wr=AR(w); r=(RANKT)jt->ranks; r=wr<r?wr:r; f=wr-r; s=AS(w); RESETRANK;
  b=1==r&&1==s[f];  // special case: ,/ on last axis which has length 1: in that case, the rules say the axis disappears (because of the way ,/ works on length-1 lists)
- if(2>r&&!b)RCA(w);  // in all OTHER cases, result=input for ranks<2
+ if(2>r&&!b)return w;  // in all OTHER cases, result=input for ranks<2
  // use virtual block (possibly self-virtual) for all cases except sparse
  if(!(SPARSE&AT(w))){
   RZ(z=jtvirtual(jtinplace,w,0,wr-1)); AN(z)=AN(w); // Allocate the block.  Then move in AN and shape

--- a/jsrc/adverbs/au.c
+++ b/jsrc/adverbs/au.c
@@ -28,18 +28,18 @@ F1(jtfdepadv){ARGCHK1(w); ASSERT(VERB&AT(w),EVDOMAIN); return sc(fdep(w));}
 #endif
 
 
-DF1(jtdfs1){F1PREFIP;A s=jt->sf,z; RZ(self); z=CALL1IP(FAV(self)->valencefns[0],  w,jt->sf=self); jt->sf=s; RETF(z);}
+DF1(jtdfs1){F1PREFIP;A s=jt->sf,z; RZ(self); z=CALL1IP(FAV(self)->valencefns[0],  w,jt->sf=self); jt->sf=s; return z;}
 DF2(jtdfs2){F2PREFIP;
 A s=jt->sf,z; 
 RZ(self); 
 z=CALL2IP(FAV(self)->valencefns[1],a,w,jt->sf=self); jt->sf=s; 
-RETF(z);}    
+return z;}
      /* for monads and dyads that can possibly involve $: */
 
 
 // $: itself
-F1(jtself1){A z; FDEPINC(d=fdep(jt->sf)); STACKCHKOFL df1(z,  w,jt->sf);  FDEPDEC(d); forcetomemory(w); RETF(z);}
-F2(jtself2){A z; FDEPINC(d=fdep(jt->sf)); STACKCHKOFL df2(z,a,w,jt->sf);  FDEPDEC(d); forcetomemory(w); RETF(z);}
+F1(jtself1){A z; FDEPINC(d=fdep(jt->sf)); STACKCHKOFL df1(z,  w,jt->sf);  FDEPDEC(d); forcetomemory(w); return z;}
+F2(jtself2){A z; FDEPINC(d=fdep(jt->sf)); STACKCHKOFL df2(z,a,w,jt->sf);  FDEPDEC(d); forcetomemory(w); return z;}
 
 A jtac1(J jt,AF f){return fdef(0,0,VERB, f,0L, 0L,0L,0L, VFLAGNONE, RMAX,RMAX,RMAX);}
 A jtac2(J jt,AF f){return fdef(0,0,VERB, 0L,f, 0L,0L,0L, VFLAGNONE, RMAX,RMAX,RMAX);}

--- a/jsrc/conjunctions/ca.c
+++ b/jsrc/conjunctions/ca.c
@@ -122,7 +122,7 @@ static DF2(atcomp){AF f;A z;
   z=f(jt,a,w,self);
   if(z){if(postflags&2){z=num((IAV(z)[0]!=AN(AR(a)>=AR(w)?a:w))^(postflags&1));}}
  }else z=upon2(a,w,self);
- RETF(z);
+ return z;
 }
 
 static DF2(atcomp0){A z;AF f;
@@ -134,7 +134,7 @@ static DF2(atcomp0){A z;AF f;
   z=f(jt,a,w,self);
   if(z){if(postflags&2){z=num((IAV(z)[0]!=AN(AR(a)>=AR(w)?a:w))^(postflags&1));}}
  }else z=upon2(a,w,self);
- RETF(z);
+ return z;
 }
 
 // The combining modifiers keep track of some flags used by partitions and Result Assembly.
@@ -351,8 +351,8 @@ F2(jtampco){AF f1=on1cell,f2=on2cell;C c,d;I flag,flag2=0,linktype=0;V*wv;
 // We marked the derived verb inplaceable only if the dyad of u/v was inplaceable
 // This supports IRS so that it can pass the rank on to the called function; no need to revalidate here
 // We pass the WILLOPEN flags through
-static DF1(withl){F1PREFIP;DECLFG; A z; I r=(RANKT)jt->ranks; IRSIP2(fs,w,gs,RMAX,(RANKT)jt->ranks,g2,z); RETF(z);}
-static DF1(withr){F1PREFIP;DECLFG; jtinplace=(J)(intptr_t)((I)jtinplace+((I)jtinplace&JTINPLACEW)); A z; I r=(RANKT)jt->ranks; IRSIP2(w,gs,fs,(RANKT)jt->ranks,RMAX,f2,z); RETF(z);}
+static DF1(withl){F1PREFIP;DECLFG; A z; I r=(RANKT)jt->ranks; IRSIP2(fs,w,gs,RMAX,(RANKT)jt->ranks,g2,z); return z;}
+static DF1(withr){F1PREFIP;DECLFG; jtinplace=(J)(intptr_t)((I)jtinplace+((I)jtinplace&JTINPLACEW)); A z; I r=(RANKT)jt->ranks; IRSIP2(w,gs,fs,(RANKT)jt->ranks,RMAX,f2,z); return z;}
 
 // Here for m&i. and m&i:, computing a prehashed table from a
 // v->fgh[2] is the info/hash/bytemask result from calculating the prehash

--- a/jsrc/conjunctions/cc.c
+++ b/jsrc/conjunctions/cc.c
@@ -46,7 +46,7 @@ static DF2(jtcut02){F2PREFIP;A fs,q,qq,*qv,z,zz=0;I*as,c,e,i,ii,j,k,m,n,*u,*ws;P
   if(z==0)z=zeroionei(0);  // use zero as fill result if error
   GA(zz,AT(z),n,m+AR(z),0); I *zzs=AS(zz); I *zs=AS(z); 
   MCISH(zzs,as,m) MCISH(zzs+m,zs,AR(z)) // move in frame of a followed by shape of result-cell
-  RETF(zz);
+  return zz;
  }
  // otherwise general case, one axis at a time
  ws=AS(w);
@@ -152,7 +152,7 @@ DF2(jtboxcut0){A z;
  I resatoms; PROD(resatoms,f,AS(a)); I cellsize; PROD(cellsize,wr-1,AS(w)+1);
  I k=bplg(t); C *wv=CAV(w);  // k is length of an atom of w
  // allocate the result area
- GATV(z,BOX,resatoms,f,AS(a)); AFLAG(z) = BOX; if(resatoms==0){RETF(z);}  // could avoid filling with 0 if we modified AN after error, or cleared after *tnextpushp
+ GATV(z,BOX,resatoms,f,AS(a)); AFLAG(z) = BOX; if(resatoms==0){return z;}  // could avoid filling with 0 if we modified AN after error, or cleared after *tnextpushp
   // We have allocated the result; now we allocate a block for each cell of w and copy
   // the w values to the new block.
   // Make result inplaceable; recursive too, since otherwise the boxes won't get freed
@@ -185,7 +185,7 @@ DF2(jtboxcut0){A z;
  ASSERT(y!=0,EVWSFULL);  // if we broke out an allocation failure, fail.  Since the block is recursive, when it is tpop()d it will recur to delete contents
  // The result can be called pristine if the contents are DIRECT and the result is recursive, because it contains all copied data
  AFLAG(z)|=(-(t&DIRECT))&(~(I)jtinplace<<(AFPRISTINEX-JTWILLBEOPENEDX))&AFPRISTINE;
- RETF(z);  // return the recursive block
+ return z;  // return the recursive block
 }
 
 
@@ -212,7 +212,7 @@ DF2(jtrazecut0){A z;C*wv,*zv;I ar,*as,(*av)[2],j,k,m,n,wt;
  // copy em in.  We use MC because the strings are probably long and unpredictable - think HTML parsing
  I wcb=wcn<<bplg(wt);  // number of bytes in a cell of w
  DO(m, j=av[i][0]; k=av[i][1]; I jj=j+n; jj=(j>=0)?j:jj; j=n-jj; k=k>j?j:k; k*=wcb; MC(zv,wv+jj*wcb,k); zv+=k;)
- RETF(z);
+ return z;
 }    /* a ;@:(<;.0) vector */
 
 
@@ -255,7 +255,7 @@ static DF2(jtcut2bx){A*av,b,t,x,*xv,y,*yv;B*bv;I an,bn,i,j,m,p,q,*u,*v,*ws;
    GATV0(z,INT,m,1); zi=AV(z); EACHC(*zi++=d;); return z;                          \
   case CDOLLAR:                                                              \
    GATV0(z,INT,m,1); zi=AV(z); EACHC(*zi++=d;);                               \
-   A zz,zw; RZ(zw=vec(INT,MAX(0,r-1),1+s)); IRS2(z,zw,0L,0L,1L,jtover,zz); RETF(zz);  \
+   A zz,zw; RZ(zw=vec(INT,MAX(0,r-1),1+s)); IRS2(z,zw,0L,0L,1L,jtover,zz); return zz;  \
   case CHEAD:                                                                \
    GA(z,t,m*c,r,s); zc=CAV(z); AS(z)[0]=m;                                     \
    EACHC(ASSERT(d!=0,EVINDEX); MC(zc,v1,k); zc+=k;);                            \
@@ -893,12 +893,12 @@ static F2(jttesa){A x;I*av,ac,c,d,k,r,*s,t,*u,*v;
  r=AR(a); s=AS(a); SHAPEN(a,r-1,c);  ac=c; av=AV(a); d=AR(w);  // r = rank of x; s->shape of x; c=#axes specd in x, av->data; d=rank of w
  ASSERT(d>=c&&(2>r||2==s[0]),EVLENGTH);  // x must not be bigger than called for by rank of w, and must be a list or 2-item table
  if(2<=r)DO(c, ASSERT(0<=av[i],EVDOMAIN););  // if movement vector given, it must be nonnegative
- if(2==r&&t&INT){RETF(a);}  // if we can use a as given, return a as is
+ if(2==r&&t&INT){return a;}  // if we can use a as given, return a as is
  GATV0(x,INT,2*c,2); s=AS(x); s[0]=2; s[1]=c;  // allocate space for start/stride, only for axes that will be modified.  We will modify it
  u=AV(x); v=u+c; s=AS(w);  // u->movement vector, v->length
  if(2==r)DO(c,   *u++=av[i]; k=av[i+ac]; if(k&((I)IMIN>>1)){k=(s[i]^REPSGN(k))-REPSGN(k);} *v++=k;);  // if k infinite, make length the axis length, + or -
  if(2> r)DO(c,   *u++=1;     k=av[i];  if(k&((I)IMIN>>1)){k=(s[i]^REPSGN(k))-REPSGN(k);} *v++=k;);
- RETF(x);
+ return x;
 }    /* tesselation standardized left argument */
 
 // These bits overlap with those used for ;.0
@@ -921,7 +921,7 @@ static DF2(jttess2){A z,zz=0,virtw,strip;I n,rs[3],cellatoms,cellbytes,vmv,hmv,v
   // trailing axes taken in full will be omitted from the shape of the result
   RZ(p=tesos(a,w,n,0));  // recalculate all the result shapes
   A za, zw; RZ(za=cant1(tymesW(head(a),cant1(abase2(p,iota(p)))))); RZ(zw=tail(a));
-  RETF(cut02(IRS2(za, zw,0L,1L,1L,jtlamin2,z),w,self));  // ((|: ({.a) * |: (#: i.)p) ,:"1 ({:a)) u;.0 w
+  return cut02(IRS2(za, zw,0L,1L,1L,jtlamin2,z),w,self);  // ((|: ({.a) * |: (#: i.)p) ,:"1 ({:a)) u;.0 w
  }
  DECLF;  // get the function pointers
  fauxblockINT(xfaux,5,1); // declare xpose arg where it has scope

--- a/jsrc/conjunctions/cf.c
+++ b/jsrc/conjunctions/cf.c
@@ -281,7 +281,7 @@ static DF1(jthkindexofmaxmin){I z=0;
 static DF2(jthklvl2){
  F2RANK(0,RMAX,jthklvl2,self);
  I comparand; RE(comparand=i0(a));  // get value to compare against
- RETF(num(((VAV(self)->flag>>VFHKLVLGTX)&1)^levelle(w,comparand-(VAV(self)->flag&VFHKLVLDEC))));  // decrement for < or >:; complement for > >:
+ return num(((VAV(self)->flag>>VFHKLVLGTX)&1)^levelle(w,comparand-(VAV(self)->flag&VFHKLVLDEC)));  // decrement for < or >:; complement for > >:
 }
 
 F2(jthook){AF f1=0,f2=0;C c,d,e,id;I flag=VFLAGNONE,linktype=0;V*u,*v;

--- a/jsrc/conjunctions/cg.c
+++ b/jsrc/conjunctions/cg.c
@@ -94,7 +94,7 @@ PRIM jtfxself[2]={ {{0,0,0,0,0,0,0},{{{jtfx,0},{0,0,0},0,0,0,0,0,0,0}}} , {{1,0,
 // run jtfx on each box in w, turning AR into an A block
 // self is a parm passed through to jtfx, coming from jtfxself above.  if AK(self) is nonzero, we return nouns as is
 // Result claims to be an array of boxes, but each box holds a function
-DF1(jtfxeach){RETF(every(w,self));}
+DF1(jtfxeach){return every(w,self);}
 
 static DF1(jtcon1){A h,*hv,*x,z;V*sv;
  PREF1(jtcon1);
@@ -120,7 +120,7 @@ static DF1(jtinsert){A hs,*hv,z;I hfx,j,m,n;A *old;
  RZ(z=from(num(-1),w));
  old=jt->tnextpushp;
  --m; DQ(n-1, --j; --hfx; hfx=(hfx<0)?m:hfx; RZ(z=CALL2(FAV(hv[hfx])->valencefns[1],from(sc(j),w),z,hv[hfx])); z=gc(z,old);)
- RETF(z);
+ return z;
 }
 
 // u`:m

--- a/jsrc/conjunctions/cip.c
+++ b/jsrc/conjunctions/cip.c
@@ -59,7 +59,7 @@ static F2(jtpdtby){A z;B b,*u,*v,*wv;C er=0;I at,m,n,p,t,wt,zk;
               if(at&B01)PDTBY(D,I,IINC) else PDTXB(D,I,IINC,c=(D)*u++);
  }}
  NAN1;
- RETF(z);
+ return z;
 }    /* x +/ .* y where x or y (but not both) is Boolean */
 
 #define BBLOCK(nn)  \

--- a/jsrc/conjunctions/cl.c
+++ b/jsrc/conjunctions/cl.c
@@ -43,7 +43,7 @@ static DF1(jtlcapco1){A z;V*v=FAV(self);
  FAV(recurself)->valencefns[0]=jtlev1;  // fill in function pointer
  AT(recurself)=efflev(0L,v->fgh[2],w);  // fill in the trigger level
  FAV(recurself)->flag=VFLAGNONE;  // fill in the inplaceability flags
- RETF(lev1(w,recurself));
+ return lev1(w,recurself);
 }
 
 static DF2(jtlcapco2){A z;V*v=FAV(self);
@@ -54,7 +54,7 @@ static DF2(jtlcapco2){A z;V*v=FAV(self);
  FAV(recurself)->valencefns[1]=jtlev2;  // fill in function pointer
  AT(recurself)=efflev(1L,v->fgh[2],a); AC(recurself)=efflev(2L,v->fgh[2],w);  // fill in the trigger levels
  FAV(recurself)->flag=VFLAGNONE;  // fill in the inplaceability flags
- RETF(lev2(a,w,recurself));
+ return lev2(a,w,recurself);
 }
 
 // Result logger for S:   w is the result; we add it to AK(self), reallocating as needed

--- a/jsrc/conjunctions/cp.c
+++ b/jsrc/conjunctions/cp.c
@@ -54,7 +54,7 @@ static F2(jttclosure){A z;I an,*av,c,d,i,wn,wr,wt,*wv,*zv,*zz;
   d=(zv-AV(z))/wn-1;
  }
  AS(z)[0]=d; AN(z)=d*wn; MCISH(1+AS(z),AS(w),wr); 
- RETF(z);
+ return z;
 }    /* {&a^:(<_) w */
 
 static DF1(jtindexseqlim1){A fs;
@@ -89,7 +89,7 @@ static DF1(jtfpown){A fs,z;AF f1;I n;V*sv;A *old;
  z=w; 
  old=jt->tnextpushp; 
  DQ(n, JBREAK0; RZ(z=CALL1IP(f1,z,fs)); z=gc(z,old);); // could force inplace after the first?
- RETF(z);
+ return z;
 // }
 }
 
@@ -192,15 +192,15 @@ static DF2(jtpinf12){PROLOG(0340);A z;  // no reason to inplace, since w must be
   if(!((isend-1)&++i&7)) {  // every so often, but always when we leave...
    JBREAK0;   // check for user interrupt, in case the function doesn't allocate memory
    RZ(z=EPILOGNORET(z));  // free up allocated blocks, but keep z.  If z is virtual it will be realized
-   if(isend){RETF(z);}  // return at end
+   if(isend){return z;}  // return at end
   }
     // make the new result the starting value for next loop, replacing w wherever it is
  }
 }
 
-static DF1(jtinv1){F1PREFIP;DECLFG;A z; ARGCHK1(w);A i; RZ(i=inv((fs))); FDEPINC(1);  z=(FAV(i)->valencefns[0])(FAV(i)->flag&VJTFLGOK1?jtinplace:jt,w,i);       FDEPDEC(1); RETF(z);}  // was invrecur(fix(fs))
-static DF1(jtinvh1){F1PREFIP;DECLFGH;A z; ARGCHK1(w);    FDEPINC(1); z=(FAV(hs)->valencefns[0])(jtinplace,w,hs);        FDEPDEC(1); RETF(z);}
-static DF2(jtinv2){DECLFG;A z; ARGCHK2(a,w); FDEPINC(1); df1(z,w,inv(amp(a,fs))); FDEPDEC(1); STACKCHKOFL RETF(z);}  // the CHKOFL is to avoid tail recursion, which prevents a recursion loop from being broken
+static DF1(jtinv1){F1PREFIP;DECLFG;A z; ARGCHK1(w);A i; RZ(i=inv((fs))); FDEPINC(1);  z=(FAV(i)->valencefns[0])(FAV(i)->flag&VJTFLGOK1?jtinplace:jt,w,i);       FDEPDEC(1); return z;}  // was invrecur(fix(fs))
+static DF1(jtinvh1){F1PREFIP;DECLFGH;A z; ARGCHK1(w);    FDEPINC(1); z=(FAV(hs)->valencefns[0])(jtinplace,w,hs);        FDEPDEC(1); return z;}
+static DF2(jtinv2){DECLFG;A z; ARGCHK2(a,w); FDEPINC(1); df1(z,w,inv(amp(a,fs))); FDEPDEC(1); STACKCHKOFL return z;}  // the CHKOFL is to avoid tail recursion, which prevents a recursion loop from being broken
 static DF1(jtinverr){F1PREFIP;ASSERT(0,EVDOMAIN);}  // used for uninvertible monads
 
 // old static CS2(jtply2, df1(z,w,powop(amp(a,fs),gs,0)),0107)  // dyad adds x to make x&u, and then reinterpret the compound.  We could interpret u differently now that it has been changed (x {~^:a: y)

--- a/jsrc/conjunctions/cp.c
+++ b/jsrc/conjunctions/cp.c
@@ -154,7 +154,7 @@ static DF1(jtply1){PROLOG(0040);DECLFG;A zz=0;
     // have to pop explicitly.  We protect the components of the overall result and the most recent result
     // We do this only occasionally
     JBREAK0;  // while we're waiting, check for attention interrupt
-    if(!gc3(&z,zz?&zz:0,zzbox?&zzbox:0,stkfreept))R0; // free old unused blocks
+    if(!gc3(&z,zz?&zz:0,zzbox?&zzbox:0,stkfreept))return 0; // free old unused blocks
     if(zzbox){
      // zzbox is normally NONrecursive and we add boxes to it as they come in.  Protecting it has made it recursive, which will
      // cause a double-free if we add another box to it.  So we have to go through it and make it nonrecursive again.  We don't have to do it recursively.

--- a/jsrc/conjunctions/cr.c
+++ b/jsrc/conjunctions/cr.c
@@ -566,7 +566,7 @@ A jtirs1(J jt,A w,A fs,I m,AF f1){A z;I wr;
  jt->ranks=(RANK2T)wr;  // install rank for called routine
  z=CALL1IP(f1,w,fs);
  jt->ranks=(RANK2T)~0;  // reset rank to infinite
- RETF(z);
+ return z;
 }
 
 // IRS setup for dyads x op y.  This routine sets jt->rank and calls the verb, which loops if it needs to
@@ -588,7 +588,7 @@ A jtirs2(J jt,A a,A w,A fs,I l,I r,AF f2){A z;I ar,wr;
  z=CALL2IP(f2,a,w,fs);   // save ranks, call setup verb, pop rank stack
    // Not all verbs (*f2)() use the fs argument.
  jt->ranks=(RANK2T)~0;  // reset rank to infinite
- RETF(z);
+ return z;
 }
 
 
@@ -629,13 +629,13 @@ static DF1(rank1i){F1PREFIP;ARGCHK1(w);DECLF;  // this version when requested ra
  I m=sv->localuse.lI4[0]; m=m>=AR(w)?~0:m; jt->ranks=(RANK2T)(m);  // install rank for called routine
  A z=CALL1IP(f1,w,fs);
  jt->ranks=(RANK2T)~0;  // reset rank to infinite
- RETF(z);
+ return z;
 }
 static DF1(rank1in){F1PREFIP;ARGCHK1(w);DECLF;  // this version when requested rank is negative
  I m=sv->localuse.lI4[0]+AR(w); m=m<0?0:m; jt->ranks=(RANK2T)(m);  // install rank for called routine
  A z=CALL1IP(f1,w,fs);
  jt->ranks=(RANK2T)~0;  // reset rank to infinite
- RETF(z);
+ return z;
 }
 static DF2(rank2i){F2PREFIP;ARGCHK1(w);DECLF;  // this version when requested rank is positive
  I ar=sv->localuse.lI4[1]; ar=ar>=AR(a)?(RANKT)~0:ar; I af=AR(a)-ar;   // left rank
@@ -645,7 +645,7 @@ static DF2(rank2i){F2PREFIP;ARGCHK1(w);DECLF;  // this version when requested ra
  jt->ranks=(RANK2T)((ar<<RANKTX)+wr);  // install as parm to the function.  Set to ~0 if possible
  A z=CALL2IP(f2,a,w,fs);   // save ranks, call setup verb, pop rank stack
  jt->ranks=(RANK2T)~0;  // reset rank to infinite
- RETF(z);
+ return z;
 }
 static DF2(rank2in){F2PREFIP;ARGCHK1(w);DECLF;  // this version when a requested rank is negative
  I wr=AR(w); I r=sv->localuse.lI4[2]; r=r>=wr?(RANKT)~0:r; wr+=r; wr=wr<0?0:wr; wr=r>=0?r:wr; I wf=AR(w)-wr;   // right rank
@@ -655,7 +655,7 @@ static DF2(rank2in){F2PREFIP;ARGCHK1(w);DECLF;  // this version when a requested
  jt->ranks=(RANK2T)((ar<<RANKTX)+wr);  // install as parm to the function.  Set to ~0 if possible
  A z=CALL2IP(f2,a,w,fs);   // save ranks, call setup verb, pop rank stack
  jt->ranks=(RANK2T)~0;  // reset rank to infinite
- RETF(z);
+ return z;
 }
 
 // u"n y when u does not support irs. We loop over cells, and as we do there is no reason to enable inplacing

--- a/jsrc/conjunctions/cu.c
+++ b/jsrc/conjunctions/cu.c
@@ -66,7 +66,7 @@ A jtevery(J jt, A w, A fs){A * RESTRICT wv,x,z,* RESTRICT zv;
   }
   I wcpre=AC(virtw);  // remember usecount before call
   if(!(x=CALL1IP(f1,virtw,fs))){ // run the user's verb
-   AC(virtw)&=~ACINPLACE; R0;  // make sure we reset the usecounts of the virtual blocks in case of error
+   AC(virtw)&=~ACINPLACE; return 0;  // make sure we reset the usecounts of the virtual blocks in case of error
   }
   // If x is DIRECT inplaceable, it must be unique and we can inherit them into a pristine result.  Otherwise clear pristinity
   if(AT(x)&DIRECT){   // will predict correctly
@@ -184,7 +184,7 @@ A jtevery2(J jt, A a, A w, A fs){A*av,*wv,x,z,*zv;
 
   I wcpre=AC(virtw), acpre=AC(virta);  // remember usecount before call
   if(!(x=CALL2IP(f2,virta,virtw,fs))){; // run the user's verb
-   AC(virtw)&=~ACINPLACE; AC(virta)&=~ACINPLACE; R0;  // make sure usecount restored on error
+   AC(virtw)&=~ACINPLACE; AC(virta)&=~ACINPLACE; return 0;  // make sure usecount restored on error
   }
   // If x is DIRECT inplaceable, it must be unique and we can inherit them into a pristine result.  Otherwise clear pristinity
   if(AT(x)&DIRECT){   // will predict correctly

--- a/jsrc/conjunctions/cu.c
+++ b/jsrc/conjunctions/cu.c
@@ -269,7 +269,7 @@ static DF1(jtunderai1){DECLF;A x,y,z;B b;I j,n,*u,*v;UC f[256],*wv,*zv;
  n=AN(w);
  GATV(z,LIT,n,AR(w),AS(w)); zv=UAV(z); wv=UAV(w);
  if(!bitwisecharamp(f,n,wv,zv))DQ(n, *zv++=f[*wv++];); 
- RETF(z);
+ return z;
 }    /* f&.(a.&i.) w */
 
 // u&.v

--- a/jsrc/conjunctions/cv.c
+++ b/jsrc/conjunctions/cv.c
@@ -6,9 +6,9 @@
 #include "j.h"
 
 
-static DF1(jtfitct1){DECLFG;F1PREFIP;A z; PUSHCCT(FAV(self)->localuse.lD) z=CALL1IP(f1,  w,fs); POPCCT RETF(z);}  // lD has the complementary ct
+static DF1(jtfitct1){DECLFG;F1PREFIP;A z; PUSHCCT(FAV(self)->localuse.lD) z=CALL1IP(f1,  w,fs); POPCCT return z;}  // lD has the complementary ct
 
-#define fitctvector(name,vector) static DF2(name){DECLFG;F2PREFIP;A z; PUSHCCT(FAV(self)->localuse.lD) z=vector; POPCCT RETF(z);}
+#define fitctvector(name,vector) static DF2(name){DECLFG;F2PREFIP;A z; PUSHCCT(FAV(self)->localuse.lD) z=vector; POPCCT return z;}
 fitctvector(jtfitct2,CALL2IP(f2,a,w,fs))
 fitctvector(jtfitcteq,jtatomic2(jtinplace,a,w,fs))
 
@@ -36,14 +36,14 @@ static DF2(jtfitpoly2){I j;
  A z; return aslash(CPLUS,tymes(a,ascan(CSTAR,shift1(plus(w,df2(z,IX(SETIC(a,j)),FAV(self)->fgh[1],slash(ds(CSTAR))))))));
 }    /* a p.!.s w */
 
-static DF1(jtfitfill1){DECLFG;F1PREFIP;A z; jt->fill=gs; z=CALL1IP(f1,  w,fs); jt->fill=0; RETF(z);}  // gs cannot be virtual
-static DF2(jtfitfill2){DECLFG;F2PREFIP;A z; jt->fill=gs; z=CALL2IP(f2,a,w,fs); jt->fill=0; RETF(z);}
+static DF1(jtfitfill1){DECLFG;F1PREFIP;A z; jt->fill=gs; z=CALL1IP(f1,  w,fs); jt->fill=0; return z;}  // gs cannot be virtual
+static DF2(jtfitfill2){DECLFG;F2PREFIP;A z; jt->fill=gs; z=CALL2IP(f2,a,w,fs); jt->fill=0; return z;}
 
 static DF1(jtfitpp1){DECLFG;A z;C d[8],*s=3+jt->pp;
  MC(d,s,8L); 
  sprintf(s,FMTI"g",AV(gs)[0]); 
  z=CALL1(f1,w,fs); MC(s,d,8L);
- RETF(z);
+ return z;
 }
 
 static DF1(jtfitf1){V*sv=FAV(self); A z; return df1(z,  w,fit(fix(sv->fgh[0],zeroionei(0)),sv->fgh[1]));}

--- a/jsrc/conjunctions/cx.c
+++ b/jsrc/conjunctions/cx.c
@@ -539,7 +539,7 @@ dobblock:
  // Note that we know we are not returning a virtual block here, so it is OK to write to AM
 
  if(z!=0)if((_ttop!=jt->tnextpushp)==AC(z)){AC(z)=ACINPLACE|ACUC1; ABACK(z)=(A)_ttop;}  // AC can't be 0
- RETF(z);
+ return z;
 }
 
 // execution of u : v, selecting the version of self to use based on  valence

--- a/jsrc/conjunctions/cx.c
+++ b/jsrc/conjunctions/cx.c
@@ -867,7 +867,7 @@ F2(jtcolon){A d,h,*hv,m;B b;C*s;I flag=VFLAGNONE,n,p;
  RE(n=i0(a));  // m : n; set n=value of a argument
  I col0;  // set if it was m : 0
  if(col0=equ(w,num(0))){RZ(w=colon0(n)); }   // if m : 0, read up to the ) .  If 0 : n, return the string unedited
- if(!n){ra0(w); RCA(w);}  // noun - return it.  Give it recursive usecount
+ if(!n){ra0(w); return w;}  // noun - return it.  Give it recursive usecount
  if((C2T+C4T)&AT(w))RZ(w=cvt(LIT,w));
  I splitloc=-1;   // will hold line number of : line
  if(10<n){ASSERT(AT(w)&LIT,EVDOMAIN) s=CAV(w); p=AN(w); if(p&&CLF==s[p-1])RZ(w=str(p-1,s));}  // if tacit form, discard trailing LF

--- a/jsrc/dc.c
+++ b/jsrc/dc.c
@@ -40,5 +40,5 @@ F1(jtdbcall){A y,*yv,z,zz,*zv;DC si,s0=0;I c=9,m=0,*s;
  RZ(y=from(scind(IRS1(z,0L,1L,jthead,zz)),over(snl(mtv),ds(CACE))));  // get script index for each line of stack; then fetch the name, or a: if no name
  yv=AAV(y); zv=5+AAV(z);
  DQ(m, *zv=incorp(*yv); yv++; zv+=c;);  // copy the script names into column 5
- RETF(z);
+ return z;
 }    /* 13!:13 function call matrix */

--- a/jsrc/f.c
+++ b/jsrc/f.c
@@ -109,7 +109,7 @@ static F1(jtthb){A z;B*x;C*y;I c,m,n,p,r,*s;
  GATV(z,LIT,m*p,r+!r,s); AS(z)[AR(z)-1]=p; 
  x=BAV(w); y=CAV(z);
  DQ(m, DQ(c-1, *y++=*x++?'1':'0'; *y++=' ';); *y++=*x++?'1':'0';);
- RETF(z);
+ return z;
 }
 
 static F1(jtthn){A d,t,z;C*tv,*x,*y,*zv;I c,*dv,k,m,n,p,r,*s,wd;FMTFUN fmt;
@@ -126,7 +126,7 @@ static F1(jtthn){A d,t,z;C*tv,*x,*y,*zv;I c,*dv,k,m,n,p,r,*s,wd;FMTFUN fmt;
   GATV(z,LIT,m*p,r+!r,s); AS(z)[AR(z)-1]=p; zv=CAV(z); memset(zv,' ',AN(z));
   y=tv; DO(m, DO(c, zv+=dv[i]; p=strlen(y); MC(zv-p-(I )(c>1+i),y,p); y+=wd;););
  }
- RETF(z);
+ return z;
 }
 
 // cvt SB string to utf8

--- a/jsrc/f2.c
+++ b/jsrc/f2.c
@@ -17,7 +17,7 @@ static F2(jtth2box){A z;I n,p,q,*v,x,y;
  jt->pos[0]=x; jt->pos[1]=y;
  z=thorn1(w); 
  jt->pos[0]=p; jt->pos[1]=q;
- RETF(z);
+ return z;
 }
 
 // Convert a formatted numeric string from C format to J format

--- a/jsrc/fbu.c
+++ b/jsrc/fbu.c
@@ -406,9 +406,9 @@ A RoutineA(J jt,A w,A prxthornuni){A z;I n,t,q,q1,b=0; UC* wv;
  ASSERT(t&LIT,EVDOMAIN);
  if(!n) {GATV(z,LIT,n,AR(w),AS(w)); return z;}; // empty lit list
  DQ(n, if(127<*wv++){b=1;break;});
- if(!b)RCA(w);
+ if(!b)return w;
  q=mtowsize(UAV(w),n);
- if(q<0)RCA(w);
+ if(q<0)return w;
  if(q==(q1=mtousize(UAV(w),n))){
   GATV0(z,C2T,q,1);
   mtow(UAV(w),n,USAV(z));

--- a/jsrc/io.c
+++ b/jsrc/io.c
@@ -352,8 +352,8 @@ DF1(jtwd){A z=0;C*p=0;D*pd;I e,*pi,t;V*sv;
 // literal array will be cut into rank-1 box array here using  <;._2 
 // and then reshape into rank-2  ((n%2),2)$
     A x=z; RZ(df1(z,x,cut(ds(CBOX),num(-2))));
-    RETF(reshape(v2(AN(z)>>1,2L),z));
-  } else {RETF(z);}
+    return reshape(v2(AN(z)>>1,2L),z);
+  } else {return z;}
 }
 
 static char breaknone=0;

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -633,8 +633,6 @@ if(z<3){_zzt+=z; z=(I)&oneone; _zzt=_i&3?_zzt:(I*)z; z=_i&2?(I)_zzt:z; z=((I*)z)
 #define EPILOGNOVIRT(z)       return rifvsdebug((gc(z,_ttop)))   // use this when the repercussions of allowing virtual result are too severe
 #define EPILOGZOMB(z)       if(!gc3(&(z),0L,0L,_ttop))R0; RETF(z);   // z is the result block.  Use this if z may contain inplaceable contents that would free prematurely
 // Routines that do little except call a function that does PROLOG/EPILOG have EPILOGNULL as a placeholder
-#define EPILOGNULL(z)   return z
-#define EPILOGNOTREQ(z)   return z  // used if originak JE had needless EPILOG
 // Routines that do not return A
 #define EPILOG0         tpop(_ttop)
 // Routines that modify the comparison tolerance must stack it
@@ -655,7 +653,6 @@ if(z<3){_zzt+=z; z=(I)&oneone; _zzt=_i&3?_zzt:(I*)z; z=_i&2?(I)_zzt:z; z=((I*)z)
 #define REPSGN(x) ((x)>>(BW-1))  // replicate sign bit of x to entire word (assuming x is signed type - if unsigned, just move sign to bit 0)
 #define SGNTO0(x) ((UI)(x)>>(BW-1))  // move sign bit to bit 0, clear other bits
 // In the original JE many verbs returned a clone of the input, i. e. return ca(w).  We have changed these to avoid the clone, but we preserve the memory in case we need to go back
-#define RCA(w)          return w
 #define RE(exp)         {if(((exp),jt->jerr!=0))return 0;}
 #define RESETERR        {jt->etxn=jt->jerr=0;}
 #define RESETERRANDMSG  {jt->etxn1=jt->etxn=jt->jerr=0;}

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -266,9 +266,6 @@ static inline omp_int_t omp_get_max_threads() { return 1;}
 #define AUDITEXECRESULTS 0  // When set, we go through all execution results to verify recursive and virtual bits are OK
 #define FORCEVIRTUALINPUTS 0  // When 1 set, we make all non-inplaceable noun inputs to executions VIRTUAL.  Tests should still run
                            // When 2 set, make all outputs from return  virtual.  Tests for inplacing will fail; that's OK if nothing crashes
-// set FINDNULLRET to trap when a routine returns 0 without having set an error message
-#define FINDNULLRET 0
-
 
 #define ALTBYTES 0x00ff00ff00ff00ffLL
 // t has totals per byte-lane, result combines them into single total.  t must be an lvalue
@@ -631,7 +628,7 @@ if(z<3){_zzt+=z; z=(I)&oneone; _zzt=_i&3?_zzt:(I*)z; z=_i&2?(I)_zzt:z; z=((I*)z)
 #define EPILOGNORET(z) (gc(z,_ttop))   // protect z and return its address
 #define EPILOG(z)       return EPILOGNORET(z)   // z is the result block
 #define EPILOGNOVIRT(z)       return rifvsdebug((gc(z,_ttop)))   // use this when the repercussions of allowing virtual result are too severe
-#define EPILOGZOMB(z)       if(!gc3(&(z),0L,0L,_ttop))R0; return z;   // z is the result block.  Use this if z may contain inplaceable contents that would free prematurely
+#define EPILOGZOMB(z)       if(!gc3(&(z),0L,0L,_ttop))return 0; return z;   // z is the result block.  Use this if z may contain inplaceable contents that would free prematurely
 // Routines that do little except call a function that does PROLOG/EPILOG have EPILOGNULL as a placeholder
 // Routines that do not return A
 #define EPILOG0         tpop(_ttop)
@@ -645,11 +642,6 @@ if(z<3){_zzt+=z; z=(I)&oneone; _zzt=_i&3?_zzt:(I*)z; z=_i&2?(I)_zzt:z; z=((I*)z)
 #define CLEARZOMBIE     {jt->assignsym=0;}  // Used when we know there shouldn't be an assignsym, just in case
 #define PUSHZOMB L*savassignsym = jt->assignsym; if(savassignsym){if(((jt->asgzomblevel-1)|((AN(jt->locsyms)-2)))<0){CLEARZOMBIE}}  // test is (jt->asgzomblevel==0||AN(jt->locsyms)<2)
 #define POPZOMB {jt->assignsym=savassignsym;}
-#if FINDNULLRET   // When we return 0, we should always have an error code set.  trap if not
-#define R0 {if(jt->jerr)return A0;else SEGFAULT;}
-#else
-#define R0 return 0;
-#endif
 #define REPSGN(x) ((x)>>(BW-1))  // replicate sign bit of x to entire word (assuming x is signed type - if unsigned, just move sign to bit 0)
 #define SGNTO0(x) ((UI)(x)>>(BW-1))  // move sign bit to bit 0, clear other bits
 // In the original JE many verbs returned a clone of the input, i. e. return ca(w).  We have changed these to avoid the clone, but we preserve the memory in case we need to go back
@@ -658,7 +650,7 @@ if(z<3){_zzt+=z; z=(I)&oneone; _zzt=_i&3?_zzt:(I*)z; z=_i&2?(I)_zzt:z; z=((I*)z)
 #define RESETERRANDMSG  {jt->etxn1=jt->etxn=jt->jerr=0;}
 #define RESETRANK       (jt->ranks=(RANK2T)~0)
 #define RNE(exp)        {return jt->jerr?0:(exp);}
-#define RZ(exp)         {if(!(exp))R0}
+#define RZ(exp)         {if(!(exp))return 0;}
 
 #define DEADARG(x)      0
 #define ARGCHK1D(x)

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -265,7 +265,7 @@ static inline omp_int_t omp_get_max_threads() { return 1;}
 
 #define AUDITEXECRESULTS 0  // When set, we go through all execution results to verify recursive and virtual bits are OK
 #define FORCEVIRTUALINPUTS 0  // When 1 set, we make all non-inplaceable noun inputs to executions VIRTUAL.  Tests should still run
-                           // When 2 set, make all outputs from RETF() virtual.  Tests for inplacing will fail; that's OK if nothing crashes
+                           // When 2 set, make all outputs from return  virtual.  Tests for inplacing will fail; that's OK if nothing crashes
 // set FINDNULLRET to trap when a routine returns 0 without having set an error message
 #define FINDNULLRET 0
 
@@ -629,9 +629,9 @@ if(z<3){_zzt+=z; z=(I)&oneone; _zzt=_i&3?_zzt:(I*)z; z=_i&2?(I)_zzt:z; z=((I*)z)
 #define PROLOG(x)       A *_ttop=jt->tnextpushp
 #define PROLOGNOTREQ(x)   // if nothing is allocated, we don't really need PROLOG
 #define EPILOGNORET(z) (gc(z,_ttop))   // protect z and return its address
-#define EPILOG(z)       RETF(EPILOGNORET(z))   // z is the result block
+#define EPILOG(z)       return EPILOGNORET(z)   // z is the result block
 #define EPILOGNOVIRT(z)       return rifvsdebug((gc(z,_ttop)))   // use this when the repercussions of allowing virtual result are too severe
-#define EPILOGZOMB(z)       if(!gc3(&(z),0L,0L,_ttop))R0; RETF(z);   // z is the result block.  Use this if z may contain inplaceable contents that would free prematurely
+#define EPILOGZOMB(z)       if(!gc3(&(z),0L,0L,_ttop))R0; return z;   // z is the result block.  Use this if z may contain inplaceable contents that would free prematurely
 // Routines that do little except call a function that does PROLOG/EPILOG have EPILOGNULL as a placeholder
 // Routines that do not return A
 #define EPILOG0         tpop(_ttop)
@@ -668,19 +668,13 @@ if(z<3){_zzt+=z; z=(I)&oneone; _zzt=_i&3?_zzt:(I*)z; z=_i&2?(I)_zzt:z; z=((I*)z)
 #define ARGCHK2(x,y)    ARGCHK1(x) ARGCHK1(y)
 #define ARGCHK3(x,y,z)  ARGCHK1(x) ARGCHK1(y) ARGCHK1(z)
 
-// RETF is the normal function return.  For debugging we hook into it
-#if AUDITEXECRESULTS && (FORCEVIRTUALINPUTS==2)
-#define RETF(exp)       A ZZZz = (exp); auditblock(ZZZz,1,1); ZZZz = virtifnonip(jt,0,ZZZz); return ZZZz
-#else
-#define RETF(exp)       return exp
 // Input is a byte.  It is replicated to all lanes of a UI
-#endif
 #define REPLBYTETOW(in,out) (out=(UC)(in),out|=out<<8,out|=out<<16,out|=out<<32)
 // Output is pointer, Input is I/UI, count is # bytes to NOT store to output pointer (0-7).
 #define STOREBYTES(out,in,n) {*(UI*)(out) = (*(UI*)(out)&~((UI)~(I)0 >> ((n)<<3))) | ((in)&((UI)~(I)0 >> ((n)<<3)));}
 // Input is the name of word of bytes.  Result is modified name, 1 bit per input byte, spaced like B01s, with the bit 0 iff the corresponding input byte was all 0.  Non-boolean bits of result are garbage.
 #define ZBYTESTOZBITS(b) (b=b|((b|(~b+VALIDBOOLEAN))>>7))  // for each byte: zero if b0 off, b7 off, and b7 turns on when you subtract 1 or 2
-// to verify gah conversion #define RETF(exp)       { A retfff=(exp);  if ((retfff) && ((AT(retfff)&SPARSE && AN(retfff)!=1) || (AT(retfff)&DENSE && AN(retfff)!=prod(AR(retfff),AS(retfff)))))SEGFAULT;; return retfff; } // scaf
+// to verify gah conversion #define return exp       { A retfff=(exp);  if ((retfff) && ((AT(retfff)&SPARSE && AN(retfff)!=1) || (AT(retfff)&DENSE && AN(retfff)!=prod(AR(retfff),AS(retfff)))))SEGFAULT;; return retfff; } // scaf
 #define SBSV(x)         (jt->sbsv+(I)(x))
 #define SBUV(x)         (jt->sbuv+(I)(x))
 #define SEGFAULT        (*(volatile I*)0 = 0)

--- a/jsrc/m.c
+++ b/jsrc/m.c
@@ -102,7 +102,7 @@ F1(jtspcount){A z;I c=0,i,j,*v;A x;
  GATV0(z,INT,2*(-PMINL+PLIML+1),2); v=AV(z);
  for(i=PMINL;i<=PLIML;++i){j=0; x=(jt->mfree[-PMINL+i].pool); while(x){x=AFCHAIN(x); ++j;} if(j){++c; *v++=(I)1<<i; *v++=j;}}
  v=AS(z); v[0]=c; v[1]=2; AN(z)=2*c;
- RETF(z);
+ return z;
 }    /* 7!:3 count of unused blocks */
 
 // Garbage collector.  Called when free has decided a call is needed
@@ -204,7 +204,7 @@ F1(jtspfor){A*wv,x,y,z;C*s;D*v,*zv;I i,m,n;
   RZ(y=symbrd(nfs(m,s))); 
   *v=0.0; spfor1(y); zv[i]=*v;
  }
- RETF(z);
+ return z;
 }    /* 7!:5 space for named object; w is <'name' */
 
 F1(jtspforloc){A*wv,x,y,z;C*s;D*v,*zv;I i,j,m,n;L*u;LX *yv,c;
@@ -236,11 +236,11 @@ F1(jtspforloc){A*wv,x,y,z;C*s;D*v,*zv;I i,j,m,n;L*u;LX *yv,c;
   }
   zv[i]=*v;
  }
- RETF(z);
+ return z;
 }    /* 7!:6 space for a locale */
 
 
-F1(jtmmaxq){ASSERTMTV(w); RETF(sc(jt->mmax));}
+F1(jtmmaxq){ASSERTMTV(w); return sc(jt->mmax);}
      /* 9!:20 space limit query */
 
 F1(jtmmaxs){I j,m=MLEN,n;
@@ -248,7 +248,7 @@ F1(jtmmaxs){I j,m=MLEN,n;
  ASSERT(1E5<=n,EVLIMIT);
  j=m-1; DO(m, if(n<=(I)1<<i){j=i; break;});
  jt->mmax=(I)1<<j;
- RETF(mtm);
+ return mtm;
 }    /* 9!:21 space limit set */
 
 
@@ -957,7 +957,7 @@ F1(jtca){A z;I t;P*wp,*zp;
  return z;
 }
 // clone block only if it is read-only
-F1(jtcaro){ if(AFLAG(w)&AFRO){RETF(ca(w));} RETF(w); }
+F1(jtcaro){ if(AFLAG(w)&AFRO){return ca(w);} return w; }
 
 // clone recursive.
 F1(jtcar){A*u,*wv,z;I n;P*p;V*v;

--- a/jsrc/px.c
+++ b/jsrc/px.c
@@ -37,7 +37,7 @@ F1(jtexec1){A z;
   STACKCHKOFL FDEPINC(1); z=parse(ddtokens(vs(w),4+1+(AN(jt->locsyms)>1))); jt->asgn=0; FDEPDEC(1);  // replace DDs, but require that they be complete within the string (no jgets)
   jt->sf=savself;
  }
- RETF(z&&!(AT(z)&NOUN)?mtv:z);  // if non-noun result, return empty $0
+ return z&&!(AT(z)&NOUN)?mtv:z;  // if non-noun result, return empty $0
 }
 
 // execute w, which is either a string or the boxed words of a string (as if from tokens())
@@ -50,7 +50,7 @@ F1(jtimmex){A z;
  AKGST(jt->locsyms)=jt->global; // in case the sentence has operators, set a locale for it
  STACKCHKOFL FDEPINC(1); z=parse(AT(w)&BOX?w:tokens(w,1+(AN(jt->locsyms)>1))); FDEPDEC(1);
  if(z&&!jt->asgn)jpr(z);
- RETF(z);
+ return z;
 }
 
 // execute for assert: check result for all 1
@@ -58,7 +58,7 @@ F1(jtimmea){A t,z,z1;
  RZ(w=ddtokens(w,4+1+(AN(jt->locsyms)>1))); z=immex(w);   // check for DD, but don't allow continuation read
  ASSERT(jt->asgn||!z||!(AT(z)&NOUN)||(t=eq(num(1),z),
      all1(AT(z)&SPARSE?df1(z1,t,atop(slash(ds(CSTARDOT)),ds(CCOMMA))):t)),EVASSERT);  // apply *./@, if sparse
- RETF(z);
+ return z;
 }
 
 static A jtcex(J jt,A w,AF f,A self){A z; RE(w); z=f(jt,w,self); RESETERR; return z;}

--- a/jsrc/r.c
+++ b/jsrc/r.c
@@ -53,7 +53,7 @@ F1(jtaro){A fs,gs,hs,s,*u,*x,y,z;B ex,xop;C id;I*hv,m;V*v;
   if(evoke(w)){RZ(w=sfne(w)); if(FUNC&AT(w))w=aro(w); return w;}  // keep nameref as a string, UNLESS it is NMDOT, in which case use the (f.'d) verb value
  }
  GAT0(z,BOX,2,1); x=AAV(z);
- if(NOUN&AT(w)){RZ(x[0]=incorp(ravel(scc(CNOUN)))); if(AT(w)&NAME)RZ(w=sfn(0,w)); RZ(x[1]=INCORPNA(w)); RETF(z);}  // if name, must be ".@'name', format name as string
+ if(NOUN&AT(w)){RZ(x[0]=incorp(ravel(scc(CNOUN)))); if(AT(w)&NAME)RZ(w=sfn(0,w)); RZ(x[1]=INCORPNA(w)); return z;}  // if name, must be ".@'name', format name as string
  GATV0(y,BOX,m,1); u=AAV(y);
  if(0<m)RZ(u[0]=incorp(aro(fs)));
  if(1<m)RZ(u[1]=incorp(aro(ex?unparsem(num(0),w):xop?hs:gs)));
@@ -236,7 +236,7 @@ A jtunDD(J jt, A w){F1PREFIP;
   }
  }
  // make result incorpable
- RETF(incorp(w));
+ return incorp(w);
 }
 
 static A jtunparse1(J jt,CW*c,A x,I j,A y){A q,z;C*s;I t;

--- a/jsrc/result.h
+++ b/jsrc/result.h
@@ -349,7 +349,7 @@ do{
   // If WILLBEOPENED is set, there is no reason to EPILOG.  We didn't have any wrecks, we didn't allocate any blocks, and we kept the
   // result as a nonrecursive block.  In fact, we must avoid EPILOG because that would increment the usecount of the contents and apply the death warrant; then
   // when the block was finally freed the backer would leak, because the check for the backer is applied only in tpop
- if(ZZFLAGWORD&ZZFLAGWILLBEOPENED){RETF(zz);}  // no need to check for inhomogeneous results
+ if(ZZFLAGWORD&ZZFLAGWILLBEOPENED){return zz;}  // no need to check for inhomogeneous results
 
  ASSERT((ZZFLAGWORD&(ZZFLAGHASUNBOX|ZZFLAGHASBOX))!=(ZZFLAGHASUNBOX|ZZFLAGHASBOX),EVDOMAIN);  // if there is a mix of boxed and non-boxed results, fail
  if(ZZFLAGWORD&ZZFLAGBOXALLO){

--- a/jsrc/rt.c
+++ b/jsrc/rt.c
@@ -124,15 +124,15 @@ static F1(jttreach){return troot(scc('0'),graft(ope(every(w,(A)&trrself))));}
 
 static F1(jttrr){PROLOG(0058);A hs,s,t,*x,z;B ex,xop;C id;I fl,*hv,m;V*v;
  ARGCHK1(w);
- if(AT(w)&NOUN+NAME){RETF(tleaf(lrep(w)));}
+ if(AT(w)&NOUN+NAME){return tleaf(lrep(w));}
  v=FAV(w); id=v->id; fl=v->flag;
  I fndx=(id==CBDOT)&&!v->fgh[0]; A fs=v->fgh[fndx]; A gs=v->fgh[fndx^1];  // In verb for m b., if f is empty look to g for the left arg.  It would be nice to be more general
  hs=v->fgh[2]; if(id==CBOX)gs=0;  // ignore gs field in BOX, there to simulate BOXATOP
- if(fl&VXOPCALL){RETF(trr(hs));}
+ if(fl&VXOPCALL){return trr(hs);}
  xop=1&&VXOP&fl; ex=id==CCOLON&&hs&&!xop;
  m=(I )!!fs+(I )(gs||ex)+(I )(id==CFORK||xop&&hs);
- if(!m){RETF(tleaf(spella(w)));}
- if(evoke(w)){RZ(w=sfne(w)); RETF((AT(w)&FUNC?jttrr:jttleaf)(jt,w));}
+ if(!m){return tleaf(spella(w));}
+ if(evoke(w)){RZ(w=sfne(w)); return (AT(w)&FUNC?jttrr:jttleaf)(jt,w);}
  GATV0(t,BOX,m,1); x=AAV(t);
  if(0<m)RZ(x[0]=incorp(fl&VGERL?treach(fxeach(fs,(A)&jtfxself[0])):trr(fs)));
  if(1<m)RZ(x[1]=incorp(fl&VGERR?treach(fxeach(gs,(A)&jtfxself[0])):ex?trr(unparsem(num(0),w)):trr(gs)));

--- a/jsrc/s.c
+++ b/jsrc/s.c
@@ -155,7 +155,7 @@ F1(jtsympool){A aa,q,x,y,*yv,z,*zv;I i,n,*u,*xv;L*pv;LX j,*v;
   RZ(aa=incorp(cstr("**local**")));
   RZ(q=sympoola(x)); u=AV(q); DO(AN(q), yv[u[i]]=aa;);
  }
- RETF(z);
+ return z;
 }    /* 18!:31 symbol pool */
 
 // l/string are length/addr of name, hash is hash of the name, g is symbol table
@@ -407,7 +407,7 @@ static A jtdllsymaddr(J jt,A w,C flag){A*wv,x,y,z;I i,n,*zv;L*v;
   ASSERT(NOUN&AT(y),EVDOMAIN);
   zv[i]=flag?(I)AV(y):(I)v;
  }
- RETF(z);
+ return z;
 }    /* 15!:6 (0=flag) or 15!:14 (1=flag) */
 
 F1(jtdllsymget){return dllsymaddr(w,0);}

--- a/jsrc/sl.c
+++ b/jsrc/sl.c
@@ -224,7 +224,7 @@ F1(jtlocnc){A*wv,y,z;C c,*u;I i,m,n,*zv;
  n=AN(w); wv=AAV(w); 
  GATV(z,INT,n,AR(w),AS(w)); zv=AV(z);
  if(!n)return z;  // if no input, return empty before handling numeric-atom case
- if(AT(w)&(INT|B01)){IAV(z)[0]=findnl(BIV0(w))?1:-1; RETF(z);}  // if integer, must have been atomic or empty.  Handle the one value
+ if(AT(w)&(INT|B01)){IAV(z)[0]=findnl(BIV0(w))?1:-1; return z;}  // if integer, must have been atomic or empty.  Handle the one value
  for(i=0;i<n;++i){
   y=wv[i];
   if(!AR(y)&&AT(y)&((INT|B01))){  // atomic numeric locale
@@ -237,7 +237,7 @@ F1(jtlocnc){A*wv,y,z;C c,*u;I i,m,n,*zv;
    else            zv[i]=probe(m,u,(UI4)nmhash(m,u),jt->stloc)?0:-1;
   }
  }
- RETF(z);
+ return z;
 }    /* 18!:0 locale name class */
 
 static F1(jtlocnlx){A y,z=mtv;B*wv;I m=0;

--- a/jsrc/sn.c
+++ b/jsrc/sn.c
@@ -73,7 +73,7 @@ A jtnfs(J jt,I n,C*s){A z;C f,*t;I m,p;NM*zv;
  ASSERT((m|p)<=255,EVLIMIT);  // error if name too long.  Requires limit be power of 2
  zv->flag=f;  // Install locative flag
  zv->m=(UC)m; zv->hash=(UI4)nmhash(m,s); // Install length, and calculate hash of simple name
- RETF(z);
+ return z;
 }    /* name from string */
 
 // string from name: returns string for the name
@@ -125,7 +125,7 @@ F1(jtnc){A*wv,x,y,z;I i,n,t,*zv;L*v;
   zc=x?zc:-1; zc=y?zc:-2;
   zv[i]=zc;  // calculate the type, store in result array
  }
- RETF(z);
+ return z;
 }    /* 4!:0  name class */
 
 
@@ -167,7 +167,7 @@ F1(jtscind){A*wv,x,y,z;I n,*zv;L*v;
  wv=AAV(w); 
  GATV(z,INT,n,AR(w),AS(w)); zv=AV(z);
  DO(n, x=wv[i]; RE(y=stdnm(x)); ASSERTN(y,EVILNAME,nfs(AN(x),CAV(x))); v=syrd(y,jt->locsyms); RESETERR; zv[i]=v?v->sn:-1;);
- RETF(z);
+ return z;
 }    /* 4!:4  script index */
 
 
@@ -246,5 +246,5 @@ F1(jtex){A*wv,y,z;B*zv;I i,n;L*v;I modifierchg=0;
   }
  }
  jt->modifiercounter+=modifierchg;
- RETF(z);
+ return z;
 }    /* 4!:55 expunge */

--- a/jsrc/u.c
+++ b/jsrc/u.c
@@ -188,7 +188,7 @@ A jtifb(J jt,I n,B* RESTRICT b){A z;I p,* RESTRICT zv;
 }    /* integer vector from boolean mask */
 
 // i. # w
-static F1(jtii){ARGCHK1(w); I j; RETF(IX(SETIC(w,j)));}
+static F1(jtii){ARGCHK1(w); I j; return IX(SETIC(w,j));}
 
 // Return the higher-priority of the types s and t.  s and t are known to be not equal.
 // If either is sparse, convert the result to sparse.
@@ -226,32 +226,32 @@ A jtodom(J jt,I r,I n,I* RESTRICT s){A z;I m,mn,*u,*zv;
 
 F1(jtrankle){return!w||AR(w)?w:ravel(w);}
 
-A jtsc(J jt,I k)     {A z; if((k^REPSGN(k))<=NUMMAX){z=num(k); z=k&~1?z:zeroionei(k); return z;} GAT0(z,INT, 1,0); IAV(z)[0]=k;     RETF(z);}  // always return I
-A jtscib(J jt,I k)   {A z; if((k^REPSGN(k))<=NUMMAX)return num(k); GAT0(z,INT, 1,0); IAV(z)[0]=k;     RETF(z);}  // return b if 0 or 1, else I
-A jtsc4(J jt,I t,I v){A z; GA(z,t,   1,0,0); IAV(z)[0]=v;     RETF(z);}  // return scalar with a given I-length type (numeric or box)
+A jtsc(J jt,I k)     {A z; if((k^REPSGN(k))<=NUMMAX){z=num(k); z=k&~1?z:zeroionei(k); return z;} GAT0(z,INT, 1,0); IAV(z)[0]=k;     return z;}  // always return I
+A jtscib(J jt,I k)   {A z; if((k^REPSGN(k))<=NUMMAX)return num(k); GAT0(z,INT, 1,0); IAV(z)[0]=k;     return z;}  // return b if 0 or 1, else I
+A jtsc4(J jt,I t,I v){A z; GA(z,t,   1,0,0); IAV(z)[0]=v;     return z;}  // return scalar with a given I-length type (numeric or box)
 A jtscb(J jt,B b)    {return num(b);}   // A block for boolean
-A jtscc(J jt,C c)    {A z; GAT0(z,LIT, 1,0); CAV(z)[0]=c;     RETF(z);}  // create scalar character
-A jtscf(J jt,D x)    {A z; GAT0(z,FL,  1,0); DAV(z)[0]=x;     RETF(z);}   // scalar float
-A jtscx(J jt,X x)    {A z; GAT0(z,XNUM,1,0); XAV(z)[0]=ca(x); RETF(z);}  // scalar extended
+A jtscc(J jt,C c)    {A z; GAT0(z,LIT, 1,0); CAV(z)[0]=c;     return z;}  // create scalar character
+A jtscf(J jt,D x)    {A z; GAT0(z,FL,  1,0); DAV(z)[0]=x;     return z;}   // scalar float
+A jtscx(J jt,X x)    {A z; GAT0(z,XNUM,1,0); XAV(z)[0]=ca(x); return z;}  // scalar extended
 
 // return A-block for the string *s with length n
-A jtstr(J jt,I n,C*s){A z; GATV0(z,LIT,n,1); MC(AV(z),s,n); RETF(z);}
+A jtstr(J jt,I n,C*s){A z; GATV0(z,LIT,n,1); MC(AV(z),s,n); return z;}
 
 // return A-block for the string *s with length n, enclosed in quotes and quotes doubled
-A jtstrq(J jt,I n,C*s){A z; I qc=2; DO(n, qc+=s[i]=='\'';) GATV0(z,LIT,n+qc,1); C *zv=CAV(z); *zv++='\''; DO(n, C c=s[i]; if(c=='\'')*zv++=c; *zv++=c;) *zv='\''; RETF(z);}
+A jtstrq(J jt,I n,C*s){A z; I qc=2; DO(n, qc+=s[i]=='\'';) GATV0(z,LIT,n+qc,1); C *zv=CAV(z); *zv++='\''; DO(n, C c=s[i]; if(c=='\'')*zv++=c; *zv++=c;) *zv='\''; return z;}
 
 // w is a LIT string; result is a new block with the same string, with terminating NUL added
-F1(jtstr0){A z;C*x;I n; ARGCHK1(w); ASSERT(LIT&AT(w),EVDOMAIN); n=AN(w); GATV0(z,LIT,n+1,1); x=CAV(z); MC(x,AV(w),n); x[n]=0; RETF(z);}
+F1(jtstr0){A z;C*x;I n; ARGCHK1(w); ASSERT(LIT&AT(w),EVDOMAIN); n=AN(w); GATV0(z,LIT,n+1,1); x=CAV(z); MC(x,AV(w),n); x[n]=0; return z;}
 
 // return A-block for a 2-atom integer vector containing a,b
-A jtv2(J jt,I a,I b){A z;I*x; GAT0(z,INT,2,1); x=AV(z); *x++=a; *x=b; RETF(z);}
+A jtv2(J jt,I a,I b){A z;I*x; GAT0(z,INT,2,1); x=AV(z); *x++=a; *x=b; return z;}
 
 // return A-block for singleton integer list whose value is k
-A jtvci(J jt,I k){A z; GAT0(z,INT,1,1); IAV(z)[0]=k; RETF(z);}
+A jtvci(J jt,I k){A z; GAT0(z,INT,1,1); IAV(z)[0]=k; return z;}
 
 // return A-block for list of type t, length n, and values *v
 // MUST NOT return virtual or fixed block, because we often modify the returned area
-A jtvec(J jt,I t,I n,void*v){A z; GA(z,t,n,1,0); MC(AV(z),v,n<<bplg(t)); RETF(z);}
+A jtvec(J jt,I t,I n,void*v){A z; GA(z,t,n,1,0); MC(AV(z),v,n<<bplg(t)); return z;}
 
 // return A-block for list of type t, length n, and values *v
 // with special handling to coerce boolean type
@@ -264,7 +264,7 @@ A jtvecb01(J jt,I t,I n,void*v){A z; I i; GA(z,t,n,1,0);if(t&B01){C*p=(C*)AV(z),
 #pragma clang loop vectorize(enable) interleave_count(4)
 #endif
 for(i=0;i<n<<bplg(t);i++)*p++=!!(*q++);
-}else MC(AV(z),v,n<<bplg(t)); RETF(z);}
+}else MC(AV(z),v,n<<bplg(t)); return z;}
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma pop_options
@@ -298,11 +298,11 @@ F1(jtvib){A z;D d,e,*wv;I i,n,*zv;
   case XNUM:
   case RAT:  z=cvt(INT,maximum(sc(p),minimum(sc(q),w))); break;
  }
- jt->ranks=oqr; RETF(z);
+ jt->ranks=oqr; return z;
 }
 
 // Convert w to integer if needed, and verify every atom is nonnegative
-F1(jtvip){I*v; ARGCHK1(w); if(!(INT&AT(w)))RZ(w=cvt(INT,w)); v=AV(w); DQ(AN(w), ASSERT(0<=*v++,EVDOMAIN);); RETF(w);}
+F1(jtvip){I*v; ARGCHK1(w); if(!(INT&AT(w)))RZ(w=cvt(INT,w)); v=AV(w); DQ(AN(w), ASSERT(0<=*v++,EVDOMAIN);); return w;}
 
 // Convert w to string, verify it is a list or atom
 F1(jtvs){ARGCHK1(w); ASSERT(1>=AR(w),EVRANK); return LIT&AT(w)?w:cvt(LIT,w);}

--- a/jsrc/verbs/v.c
+++ b/jsrc/verbs/v.c
@@ -6,8 +6,8 @@
 #include "j.h"
 
 
-F1(jttally ){A z; I k; ARGCHK1(w); z=sc(SETIC(w,k));            RETF(AT(w)&XNUM+RAT?xco1(z):z);}  //  # y
-F1(jtshapex){A z; ARGCHK1(w); z=vec(INT,AR(w),AS(w)); RETF(AT(w)&XNUM+RAT?xco1(z):z);}
+F1(jttally ){A z; I k; ARGCHK1(w); z=sc(SETIC(w,k));            return AT(w)&XNUM+RAT?xco1(z):z;}  //  # y
+F1(jtshapex){A z; ARGCHK1(w); z=vec(INT,AR(w),AS(w)); return AT(w)&XNUM+RAT?xco1(z):z;}
 F1(jtshape){ARGCHK1(w); return vec(INT,AR(w),AS(w));}  // $ y
 F1(jtisempty){ARGCHK1(w); if((AT(w)&SPARSE)!=0)return eps(zeroionei(0),shape(w)); return num(AN(w)==0);}  // 0 e. $
 F1(jtisnotempty){ARGCHK1(w); if((AT(w)&SPARSE)!=0)return __not(eps(zeroionei(0),shape(w))); return num(AN(w)!=0);}  // *@#@,
@@ -27,17 +27,17 @@ F1(jtravel){A a,c,q,x,y,y0,z;B*b;I f,j,m,r,*u,*v,*yv;P*wp,*zp;
    // the self-virtual-block code in virtual() because we can do it for indirect types also, since we know we are not changing
    // the number of atoms
    // We preserve pristinity between the input and the output
-   AR(w)=(RANKT)(1+f); AS(w)[f]=m; RETF(w);
+   AR(w)=(RANKT)(1+f); AS(w)[f]=m; return w;
   }
   // Not self-virtual.  Create a (noninplace) virtual copy, but not if NJA memory  NJAwhy
   // If rank 0 were the only thing stopping us from inplacing, we could inherit pristinity
-  if(!(AFLAG(w)&(AFNJA))){RZ(z=virtual(w,0,1+f)); AN(z)=AN(w); MCISH(AS(z),AS(w),f) AS(z)[f]=m; RETF(z);}
+  if(!(AFLAG(w)&(AFNJA))){RZ(z=virtual(w,0,1+f)); AN(z)=AN(w); MCISH(AS(z),AS(w),f) AS(z)[f]=m; return z;}
 
   // If we have to allocate a new block, do so.  In that rare case, revoke pristinity of w
   GA(z,AT(w),AN(w),1+f,AS(w)); AS(z)[f]=m;   // allocate result area, shape=frame+1 more to hold size of cell; fill in shape
   MC(AV(z),AV(w),AN(w)<<bplg(AT(w)));
   PRISTCLRF(w)
-  RETF(z); // if dense, move the data and relocate it as needed
+  return z; // if dense, move the data and relocate it as needed
  }
  // the rest handles sparse matrix enfile
  RESETRANK;   // clear IRS for calls made here
@@ -60,7 +60,7 @@ F1(jtravel){A a,c,q,x,y,y0,z;B*b;I f,j,m,r,*u,*v,*yv;P*wp,*zp;
  SPB(zp,e,ca(SPA(wp,e)));
  SPB(zp,x,x);
  SPB(zp,i,y); 
- RETF(z);
+ return z;
 }
 
 F1(jttable){A z,zz;I r,wr;
@@ -82,14 +82,14 @@ static A jtlr2(J jt,RANK2T ranks,A a,A w){I acr,af,ar,wcr,wf,wr;
  // Cells of the shorter-frame argument are repeated.  If the shorter- (or equal-)-frame argument
  // is the one being discarded (eg (i. 10 10) ["0 i. 10), the replication doesn't matter, and we
  // simply keep the surviving argument intact.
- if(wf>=af){RETF(w);}  // no replication - quick out
- RESETRANK; RETF(reitem(vec(INT,af-wf,AS(a)),lamin1(w)));  // could use virtual block, but this case is so rare...
+ if(wf>=af){return w;}  // no replication - quick out
+ RESETRANK; return reitem(vec(INT,af-wf,AS(a)),lamin1(w));  // could use virtual block, but this case is so rare...
 } 
 
-F2(jtleft2 ){F2PREFIP;RANK2T jtr=jt->ranks; if(jtr==(RANK2T)~0)RETARG(a); RETF(lr2((jtr<<RMAXX)|(jtr>>RMAXX),w,a));}  // swap a & w, and their ranks
-F2(jtright2){F2PREFIP;RANK2T jtr=jt->ranks; if(jtr==(RANK2T)~0)RETARG(w); RETF(lr2(jtr,a,w));}
+F2(jtleft2 ){F2PREFIP;RANK2T jtr=jt->ranks; if(jtr==(RANK2T)~0)RETARG(a); return lr2((jtr<<RMAXX)|(jtr>>RMAXX),w,a);}  // swap a & w, and their ranks
+F2(jtright2){F2PREFIP;RANK2T jtr=jt->ranks; if(jtr==(RANK2T)~0)RETARG(w); return lr2(jtr,a,w);}
 
-F1(jtright1){RETF(w);}
+F1(jtright1){return w;}
 
 // i. y
 F1(jtiota){A z;I m,n,*v;
@@ -99,7 +99,7 @@ F1(jtiota){A z;I m,n,*v;
  if(1==n){m=*v; return 0>m?apv(-m,-m-1,-1L):IX(m);}
  A mg; RZ(mg=mag(w)); PRODX(m,n,IAV(mg),1); RZ(z=IX(m)); RZ(z=reshape(mag(w),z));
  DO(n, A zz; if(0>v[i])z=IRS1(z,0L,n-i,jtreverse,zz););
- RETF(z);
+ return z;
 }
 
 // i: w
@@ -112,7 +112,7 @@ F1(jtjico1){A y,z;B b;D d,*v;I c,m,n;
  if(b&&m*c==2*ABS(n))z=apv(1+m,-n,0>d?-c:c);  // if integer works, use it
  else                z=plusW(scf(0>d?d:-d),tymesW(scf(2*ABS(d)/m),apv(1+m,0>d?m:0L,0>d?-1L:1L)));  // otherwise FL
  if(AT(w)&XNUM+RAT)z=cvt(AT(w)&XNUM||equ(w,floor1(w))?XNUM:RAT,z);  // cvrt to XNUM as needed
- RETF(z);
+ return z;
 }
 
 DF1(jtnum1){ARGCHK2(w,self); return FAV(self)->fgh[2];}
@@ -143,5 +143,5 @@ A jtcharmap(J jt,A w,A x,A y){A z;B bb[256];I k,n,wn;UC c,*u,*v,zz[256];
  GATV(z,LIT,wn,AR(w),AS(w)); v=UAV(z); u=UAV(w);
  if(((k-1)&(n-AN(y)))>=0)DQ(wn, c=*u++; ASSERT(bb[c],EVINDEX); *v++=zz[c];)  // not all codes mapped AND #x>=#y, meaning index error possible on {
  else if(!bitwisecharamp(zz,wn,u,v))DQ(wn, *v++=zz[*u++];);  // no index error possible, and special case not handled
- RETF(z);
+ return z;
 }    /* y {~ x i. w */

--- a/jsrc/verbs/v0.c
+++ b/jsrc/verbs/v0.c
@@ -36,7 +36,7 @@ static F1(jtrsort){A t,z;
  A tt; RZ(IRS2(t,t,0L,1L,1L,jtindexof,tt));
  z=dgrade2(w,cant1(IRS2(tt,t,0L,1L,1L,jtfrom,z)));
  POPCCT
- RETF(z);
+ return z;
 }
 
 static F2(jtcfrz){A z;B b=0,p;I j,n;Z c,d,*t,*u,*v;
@@ -218,7 +218,7 @@ static A jtrfcz(J jt,I m,A w){A x,y,z;B bb=0,real;D c,d;I i;Z r,*xv,*yv,*zv;
    DO(m, zv[i]=newt(m,xv,zv[i],10L););
  }}
  if(real){B b=1; DO(m, if(zv[i].im){b=0; break;}); if(b)z=cvt(FL,z);}
- RETF(z);
+ return z;
 }    /* roots from coefficients, degree m is 2 or more */
 
 // roots from coefficients.  w is (possibly empty) list of coefficients
@@ -329,7 +329,7 @@ DF2(jtpoly2){F2PREFIP;A c,za;I b;D*ad,d,p,*x,u,*z;I an,at,j,t,n,wt;Z*az,e,q,*wz,
  b=b?3:b;
  if(((j-1)&((t&XNUM+RAT+SPARSE)-1))<0){
   if(ASGNINPLACESGN(SGNIF((I)jtinplace,JTINPLACEWX),w))za=w;else{GA(za,t,AN(w),AR(w),AS(w));}
-  if(n==0){RETF(za);}  // don't run the copy loop if 0 atoms in result
+  if(n==0){return za;}  // don't run the copy loop if 0 atoms in result
   z=DAV(za); zz=ZAV(za);
   b+=(t>>FLX)&3; // must be FL/CMPX, add 1 or 2
  }else{if(postfn)return jtupon2cell(jt,a,w,self);  // revert if there is a postfn, and we are using the eval path.  type must be FL
@@ -355,7 +355,7 @@ DF2(jtpoly2){F2PREFIP;A c,za;I b;D*ad,d,p,*x,u,*z;I an,at,j,t,n,wt;Z*az,e,q,*wz,
  case 4: NAN0; DO(n, p=d; u=*x++; DO(an,p*=u-ad[i];); *z++=p;); NAN1;                  break;
  case 5: NAN0; DO(n, q=e; y=*wz++; DO(an,q=ztymes(q,zminus(y,az[i]));); *zz++=q;); NAN1; break;
  }
- RETF(za);
+ return za;
 }    /* a p."r w */
 
 

--- a/jsrc/verbs/v1.c
+++ b/jsrc/verbs/v1.c
@@ -235,7 +235,7 @@ F2(jtmatch){A z;I af,m,n,mn,wf;
  mn=m*n;  // total number of matches to do, i. e. # results
  GATV(z,B01,mn,wf,AS(w)); matchsub(a,w,BAV(z),af,wf,m,n,eqis0^1);  // matchsub stores, and we ignore the result
  // We do not check for a==w here & thus will compare them
- RETF(z);
+ return z;
 }    /* a -:"r w */
 
 F2(jtnotmatch){return jtmatch((J)((I)jt+1),a,w);}   /* a -.@-:"r w */

--- a/jsrc/verbs/v2.c
+++ b/jsrc/verbs/v2.c
@@ -281,7 +281,7 @@ static F1(jtprevprime){A fs,x,y;I k,m,n,*xv,*yv;X*wv;
 static F1(jttotient){A b,x,z;B*bv,p=0;I k,n,t;
  ARGCHK1(w);
  n=AN(w); t=AT(w);
- if(t&B01)RCA(w);
+ if(t&B01)return w;
  GATV(b,B01,n,AR(w),AS(w)); bv=BAV(b);
  if(t&INT){I*wv=AV(w),*xv;
   GATV(x,INT,n,AR(w),AS(w)); xv=AV(x);

--- a/jsrc/verbs/v2.c
+++ b/jsrc/verbs/v2.c
@@ -85,7 +85,7 @@ static F1(jtprime1){A d,t,y,z;B*b,*u;I c,*dv,e,i,j,k,m,n,p,q,*wv,x,*zv;
   while(n>k&&1==wv[dv[k]])zv[dv[k++]]=3;
   while(n>k&&2==wv[dv[k]])zv[dv[k++]]=5;
  }
- if(n==k){RETF(z);} 
+ if(n==k){return z;}
  j=3; p=0; e=PT; q=1+(I)sqrt((D)m); x=wv[dv[k]]; 
  GATV0(t,B01,q,1);         u=BAV(t); sieve(0L,q,u,u); 
  GATV0(y,B01,MIN(m,MM),1); b=BAV(y); 
@@ -96,7 +96,7 @@ static F1(jtprime1){A d,t,y,z;B*b,*u;I c,*dv,e,i,j,k,m,n,p,q,*wv,x,*zv;
   else   for(i=1-(p&1);i<q;i+=2)
    if(b[i]){while(j==x){zv[dv[k++]]=i+p; if(n==k)return z; x=wv[dv[k]];} ++j;}
  }
- while(n>k)zv[dv[k++]]=p; RETF(z);
+ while(n>k)zv[dv[k++]]=p; return z;
 }
 
 static I init4792(J jt) {
@@ -202,7 +202,7 @@ static F1(jtiprimetest){A z;B*b;I d,j,n,*pv,q,*v,wn,*wv;
   if(32>n)b[j]=pmsk[MAX(0,n)];
   else{b[j]=1; DQ(AN(jt->p4792), d=*v++; q=n/d; if(n==q*d){b[j]=0; break;}else if(q<d)break;);}
  }
- RETF(z);
+ return z;
 }
 
 static F1(jtxprimetest){A z;B*b,rat;I d,j,q,n,*pv,*v,wn,wt,*yv;X r,*wv,x,xmaxint,y;
@@ -225,7 +225,7 @@ static F1(jtxprimetest){A z;B*b,rat;I d,j,q,n,*pv,*v,wn,wt,*yv;X r,*wv,x,xmaxint
    if(32>n)b[j]=pmsk[MAX(0,n)];
    else DQ(AN(jt->p4792), d=*v++; q=n/d; if(n==q*d){b[j]=0; break;}else if(q<d)break;);
  }}
- RETF(z);
+ return z;
 }    /* prime test for extended integers or rationals */
 
 static F1(jtprimetest){A x;I t;
@@ -391,7 +391,7 @@ F2(jtqco2){A q,y,z;B b,bb,xt;I c,j,k,m,*qv,wn,wr,*yv,*zv;
   GATV(z,INT,wn*m,1+wr,AS(w)); AS(z)[wr]=m; zv=AV(z);
   memset(zv,C0,AN(z)*SZI);
   j=0; c=AS(q)[wr]; DQ(wn, DQ(c, if(qv[j]&&m>yv[j])++zv[yv[j]]; ++j;); zv+=m;);
-  RETF(AT(w)&XNUM+RAT?cvt(XNUM,z):z);
+  return AT(w)&XNUM+RAT?cvt(XNUM,z):z;
 }}   /* a q: w for array w */
 
 static F1(jtxfactor);
@@ -675,7 +675,7 @@ static F1(test_ecm){A*wv,z;X*ab,n,*zv;
  ab=XAV(wv[0]);
  GAT0(z,XNUM,3,1); zv=XAV(z);
  RZ(ecm(n,ab[0],ab[1],i0(wv[2]),XAV(wv[3]),zv));
- RETF(z);
+ return z;
 }
 
 static F1(test_ecm_s1){A*wv,z;X*ab,n,*zv;
@@ -692,7 +692,7 @@ static F1(test_ecm_s1){A*wv,z;X*ab,n,*zv;
  ab=XAV(wv[0]);
  GAT0(z,XNUM,3,1); zv=XAV(z);
  RZ(ecm_s1(n,ab[0],ab[1],i0(wv[2]),XAV(wv[3]),zv));
- RETF(z);
+ return z;
 }
 
 static F1(test_ecm_s2){A*wv,z;I*b1b2;X*ab,n,*zv;
@@ -710,7 +710,7 @@ static F1(test_ecm_s2){A*wv,z;I*b1b2;X*ab,n,*zv;
  b1b2=AV(wv[2]);
  GAT0(z,XNUM,3,1); zv=XAV(z);
  RZ(ecm_s2(n,ab[0],ab[1],b1b2[0],b1b2[1],XAV(wv[3]),zv));
- RETF(z);
+ return z;
 }
 
 static F1(test_fac_ecm){

--- a/jsrc/verbs/v2.c
+++ b/jsrc/verbs/v2.c
@@ -496,7 +496,7 @@ static XF1(jtpollard_rho){I i,n;X g,y1,y2;
   RZ(y2=xrem(w,xplus(iv1,xsq(xplus(iv1,xsq(y2))))));
   RZ(g=xgcd(w,xrem(w,xminus(y2,y1))));
   if(!equ(g,iv1)&&!equ(g,w))return g;
-  if(!gc3(&y1,&y2,0L,old))R0;
+  if(!gc3(&y1,&y2,0L,old))return 0;
  }
  return iv1;
 }
@@ -539,7 +539,7 @@ static B jtecd(J jt,X n,X a,X b,X*q,X*z){X m,s,x2,y2,yy,z2;
   RZ(z2=xtymes(xc(2L),xtymes(q[1],q[2])));
   RZ(z[0]=xrem(n,x2)); RZ(z[1]=xrem(n,y2)); RZ(z[2]=xrem(n,z2));
  }
- if(!gc3(z,z+1,z+2,old))R0;
+ if(!gc3(z,z+1,z+2,old))return 0;
  return 1;
 }    /* elliptic curve double point (mod proj coord) */
 
@@ -564,7 +564,7 @@ static B jteca(J jt,X n,X a,X b,X*p,X*q,X*z){
    RZ(z3=xtymes(p[2],xtymes(q[2],w)));
    RZ(z[0]=xrem(n,x3)); RZ(z[1]=xrem(n,y3)); RZ(z[2]=xrem(n,z3));
  }}
- if(!gc3(z,z+1,z+2,old))R0;
+ if(!gc3(z,z+1,z+2,old))return 0;
  return 1;
 }    /* elliptic curve add (mod proj coord) */
 
@@ -582,7 +582,7 @@ static B jtecm(J jt,X n,X a,X b,I m,X*p,X*z){
   DQ(k, RZ(ecd(n,a,b,q,q)); if(BIT0&(c^d))RZ(eca(n,a,b,q,c&BIT0?p:pm,q)); c<<=1; d<<=1;);
   z[0]=q[0]; z[1]=q[1]; z[2]=q[2];
  }
- if(!gc3(z,z+1,z+2,old))R0;
+ if(!gc3(z,z+1,z+2,old))return 0;
  return 1;
 }    /* scalar mult ladder (mod proj coord) */
 
@@ -593,7 +593,7 @@ static B jtecm_s1(J jt,X n,X a,X b,I b1,X*q,X*z){A tt;D d,lg;I dd,m,*pv;X x[3];
  x[0]=q[0]; x[1]=q[1]; x[2]=q[2];
  DQ(m, d=(D)*pv++; dd=(I)pow(d,jfloor(5e-14+lg/log(d))); RZ(ecm(n,a,b,dd,x,x)););
  z[0]=x[0]; z[1]=x[1]; z[2]=x[2];
- if(!gc3(z,z+1,z+2,old))R0;
+ if(!gc3(z,z+1,z+2,old))return 0;
  return 1;
 }
 
@@ -610,7 +610,7 @@ static B jtecm_s2(J jt,X n,X a,X b,I b1,I b2,X*q,X*z){A sda,tt;I d,di,i,k,m,p0,*
   di=pd[i];
   DQ(di/d, RZ(eca(n,a,b,x,sdd,x)););
   RZ(eca(n,a,b,x,sd+3*(di%d),x));
- if(!gc3(x,x+1,x+2,old))R0;
+ if(!gc3(x,x+1,x+2,old))return 0;
  }
  z[0]=x[0]; z[1]=x[1]; z[2]=x[2];
  return 1;

--- a/jsrc/verbs/va2.c
+++ b/jsrc/verbs/va2.c
@@ -657,7 +657,7 @@ static A jtva2(J jt,AD * RESTRICT a,AD * RESTRICT w,AD * RESTRICT self,UI allran
   }else{GA(z,rtype((I)jtinplace),zn,(RANKT)fr,0); MCISH(AS(z),AS(((I)jtinplace&VIPWFLONG)?w:a),(fr>>RANKTX)&RANKTMSK); MCISH(AS(z)+((fr>>RANKTX)&RANKTMSK),scell,(fr&RANKTMSK)-((fr>>RANKTX)&RANKTMSK));} 
 //                                                 frame loc     shape of long frame             len of long frame           cellshape loc              cellshape     longer cellen 
   // fr free
-  if(zn==0){RETF(z);}  // If the result is empty, the allocated area says it all
+  if(zn==0){return z;}  // If the result is empty, the allocated area says it all
   // zn  NOT USED FROM HERE ON
 
   // End of setup phase.  The execution phase:
@@ -676,10 +676,10 @@ static A jtva2(J jt,AD * RESTRICT a,AD * RESTRICT w,AD * RESTRICT self,UI allran
    }
 
    // The work has been done.  If there was no error, check for optional conversion-if-possible or -if-necessary
-   if(rc==EVOK){if((I)jtinplace&VRI+VRD)z=cvz((I)jtinplace,z); RETF(z);  // normal return is here.  The rest is error recovery
+   if(rc==EVOK){if((I)jtinplace&VRI+VRD)z=cvz((I)jtinplace,z); return z;  // normal return is here.  The rest is error recovery
    }else if(rc-EWOVIP>=0){A zz;C *zzv;I zzk;
     // Here for overflow that can be corrected in place
-// not yet    if(rc==EVOKCLEANUP){jt->mulofloloc=0; RETF(z);}  // if multiply that did not overflow, clear the oflo position for next time, and return
+// not yet    if(rc==EVOKCLEANUP){jt->mulofloloc=0; return z;}  // if multiply that did not overflow, clear the oflo position for next time, and return
     // If the original result block cannot hold the D result, allocate a separate result area
     if(sizeof(D)==sizeof(I)){zz=z; MODBLOCKTYPE(zz,FL); zzk=aawwzk[4];   // shape etc are already OK
     }else{GATV(zz,FL,AN(z),AR(z),AS(z)); zzk=aawwzk[4]*(sizeof(D)/sizeof(I));}
@@ -866,7 +866,7 @@ DF2(jtsumattymes1){
  }
 
  RZ(jtsumattymesprods(jt,it,voidAV(a),voidAV(w),dplen,nfro,nfri,ndpo,ndpi,voidAV(z)));  // eval, check for error
- RETF(z);
+ return z;
 }
 
 
@@ -910,7 +910,7 @@ static A jtsumattymes(J jt, A a, A w, I b, I t, I m, I n, I nn, I r, I *s, I zn)
    }
   }
  }
- RETF(z);
+ return z;
 }    /* a +/@:* w for non-scalar a and w */
 
 
@@ -950,7 +950,7 @@ static A jtsumatgbool(J jt,A a,A w,C id){A t,z;B* RESTRICTI av,* RESTRICTI wv;I 
   case CGT:      SUMBFLOOP(GT  ); break;
   case CGE:      SUMBFLOOP(GE  ); break;
  }
- RETF(z);
+ return z;
 }    /* a +/@:g w  for boolean a,w where a-:&(* /@$)w; see also plusinsB */
 
 DF2(jtfslashatg){A fs,gs,y,z;B b,sb=0;C*av,c,d,*wv;I ak,an,ar,*as,at,m,
@@ -1009,7 +1009,7 @@ DF2(jtfslashatg){A fs,gs,y,z;B b,sb=0;C*av,c,d,*wv;I ak,an,ar,*as,at,m,
   DQ(nn-1, av-=ak; wv-=wk; I lrc; lrc=((AHDR2FN*)adocv.f)(n,m,av,wv,yv,jt); rc=lrc<rc?lrc:rc; lrc=((AHDR2FN*)adocvf.f)((I)1,zn,yv,p?zu:zv,p?zv:zu,jt); rc=lrc<rc?lrc:rc; p^=1;);  // p==1 means result goes to ping buffer zv
   if(NEVM<(rc&255)){df1(z,df2(y,a,w,gs),fs);}else{if(rc&255)jsignal(rc); z=p?z1:z;}  // if overflow, revert to old-fashioned way.  If p points to ping, prev result went to pong, make pong the result
  }
- RE(0); RETF(z);
+ RE(0); return z;
 }    /* a f/@:g w where f and g are atomic*/
 
 // Consolidated entry point for ATOMIC2 verbs.  These can be called with self pointing either to a rank block or to the block for
@@ -1027,8 +1027,8 @@ DF2(jtatomic2){A z;
  // check for singletons
  if(!(awm1|((AT(a)|AT(w))&(NOUN&UNSAFE(~(B01+INT+FL)))))){
   z=jtssingleton(jtinplace,a,w,self,(RANK2T)awr,selfranks);
-  if(z!=0){RETF(z);}  // normal case is good return
-  if(jt->jerr<=NEVM){RETF(z);}   // if error is unrecoverable, don't retry
+  if(z!=0){return z;}  // normal case is good return
+  if(jt->jerr<=NEVM){return z;}   // if error is unrecoverable, don't retry
   // if retryable error, fall through.  The retry will not be through the singleton code
   jtinplace=(J)((I)jtinplace|JTRETRY);  // indicate that we are retrying the operation.  We must, because jt->jerr is set with the retry code
  }
@@ -1043,8 +1043,8 @@ DF2(jtatomic2){A z;
  ASSERTAGREE(AS(a),AS(w),af);  // outermost (or only) agreement check
  // Run the full dyad, retrying if a retryable error is returned
  z=jtva2(jtinplace,a,w,self,(awr<<RANK2TX)+selfranks);  // execute the verb
- if(z!=0){RETF(z);}  // normal case is good return
- if(jt->jerr<=NEVM){RETF(z);}   // if error is unrecoverable, don't retry
+ if(z!=0){return z;}  // normal case is good return
+ if(jt->jerr<=NEVM){return z;}   // if error is unrecoverable, don't retry
  return z=jtva2((J)((I)jtinplace|JTRETRY),a,w,self,(awr<<RANK2TX)+selfranks);  // execute the verb
 }
 

--- a/jsrc/verbs/va2s.c
+++ b/jsrc/verbs/va2s.c
@@ -32,7 +32,7 @@ F1(jtvaspz){A e,x,y;B c,*u,*xu,*xv;I j,n,*v,*yu,*yv,xc,yc;P*wp;
  if(1==xc)memset(xv,c,n);
  *AS(y)=n; AN(y)=n*yc;
  *AS(x)=n; AN(x)=n*xc;
- RETF(w);
+ return w;
 }    /* post processing on result; modifies argument in place */
 
 static A jtvasp0(J jt,A a,A w,VF ado,I cv,I t,I zt){A e,x,xx,y,z,ze,zx;B b;I n;P*p,*zp;

--- a/jsrc/verbs/vb.c
+++ b/jsrc/verbs/vb.c
@@ -34,7 +34,7 @@ static F2(jtebarmat){A ya,yw,z;B b,*zv;C*au,*av,*u,*v,*v0,*wu,*wv;I*as,c,i,k,m,n
    DO(n, u=av; b=1; DO(si, MC(au,u,s); MC(wu,v,s); if(!equ(ya,yw)  ){b=0; break;} u+=s; v+=r;); v=v0+=k; zv[i]=b;);
    zv+=c; v=v0=wv+=r;
  }}
- RETF(z);
+ return z;
 }    /* E. on matrix arguments */
 
 static F2(jtebarvec){A y,z;B*zv;C*av,*wv,*yv;I an,k,n,s,t,wn;
@@ -46,7 +46,7 @@ static F2(jtebarvec){A y,z;B*zv;C*av,*wv,*yv;I an,k,n,s,t,wn;
  if((-an&(an-wn))<0)memset(zv+n,C0,wn-n); else memset(zv,C0,wn);
  if(t&B01+LIT+C2T+C4T+INT+SBT||1.0==jt->cct&&t&FL+CMPX)DO(n, zv[i]=!memcmpne(av,wv,s); wv+=k;)
  else{GA(y,t,an,AR(a),0); yv=CAV(y); DO(n, MC(yv,wv,s); zv[i]=equ(a,y); wv+=k;);}
- RETF(z);
+ return z;
 }    /* E. on vector arguments */
 
 /* preparations for ebar                    */
@@ -230,5 +230,5 @@ F2(jtifbebar){A y,z;C*av,*wv;I c,d,i,k=0,m,n,p,*yv,*zu,*zv;
   default:        EBLOOP(UC,u[i],  v[k+m],   if(i==m)IFB1);
  }
  AN(z)=AS(z)[0]=zv-AV(z);
- RETF(z);
+ return z;
 }    /* a ([: I. E.) w where a and w are atoms or lists */

--- a/jsrc/verbs/vcant.c
+++ b/jsrc/verbs/vcant.c
@@ -88,7 +88,7 @@ static F2(jtcanta){A m,s,t,z;C*wv,*zv;I*av,j,*mv,r,*sv,*tv,wf,wr,*ws,zn,zr,ms[4]
 
  default:        CANTA(C, MC(u,v,cellsizeb); u+=cellsizeb;); break;
  }     
- RETF(z);  // should EPILOG?
+ return z;  // should EPILOG?
 }    /* dyadic transpose in APL\360, a f"(1,r) w where 1>:#$a  */
 
 F1(jtcant1){I r; 
@@ -98,14 +98,14 @@ F1(jtcant1){I r;
  // We extracted from w, so mark it (or its backer if virtual) non-pristine.  If w was pristine and inplaceable, transfer its pristine status to the result
  // But if we are returning the input block unchanged, leave pristinity unchanged
  if(z!=w){PRISTXFERF(z,w)}
- RETF(z);
+ return z;
 }    /* |:"r w */
 
 F2(jtcant2){A*av,p,t,y;I j,k,m,n,*pv,q,r,*v;
  F2PREFIP;ARGCHK2(a,w); 
  r=(RANKT)jt->ranks; r=AR(w)<r?AR(w):r; 
  q=jt->ranks>>RANKTX; q=AR(a)<q?AR(a):q; RESETRANK;
- if(((q-2)&(AR(a)-q-1))>=0){t=rank2ex(a,w,UNUSED_VALUE,MIN(q,1),r,q,r,jtcant2); PRISTCLRF(w) RETF(t);} // rank loop on a.  Loses pristinity
+ if(((q-2)&(AR(a)-q-1))>=0){t=rank2ex(a,w,UNUSED_VALUE,MIN(q,1),r,q,r,jtcant2); PRISTCLRF(w) return t;} // rank loop on a.  Loses pristinity
  if(BOX&AT(a)){
   RZ(y=pfill(r,t=raze(a))); v=AV(y);
   GATV0(p,INT,AN(y),1); pv=AV(p);
@@ -115,5 +115,5 @@ F2(jtcant2){A*av,p,t,y;I j,k,m,n,*pv,q,r,*v;
  A z; IRS2(p,w,0L,1L,r,jtcanta,z); RZ(z);  // Set rank for w in canta.  p is now INT type.  No need to check agreement since a has rank 1
  // We extracted from w, so mark it (or its backer if virtual) non-pristine.  If w was pristine and inplaceable, transfer its pristine status to the result
  PRISTXFERF(z,w)
- RETF(z);
+ return z;
 }    /* a|:"r w main control */ 

--- a/jsrc/verbs/vcat.c
+++ b/jsrc/verbs/vcat.c
@@ -99,7 +99,7 @@ static F2(jtovs){A ae,ax,ay,q,we,wx,wy,x,y,z,za,ze;B*ab,*wb,*zb;I acr,ar,*as,at,
   }
   SPB(zp,i,p?take(sc(mn-p),y):y); SPB(zp,x,p?take(sc(mn-p),x):x);
  }
- RETF(z);
+ return z;
 }    /* a,"r w where a or w or both are sparse */
 
 
@@ -135,7 +135,7 @@ static F2(jtovg){A s,z;C*x;I ar,*as,c,k,m,n,r,*sv,t,wr,*ws,zn;
  GA(z,AT(a),zn,r,sv); AS(z)[0]=m+n; x=CAV(z); k=bpnoun(AT(a));
  RZ(x=ovgmove(k,c,m,s,a,x,z));
  RZ(x=ovgmove(k,c,n,s,w,x,z));
- RETF(z);
+ return z;
 }    /* a,w general case for dense array with the same type; jt->ranks=~0 */
 
 // these variants copy vectors or scalars, with optional repetition of items and, for the scalars, scalar repetition
@@ -221,7 +221,7 @@ F2(jtover){AD * RESTRICT z;C*zv;I replct,framect,acr,af,ar,*as,k,ma,mw,p,q,r,t,w
     // If a and w are the same, we mustn't mark the result pristine!  It has repetitions
     if((aflg&AFVIRTUAL)!=0){AFLAG(ABACK(a))&=~AFPRISTINE;}  //  like PRISTCOMSETF
     if((wflg&AFVIRTUAL)!=0){AFLAG(ABACK(w))&=~AFPRISTINE;}  //  like PRISTCOMSETF
-    RETF(z);
+    return z;
    }
   }
  }
@@ -246,7 +246,7 @@ F2(jtover){AD * RESTRICT z;C*zv;I replct,framect,acr,af,ar,*as,k,ma,mw,p,q,r,t,w
  // copy in the data, creating the result in order (to avoid page thrashing and to make best use of write buffers)
  // scalar replication is required for any arg whose rank is 0 and yet its length is >1.  Choose the copy routine based on that
  moveawtbl[SGNTO0((acr-1)&(1-ma))*2+(SGNTO0(((wcr-1)&(1-mw))))](CAV(z),CAV(a),CAV(w),replct*framect,k,ma*k,mw*k,(wf>=af)?replct:1,(wf>=af)?1:replct);
- RETF(z);
+ return z;
 }    /* overall control, and a,w and a,"r w for cell rank <: 2 */
 
 F2(jtstitch){I ar,wr; A z;
@@ -274,7 +274,7 @@ F2(jtlamin2){A z;I ar,p,q,wr;
  if(q)RZ(w=IRS1(w,0L,q,jtlamin1,z));
  RZ(IRS2(a,w,0L,p+!!p,q+!!q,jtover,z));
  if(!(p|q))z=IRS1(z,0L,0L,jtlamin1,a);
- RETF(z);
+ return z;
 }    /* a,:"r w */
 
 // Append, including tests for append-in-place
@@ -363,7 +363,7 @@ A jtapip(J jt, A a, A w){F2PREFIP;A h;C*av,*wv;I ak,k,p,*u,*v,wk,wm,wn;
       }
       // a was inplaceable & thus not virtual, but we must clear pristinity from w wherever it is
       PRISTCLRF(w)
-      RETF(a);
+      return a;
      }else ASSERT(!(aflag&AFNJA),EVALLOC)  // if we failed only because the new value wouldn't fit, signal EVALLOC if NJA, to avoid creating a huge unassignable value
     }  // end 'items of a are big enough'
    }  // end 'a and w compatible in rank and type'

--- a/jsrc/verbs/vchar.c
+++ b/jsrc/verbs/vchar.c
@@ -41,5 +41,5 @@ DF2(jtcharfn2){A z;B b;C c;I an,ar,*as,m,n,wn,wr,*ws,zn,zt;V*v;VF ado=0;
  GA(z,zt,zn,r,s); if(!zn)return z;
  n^=-b; n=(n==~1)?1:n;  // encode b flag in sign of n
  ((AHDR2FN*)ado)(n,m,CAV(a),CAV(w),CAV(z),jt);
- RETF(z);
+ return z;
 }

--- a/jsrc/verbs/vcompsc.c
+++ b/jsrc/verbs/vcompsc.c
@@ -327,7 +327,7 @@ AF jtatcompf(J jt,A a,A w,A self){I m;
   return 0;
  }else{  // E. (6) or e. (7)
   jt->workareas.compsc.postflags=0;
-  if((AR(a)|AR(w))>1){if(!(m&1)||AR(a)>(AR(w)?AR(w):1))R0;}  // some rank > 1, fail if E. or e. returns rank>1
+  if((AR(a)|AR(w))>1){if(!(m&1)||AR(a)>(AR(w)?AR(w):1))return 0;}  // some rank > 1, fail if E. or e. returns rank>1
   if(((m&1)|(AN(a)-1))==0)return 0;  // E. when a is a singleton - no need for the full E. treatment
   return atcompX[((m>>2)&~1)+(m&1)];  // choose i.-family routine
  }

--- a/jsrc/verbs/vd.c
+++ b/jsrc/verbs/vd.c
@@ -153,7 +153,7 @@ F1(jtqr){A r,z;D c=inf,d=0,x;I n1,n,*s,wr;
  if(FL&AT(r)){D*v=DAV(r);  DQ(n, x= ABS(*v); if(x<c)c=x; if(x>d)d=x; v+=n1;);}
  else        {Z*v=ZAV(r);  DQ(n, x=zmag(*v); if(x<c)c=x; if(x>d)d=x; v+=n1;);}
  ASSERT(!n||c>d*FUZZ,EVDOMAIN);
-RETF(z);
+return z;
 }
 
 // return inverse of w, calculated by lq applied to adjoint
@@ -172,7 +172,7 @@ static F1(jtlq){A l;D c=inf,d=0,x;I n1,n,*s,wr;
  if(FL&AT(l)){D*v=DAV(l); D determ=jt->workareas.minv.determ; DQ(n, x= ABS(*v); if(determ!=0){determ*=x; if(determ>1e20)determ=0.0;} if(x<c)c=x; if(x>d)d=x; v+=n1;); jt->workareas.minv.determ=determ;} 
  else        {Z*v=ZAV(l);  DQ(n, x=zmag(*v); if(x<c)c=x; if(x>d)d=x; v+=n1;);}
  ASSERT(!n||c>d*FUZZ,EVDOMAIN);
- RETF(pdt(jtrinvip(jt,l,n,AT(w)&FL?2:0),w));  // engage fast reciprocal for float matrices
+ return pdt(jtrinvip(jt,l,n,AT(w)&FL?2:0),w);  // engage fast reciprocal for float matrices
 }
 
 // Boolean/integer correction.  If the inversand was B01 or INT, we can eliminate some rounding error by forcing the

--- a/jsrc/verbs/ve.c
+++ b/jsrc/verbs/ve.c
@@ -323,7 +323,7 @@ F1(jtbase1){A z;B*v;I c,m,n,p,r,*s,t,*x;
  GATV(z,INT,m,r?r-1:0,s); x=AV(z); v=BAV(w);
  if(c)DQ(m, p=0; DQ(c, p=2*p+*v++;); *x++=p;)
  else memset(x,C0,m*SZI);
- RETF(z);
+ return z;
 }
 
 F2(jtbase2){I ar,*as,at,c,t,wr,*ws,wt;
@@ -358,7 +358,7 @@ F1(jtabase1){A d,z;B*zv;I c,n,p,r,t,*v;UI x;
   // We also can't delete a digit if there is only 1 digit in the numbers
   if(AS(z)[AR(z)-1]<=1 || i0(aslash(CPLUSDOT,ravel(lt(w,zeroionei(0))))))return z;
   if(0==i0(aslash(CMAX,ravel(IRS1(z,0L,1L,jthead,d)))))return IRS1(z,0L,1L,jtbehead,d);
-  RETF(z);
+  return z;
  }
  // Integer.  Calculate x=max magnitude encountered (minimum of 1, to leave 1 output value)
  x=1; v=AV(w);
@@ -367,7 +367,7 @@ F1(jtabase1){A d,z;B*zv;I c,n,p,r,t,*v;UI x;
  GATV(z,B01,n*c,1+r,AS(w)); AS(z)[r]=c;  // Allocate result area, install shape
  v=n+AV(w); zv=AN(z)+BAV(z);  // v->last input location (prebiased), zv->last result location (prebiased)
  DQ(n, x=*--v; DQ(c, *--zv=(B)(x&1); x>>=1;));  // copy in the bits, starting with the LSB
- RETF(z);
+ return z;
 }
 
 F2(jtabase2){A z;I an,ar,at,t,wn,wr,wt,zn;
@@ -396,7 +396,7 @@ F2(jtabase2){A z;I an,ar,at,t,wn,wr,wt,zn;
     DQ(wn, x=*--wv; *--zv=x&d1; *--zv=x>>k;)
    }
   }else DQ(wn, x=*--wv; u=av; DQ(an, d=*--u; *--zv=r=remii(d,x); x=d?(x-r)/d:0;););
-  RETF(z);
+  return z;
  }
  {PROLOG(0070);A y,*zv;C*u,*yv;I k;
   F2RANK(1,0,jtabase2,UNUSED_VALUE);
@@ -420,5 +420,5 @@ A jtintmod2(J jt,A w,I mod){A z;B *v;I n,q,r,*u;UI m=0;  // init m for warning
  DQ(q, DQ(SZI, m=(m>>8)+((UI)*v<<((SZI-1)*8)); v+=SZI;); *u++=m&mask;)
  DQ(r, m=(m>>8)+((UI)*v<<((SZI-1)*8)); v+=SZI;);  // 1-8 bytes
  STOREBYTES(v,m&mask,8-r);
- RETF(z);
+ return z;
 }

--- a/jsrc/verbs/vf.c
+++ b/jsrc/verbs/vf.c
@@ -117,7 +117,7 @@ F2(jtrotate){A origw=w,y,z;B b;C*u,*v;I acr,af,ar,*av,d,k,m,n,p,*s,wcr,wf,wn,wr;
  } 
  // w is going to be replaced.  That makes it non-pristine; but if it is inplaceable it can pass its pristinity to the result, as long as there is no fill
  PRISTXFERFIF(z,origw,jt->fill==0)  // transfer pristinity if there is no fill
- RETF(z);
+ return z;
 }    /* a|.!.f"r w */
 
 static F1(jtrevsp){A a,q,x,y,z;I c,f,k,m,n,r,*v,wr;P*wp,*zp;
@@ -159,7 +159,7 @@ F1(jtreverse){A z;C*wv,*zv;I f,k,m,n,nk,r,*v,*ws,wt,wr;
   case sizeof(int):{int*s=(int*)wv,*t,*u=(int*)zv; DQ(m, t=s+=n; DQ(n, *u++=*--t;););} break;
   case sizeof(I): {I*s=(I*)wv,*t,*u=(I*)zv; DQ(m, t=s+=n; DQ(n, *u++=*--t;););} break;
  }
- RETF(z);
+ return z;
 }    /* |."r w */
 
 
@@ -216,10 +216,10 @@ F2(jtreshape){A z;B filling;C*wv,*zv;I acr,ar,c,k,m,n,p,q,r,*s,t,* RESTRICT u,wc
  ARGCHK2(a,w);
  ar=AR(a); acr=jt->ranks>>RANKTX; acr=ar<acr?ar:acr;
  wr=AR(w); wcr=(RANKT)jt->ranks; wcr=wr<wcr?wr:wcr; wf=wr-wcr; ws=AS(w); RESETRANK;
- if((I )(1<acr)|(I )(acr<ar)){z=rank2ex(a,w,UNUSED_VALUE,MIN(acr,1),wcr,acr,wcr,jtreshape); PRISTCLRF(w) RETF(z);}  // multiple cells - must lose pristinity
+ if((I )(1<acr)|(I )(acr<ar)){z=rank2ex(a,w,UNUSED_VALUE,MIN(acr,1),wcr,acr,wcr,jtreshape); PRISTCLRF(w) return z;}  // multiple cells - must lose pristinity
  // now a is an atom or a list.  w can have any rank
  RZ(a=vip(a)); r=AN(a); u=AV(a);   // r=length of a   u->values of a
- if((SPARSE&AT(w))!=0){RETF(reshapesp(a,w,wf,wcr));}
+ if((SPARSE&AT(w))!=0){return reshapesp(a,w,wf,wcr);}
  wn=AN(w); PRODX(m,r,u,1) CPROD(wn,c,wf,ws); CPROD(wn,n,wcr,wf+ws);  // m=*/a (#atoms in result)  c=#cells of w  n=#atoms/cell of w
  ASSERT(n||!m||jt->fill,EVLENGTH);  // error if attempt to extend array of no items to some items without fill
  t=AT(w); filling = 0;
@@ -229,11 +229,11 @@ F2(jtreshape){A z;B filling;C*wv,*zv;I acr,ar,c,k,m,n,p,q,r,*s,t,* RESTRICT u,wc
    // because then who would free the blocks?  (Actually it would be OK if nonrecursive, but we are trying to exterminate those).  Since it must be DIRECT, there's no question about PRISTINE, but that would be OK to transfer if inplaceable
    if(ASGNINPLACESGN(SGNIF((I)jtinplace,JTINPLACEWX)&(r-(wcr+1))&((n-(m+1))|-(t&DIRECT)),w)){  //  inplace allowed, just one cell, result rank (an) <= current rank (so rank fits), usecount is right
     // operation is loosely inplaceable.  Copy in the rank, shape, and atom count.
-    AR(w)=(RANKT)(r+wf); AN(w)=m; ws+=wf; MCISH(ws,u,r) RETF(w);   // Start the copy after the (unchanged) frame
+    AR(w)=(RANKT)(r+wf); AN(w)=m; ws+=wf; MCISH(ws,u,r) return w;   // Start the copy after the (unchanged) frame
    }
    // Not inplaceable.  Create a (noninplace) virtual copy, but not if NJA memory
-// correct   if(!(AFLAG(w)&(AFNJA))){RZ(z=virtual(w,0,r+wf)); AN(z)=m; I *zs=AS(z); DO(wf, *zs++=ws[i];); DO(r, zs[i]=u[i];) RETF(z);}
-   if((SGNIF(AFLAG(w),AFNJAX)|((t&(DIRECT|RECURSIBLE))-1))>=0){RZ(z=virtual(w,0,r+wf)); AN(z)=m; I * RESTRICT zs=AS(z); MCISH(zs,ws,wf) MCISH(zs+wf,u,r) RETF(z);}  // NJAwhy
+// correct   if(!(AFLAG(w)&(AFNJA))){RZ(z=virtual(w,0,r+wf)); AN(z)=m; I *zs=AS(z); DO(wf, *zs++=ws[i];); DO(r, zs[i]=u[i];) return z;}
+   if((SGNIF(AFLAG(w),AFNJAX)|((t&(DIRECT|RECURSIBLE))-1))>=0){RZ(z=virtual(w,0,r+wf)); AN(z)=m; I * RESTRICT zs=AS(z); MCISH(zs,ws,wf) MCISH(zs+wf,u,r) return z;}  // NJAwhy
    // for NJA/SMM, fall through to nonvirtual code
   }
  }else if(filling=jt->fill!=0){RZ(w=setfv(w,w)); t=AT(w);}   // if fill required, set fill value.  Remember if we need to fill
@@ -247,7 +247,7 @@ F2(jtreshape){A z;B filling;C*wv,*zv;I acr,ar,c,k,m,n,p,q,r,*s,t,* RESTRICT u,wc
  // w has been destroyed
  if(filling)DQ(c, mvc(q,zv,q,wv); mvc(p-q,q+zv,k,jt->fillv); zv+=p; wv+=q;)
  else DQ(c, mvc(p,zv,q,wv); zv+=p; wv+=q;);
- RETF(z);
+ return z;
 }    /* a ($,)"r w */
 
 F2(jtreitem){A y,z;I acr,an,ar,r,*v,wcr,wr;
@@ -255,7 +255,7 @@ F2(jtreitem){A y,z;I acr,an,ar,r,*v,wcr,wr;
  ARGCHK2(a,w);
  ar=AR(a); acr=jt->ranks>>RANKTX; acr=ar<acr?ar:acr;
  wr=AR(w); wcr=(RANKT)jt->ranks; wcr=wr<wcr?wr:wcr; r=wcr-1; RESETRANK;
- if((I )(1<acr)|(I )(acr<ar)){z=rank2ex(a,w,UNUSED_VALUE,MIN(acr,1),wcr,acr,wcr,jtreitem); PRISTCLRF(w) RETF(z);}  // multiple cells - must lose pristinity  // We handle only single operations here, where a has rank<2
+ if((I )(1<acr)|(I )(acr<ar)){z=rank2ex(a,w,UNUSED_VALUE,MIN(acr,1),wcr,acr,wcr,jtreitem); PRISTCLRF(w) return z;}  // multiple cells - must lose pristinity  // We handle only single operations here, where a has rank<2
  // acr<=ar; ar<=acr; therefore ar==acr here
  fauxblockINT(yfaux,4,1);
  if(1>=wcr)y=a;  // y is atom or list: $ is the same as ($,)
@@ -298,7 +298,7 @@ F2(jtexpand){A z;B*av;C*wv,*wx,*zv;I an,*au,i,k,p,wc,wk,wn,wt,zn;
     else{if(p){MC(zv,wv,p); wv+=p; zv+=p; p=0;} zv+=wk;}
    if(p){MC(zv,wv,p);}
  }
- RETF(z);
+ return z;
 }    /* a&#^:_1 w or a&#^:_1!.f w */
 
 

--- a/jsrc/verbs/vfrom.c
+++ b/jsrc/verbs/vfrom.c
@@ -80,7 +80,7 @@ F2(jtifrom){A z;C*wv,*zv;I acr,an,ar,*av,j,k,m,p,pq,q,wcr,wf,wk,wn,wr,*ws,zn;
     RZ(z=virtualip(w,index0*k,ar+wr-1));
     // fill in shape and number of atoms.  ar can be anything.
     I* as=AS(a); AN(z)=zn; I *s=AS(z); MCISH(s,as,ar) MCISH(s+ar,ws+1,wr-1)
-    RETF(z);
+    return z;
    }
   }
   // for copying items, we need    k: size in bytes of an item of a cell of w
@@ -110,7 +110,7 @@ F2(jtifrom){A z;C*wv,*zv;I acr,an,ar,*av,j,k,m,p,pq,q,wcr,wf,wk,wn,wr,*ws,zn;
    }
    break;
   }
-  RETF(z);
+  return z;
 }    /* a{"r w for numeric a */
 
 #define BSET(x,y0,y1,y2,y3)     *x++=y0; *x++=y1; *x++=y2; *x++=y3;
@@ -154,7 +154,7 @@ static F2(jtbfrom){A z;B*av,*b;C*wv,*zv;I acr,an,ar,k,m,p,q,r,*u=0,wcr,wf,wk,wn,
 
    else DQ(m, b=av; DQ(an, MC(zv,wv+k**b++,k); zv+=k;); wv+=wk;);
  }
- RETF(z);
+ return z;
 }    /* a{"r w for boolean a */
 
 // a is array whose 1-cells are index lists, w is array
@@ -262,7 +262,7 @@ static A jtafrom2(J jt,A p,A q,A w,I r){A z;C*wv,*zv;I d,e,j,k,m,n,pn,pr,* RESTR
   JMCDECL(endmask) JMCSETMASK(endmask,k+(SZI-1),0) 
   DQ(m, DO(pn, j=e*pv[i]; DO(qn, x+=k; JMCR(x,v+k*(j+qv[i]),k+(SZI-1),loop1,0,endmask);)); v+=n;);} break;
  }
- RETF(z);   // return block
+ return z;   // return block
 }   /* (<p;q){"r w  for positive integer arrays p,q */
 
 // n is length of axis, w is doubly-unboxed selector
@@ -360,7 +360,7 @@ F2(jtfrom){I at;A z;
  }else if(!((AT(a)|AT(w))&(NOUN&~SPARSE))){z=fromss(a,w);}  // sparse cases
  else if(AT(w)&SPARSE){z=at&BOX?frombs(a,w) : fromis(a,w);}
  else{z=fromsd(a,w);}
- RETF(z);
+ return z;
 }   /* a{"r w main control */
 
 F2(jtsfrom){
@@ -388,7 +388,7 @@ F2(jtsfrom){
      DQ(AN(ind), JMCR(zv,wv+*iv++*cellsize,cellsize+(SZI-1),loop1,0,endmask); zv+=cellsize;)  // use memcpy
      break;
     }
-    RETF(z);
+    return z;
    }
   }
  }else{A ind;
@@ -396,7 +396,7 @@ F2(jtsfrom){
   RE(aindex1(a,w,0L,&ind)); if(ind)return frombsn(ind,w,0L);
  }
  // If we couldn't handle it as a special case, do it the hard way
- A z; RETF(from(IRS1(a,0L,1L,jtbox,z),w));
+ A z; return from(IRS1(a,0L,1L,jtbox,z),w);
 }    /* (<"1 a){w */
 
 static F2(jtmapx);
@@ -433,7 +433,7 @@ F2(jtfetch){A*av, z;I n;F2PREFIP;
 #endif
    // Since the whole purpose of fetch is to copy one contents by address, we turn off pristinity of w
    PRISTCLRF(w)
-   RETF(z);   // turn off inplace if w not inplaceable, or jt not inplaceable.
+   return z;   // turn off inplace if w not inplaceable, or jt not inplaceable.
   }
   RZ(a=jtbox(JTIPAtoW,a));  // if not special case, box any unboxed a
  }
@@ -444,5 +444,5 @@ F2(jtfetch){A*av, z;I n;F2PREFIP;
    );
  // Since the whole purpose of fetch is to copy one contents by address, we turn off pristinity of w
  PRISTCLRF(w)
- RETF(z);   // Mark the box as non-inplaceable, as above
+ return z;   // Mark the box as non-inplaceable, as above
 }

--- a/jsrc/verbs/vfromsp.c
+++ b/jsrc/verbs/vfromsp.c
@@ -164,7 +164,7 @@ F2(jtfromsd){A e,x,z;I acr,af,ar,*v,wcr,wf,wr,*ws;P*ap,*zp;
   RZ(x=cant2(less(IX(AR(x)),sc(wf)),x));
   SPB(zp,x,x);
  }else SPB(zp,x,ifrom(SPA(ap,x),w));
- RETF(z);
+ return z;
 }    /* a{"r w, sparse a, dense w */
 
 F2(jtfromss){A e,x,y,z;B*b;I acr,af,ar,c,d,k,m,n,p,*u,*v,wcr,wf,wr,*ws,*yv;P*ap,*wp,*xp,*zp;
@@ -192,5 +192,5 @@ F2(jtfromss){A e,x,y,z;B*b;I acr,af,ar,c,d,k,m,n,p,*u,*v,wcr,wf,wr,*ws,*yv;P*ap,
  DQ(m, if(k)ICPY(yv,u,k); ICPY(yv+k,v+d*u[k],d); if(p)ICPY(yv+k+d,u+1+k,p); yv+=n; u+=c;);
  SPB(zp,i,y);
  SPB(zp,x,SPA(xp,x));
- RETF(z);
+ return z;
 }    /* a{"r w, sparse a, sparse w */

--- a/jsrc/verbs/vg.c
+++ b/jsrc/verbs/vg.c
@@ -714,14 +714,14 @@ F1(jtgr1){PROLOG(0075);A z;I c,f,ai,m,n,r,*s,t,wn,wr,zn;
  EPILOG(z);
 }    /*   grade"r w main control for dense w */
 
-F1(jtgrade1 ){A z;GBEGIN(-1); RZ(   w); z=SPARSE&AT(w)?grd1sp(  w):gr1(  w); GEND RETF(z);}
-F1(jtdgrade1){A z;GBEGIN( 1); RZ(   w); z=SPARSE&AT(w)?grd1sp(  w):gr1(  w); GEND RETF(z);}
+F1(jtgrade1 ){A z;GBEGIN(-1); RZ(   w); z=SPARSE&AT(w)?grd1sp(  w):gr1(  w); GEND return z;}
+F1(jtdgrade1){A z;GBEGIN( 1); RZ(   w); z=SPARSE&AT(w)?grd1sp(  w):gr1(  w); GEND return z;}
 // Since grade2 pulls from a, mark a as non-pristine.  But since there can be no repeats, transfer a's pristinity to result if a is inplaceable
 // We do this in jtgr2 because it has a branch where all boxed values go
 F2(jtgrade2 ){F2PREFIP;A z;GBEGIN(-1); ARGCHK2(a,w); RZ(z=SPARSE&AT(w)?grd2sp(a,w):jtgr2(jtinplace,a,w)); GEND
- RETF(z);}
+ return z;}
 F2(jtdgrade2){F2PREFIP;A z;GBEGIN( 1); ARGCHK2(a,w); RZ(z=SPARSE&AT(w)?grd2sp(a,w):jtgr2(jtinplace,a,w)); GEND
- RETF(z);}
+ return z;}
 
 
 #define OSGT(i,j) (u[i]>u[j])

--- a/jsrc/verbs/vgranking.c
+++ b/jsrc/verbs/vgranking.c
@@ -106,7 +106,7 @@ F1(jtranking){A y,z;C*wv;I icn,i,k,m,n,t,wcr,wf,wn,wr,*ws,wt,*zv;CR rng;TTYPE *y
   RZ(IRS1(w,0L,wcr,jtgrade1,y)); yv=AV(y); 
   GATV(z,INT,m*n,1+wf,ws); if(!wcr)AS(z)[wf]=1; zv=AV(z); 
   DO(m, DO(n, zv[*yv++]=i;); zv+=n;);
-  RETF(z);
+  return z;
  }
  // here for small-range ordinals, processed through the ranking loop
  GATV(z,INT,m*n,1+wf,ws); if(!wcr)AS(z)[wf]=1; zv=AV(z);
@@ -127,5 +127,5 @@ F1(jtranking){A y,z;C*wv;I icn,i,k,m,n,t,wcr,wf,wn,wr,*ws,wt,*zv;CR rng;TTYPE *y
   }
   wv+=n*k;
  }
- RETF(z);
+ return z;
 }

--- a/jsrc/verbs/vgsort.c
+++ b/jsrc/verbs/vgsort.c
@@ -261,7 +261,7 @@ static SF(jtsortiq){FPREFIP;  // m=#sorts, n=#items in each sort, w is block
  A z; 
  if(ASGNINPLACESGN(SGNIF((I)jtinplace,JTINPLACEWX),w))z=w; else RZ(z=ca(w));   // output area, possibly the same as the input
  I *zv=IAV(z); DQ(m, sortiq1(zv,n); if(jt->workareas.compare.complt>0){I *zv1=zv; I *zv2=zv+n; DQ(n>>1, I t=*zv1; *zv1++=*--zv2; *zv2=t;)} zv+=n;)  // sort each list (ascending); reverse if descending
- RETF(z);
+ return z;
 }
 
 
@@ -355,7 +355,7 @@ static SF(jtsortdq){FPREFIP;  // m=#sorts, n=#items in each sort, w is block
  A z; 
  if(ASGNINPLACESGN(SGNIF((I)jtinplace,JTINPLACEWX),w))z=w; else RZ(z=ca(w));   // output area, possibly the same as the input
  D *zv=DAV(z); DQ(m, sortdq1(zv,n); if(jt->workareas.compare.complt>0){D *zv1=zv; D *zv2=zv+n; DQ(n>>1, D t=*zv1; *zv1++=*--zv2; *zv2=t;)} zv+=n;)  // sort each list (ascending); reverse if descending
- RETF(z);
+ return z;
 }
 
 // We are known to have 1 atom per item

--- a/jsrc/verbs/vi.c
+++ b/jsrc/verbs/vi.c
@@ -1167,7 +1167,7 @@ A jtindexofsub(J jt,I mode,A a,A w){PROLOG(0079);A h=0,hi=mtv,z;B mk=w==mark,th;
     // creating and processing the small-range table itself, so we will let it do that.  We return a special short block (LSB=1)
     // that indicates the length of the key (AN) and the start and range of the keys (AK and AM)
     A z; GAT0(z,INT,1,0); AN(z)=k; AK(z)=datamin; AM(z)=p;  // allocate and return
-    RETF((A)((I)z+1));  // return the tagged address
+    return (A)((I)z+1);  // return the tagged address
    }
    // make sure we have a hashtable of the requisite size.  p has the number of entries, booladj indicates whether they are 1 bit each.
    // if the #entries fits in a US, use the short table.  But bits always use the long table
@@ -1309,7 +1309,7 @@ A jtindexofsub(J jt,I mode,A a,A w){PROLOG(0079);A h=0,hi=mtv,z;B mk=w==mark,th;
  RZ(z=EPILOGNORET(z));
  // Since EPILOG may have rewritten AM, and IFORKEY never returns to the parser, we can store the FORKEY result in AM.
  *((mode&IIOPMSK)==IFORKEY?(I*)&AM(z):(I*)&jt->shapesink)=forkeyresult;
- RETF(z);
+ return z;
 }    /* a i."r w main control */
 
 // verb to handle compounds like m&i. e.&n .  m/n has already been hashed and the result saved away
@@ -1378,7 +1378,7 @@ F1(jtnub){
  A z; RZ(z=indexofsub(INUB,w,w));
  // We extracted from w, so mark it (or its backer if virtual) non-pristine.  If w was pristine and inplaceable, transfer its pristine status to the result.  We overwrite w because it is no longer in use
  PRISTXFERF(z,w)
- RETF(z);
+ return z;
 }    /* ~.w */
 
 // x -. y.  does not have IRS
@@ -1394,7 +1394,7 @@ F2(jtless){A x=w;I ar,at,k,r,*s,wr,*ws,wt;
      repeat(__not(eps(a,x)),a));
  // We extracted from a, so mark it non-pristine.  If a was pristine and inplaceable, transfer its pristine status to the result
  PRISTXFERAF(x,a)
- RETF(x);
+ return x;
 }    /* a-.w */
 
 // x e. y

--- a/jsrc/verbs/vi.c
+++ b/jsrc/verbs/vi.c
@@ -999,7 +999,7 @@ A jtindexofsub(J jt,I mode,A a,A w){PROLOG(0079);A h=0,hi=mtv,z;B mk=w==mark,th;
     case IIDOT:  
     case IICO:    GATV(z,INT,zn,f+f0,s); if(af)MCISH(f+AS(z),ws+wf,f0); v=AV(z); DQ(zn, *v++=m;); return z;
     case IEPS:    GATV(z,B01,zn,f+f0,s); if(af)MCISH(f+AS(z),ws+wf,f0); memset(BAV(z),C0,zn); return z;
-    case ILESS:                              RCA(w);
+    case ILESS:                              return w;
     case IIFBEPS:                            return mtv;
     case IANYEPS: case IALLEPS: case II0EPS: return num(0);
     case ISUMEPS:                            return sc(0L);
@@ -1386,7 +1386,7 @@ F2(jtless){A x=w;I ar,at,k,r,*s,wr,*ws,wt;
  F2PREFIP;ARGCHK2(a,w);
  at=AT(a); ar=AR(a); 
  wt=AT(w); wr=AR(w); r=MAX(1,ar);
- if(ar>1+wr)RCA(a);  // if w's rank is smaller than that of a cell of a, nothing can be removed, return a
+ if(ar>1+wr)return a;  // if w's rank is smaller than that of a cell of a, nothing can be removed, return a
  // if w's rank is larger than that of a cell of a, reheader w to look like a list of such cells.  The number of atoms stays the same
  if(wr&&r!=wr){RZ(x=virtual(w,0,r)); AN(x)=AN(w); s=AS(x); ws=AS(w); k=ar>wr?0:1+wr-r; *s=prod(k,ws); MCISH(1+s,k+ws,r-1);}  // bug: should test for error on the prod()
  // if nothing special (like sparse, or incompatible types, or x requires conversion) do the fast way; otherwise (-. x e. y) # y

--- a/jsrc/verbs/viix.c
+++ b/jsrc/verbs/viix.c
@@ -181,5 +181,5 @@ F2(jticap2){A*av,*wv,z;C*uu,*vv;I ar,*as,at,b,c,ck,cm,ge,gt,j,k,m,n,p,q,r,t,wr,*
     case RAT:  BSLOOF(Q,Q, qcompare); break;
     default:   ASSERT(0,EVNONCE);
  }}
- RETF(z);
+ return z;
 }    /* a I. w */

--- a/jsrc/verbs/vo.c
+++ b/jsrc/verbs/vo.c
@@ -44,7 +44,7 @@ F1(jtbox){A y,z,*zv;C*wv;I f,k,m,n,r,wr,*ws;
   // Since we are allocating the new boxes, the result will ipso facto be PRIVATE, as long as w is DIRECT.  If w is not DIRECT, we can be PRISTINE if we ensure that
   // w is PRISTINE inplaceable, but we don't bother to do that because 
   // If the input is DIRECT, mark the result as PRISTINE
-  GATV(z,BOX,n,f,ws); AFLAG(z) = BOX+((-(wt&DIRECT))&AFPRISTINE); if(n==0){RETF(z);}  // Recursive result; could avoid filling with 0 if we modified AN after error, or cleared after *tnextpushp
+  GATV(z,BOX,n,f,ws); AFLAG(z) = BOX+((-(wt&DIRECT))&AFPRISTINE); if(n==0){return z;}  // Recursive result; could avoid filling with 0 if we modified AN after error, or cleared after *tnextpushp
   // We have allocated the result; now we allocate a block for each cell of w and copy the w values to the new block.
 
   // Since we are making the result recursive, we can save a lot of overhead by NOT putting the cells onto the tstack.  As we have marked the result as
@@ -62,7 +62,7 @@ F1(jtbox){A y,z,*zv;C*wv;I f,k,m,n,r,wr,*ws;
   PRISTCLRF(w);  // destroys w
   ASSERT(y!=0,EVWSFULL);  // if we broke out an allocation failure, fail.  Since the block is recursive, when it is tpop()d it will recur to delete contents
  }
- RETF(z);
+ return z;
 }    /* <"r w */
 
 F1(jtboxopen){F1PREFIP; ARGCHK1(w); if((-AN(w)&-(AT(w)&BOX+SBOX))>=0){w = jtbox(jtinplace,w);} return w;}
@@ -140,7 +140,7 @@ F2PREFIP;ARGCHK2(a,w);
   }
   // a has the new value to add at the front of the list
   AK(w)-=SZI; AN(w)=AS(w)[0]=AN(w)+1; AAV(w)[0]=a;  // install a at front, add to counts
-  RETF(w);  // return the augmented result
+  return w;  // return the augmented result
  }
 #endif
  // else fall through to handle general case
@@ -543,7 +543,7 @@ static A jtrazeg(J jt,A w,I t,I n,I r,A*v,I nonempt){A h,h1,y,z;C*zu;I c=0,i,j,k
    {j=k*AN(y); MC(zu,AV(y),j); zu+=j;}
   }
  }
- RETF(z);
+ return z;
 }    /* raze general case */
 
 // ; y
@@ -600,7 +600,7 @@ F1(jtraze){A*v,y,z,* RESTRICT zv;C* RESTRICT zu;I *wws,d,i,klg,m=0,n,r=1,t=0,te=
   DO(n, y=v[i]; d=AN(y)<<klg; MC(zu,AV(y),d); zu+=d;)
  }
 
- RETF(z);
+ return z;
 }
 
 // TODO: remove divides from razeh
@@ -625,6 +625,6 @@ F1(jtrazeh){A*wv,y,z;C*xv,*yv,*zv;I c=0,ck,dk,i,k,n,p,r,*s,t;
    case sizeof(C):                 DQ(p, *xv=*yv++;            xv+=ck;);  break;
    default:                        DQ(p, MC(xv,yv,dk); yv+=dk; xv+=ck;); 
  }}
- RETF(z);
+ return z;
 }    /* >,.&.>/,w */
 

--- a/jsrc/verbs/vo.c
+++ b/jsrc/verbs/vo.c
@@ -428,7 +428,7 @@ static A jtopes(J jt,I zt,A cs,A w){A a,d,e,sh,t,*wv,x,x1,y,y1,z;B*b;C*xv;I an,*
 F1(jtope){PROLOG(0080);A cs,*v,y,z;I nonh;C*x;I i,n,*p,q=RMAX,r=0,*s,t=0,te=0,*u,zn;
  ARGCHK1(w);
  n=AN(w); v=AAV(w);
- if(!(BOX&(AT(w)&REPSGN(-n))))RCA(w);  // return w if empty or open
+ if(!(BOX&(AT(w)&REPSGN(-n))))return w;  // return w if empty or open
  if(!AR(w)){
   // scalar box: Turn off pristine in w since we are pulling an address from it.  Contents must not be inplaceable
   z=*v;

--- a/jsrc/verbs/vp.c
+++ b/jsrc/verbs/vp.c
@@ -140,7 +140,7 @@ F2(jtadot2){A m,p;I n;
  ARGCHK2(a,w);
  SETIC(w,n); p=sc(n); if(XNUM&AT(a))p=cvt(XNUM,p); RZ(m=fact(p));
  ASSERT(all1(le(negate(m),a))&&all1(lt(a,m)),EVINDEX);
- if(!AR(w)){RZ(vi(a)); RCA(w);}
+ if(!AR(w)){RZ(vi(a)); return w;}
  RZ(p=dfr(vi(abase2(apv(n,n,-1L),a))));
  return equ(w,IX(n))?p:from(p,w);  // special case when w is index vector - just return permutation.  Otherwise shuffle items of w
  // pristinity unchanged here: if w boxed, it was set by {

--- a/jsrc/verbs/vrand.c
+++ b/jsrc/verbs/vrand.c
@@ -534,7 +534,7 @@ DF2(jtrollk){A g,z;V*sv;
  ARGCHK3(a,w,self);
  sv=FAV(self); g=sv->fgh[2]?sv->fgh[2]:sv->fgh[1];
  if(AT(w)&XNUM+RAT||!(!AR(w)&&1>=AR(a)&&(g==ds(CDOLLAR)||1==AN(a))))return roll(df2(z,a,w,g));
- RETF(rollksub(a,vi(w)));
+ return rollksub(a,vi(w));
 }    /* ?@$ or ?@# or [:?$ or [:?# */
 
 static X jtxrand(J jt,X x){PROLOG(0090);A q,z;B b=1;I j,m,n,*qv,*xv,*zv;
@@ -641,7 +641,7 @@ F1(jtroll){A z;B b=0;I m,wt;
  if(    2==m)RZ(z=roll2   (w,&b));
  if(!b&&0!=m)RZ(z=rollnot0(w,&b));
  if(!b      )RZ(z=rollany (w,&b));
- RETF(z&&!(FL&AT(z))&&wt&XNUM+RAT?xco1(z):z);
+ return z&&!(FL&AT(z))&&wt&XNUM+RAT?xco1(z):z;
 }
 
 F2(jtdeal){A z;I at,j,k,m,n,wt,*zv;UI c,s,t,x=jt->rngM[jt->rng];UI sq;
@@ -666,7 +666,7 @@ F2(jtdeal){A z;I at,j,k,m,n,wt,*zv;UI c,s,t,x=jt->rngM[jt->rng];UI sq;
   
   AN(z)=AS(z)[0]=m;  // lots of wasted space!
  }
- RETF(at&XNUM+RAT||wt&XNUM+RAT?xco1(z):z);
+ return at&XNUM+RAT||wt&XNUM+RAT?xco1(z):z;
 }
 
 // support for ?.
@@ -721,7 +721,7 @@ DF2(jtrollkdot){A g,z;V*sv;
  ARGCHK3(a,w,self);
  sv=FAV(self); g=sv->fgh[2]?sv->fgh[2]:sv->fgh[1];
  if(AT(w)&XNUM+RAT||!(!AR(w)&&1>=AR(a)&&(g==ds(CDOLLAR)||1==AN(a))))return roll(df2(z,a,w,g));
- RETF(rollksub(a,vi(w)));
+ return rollksub(a,vi(w));
 }    /* ?@$ or ?@# or [:?$ or [:?# */
 
 #undef xrand
@@ -841,7 +841,7 @@ static F1(jtrolldot){A z;B b=0;I m,wt;
  if(    2==m)RZ(z=roll2   (w,&b));
  if(!b&&0!=m)RZ(z=rollnot0(w,&b));
  if(!b      )RZ(z=rollany (w,&b));
- RETF(z&&!(FL&AT(z))&&wt&XNUM+RAT?xco1(z):z);
+ return z&&!(FL&AT(z))&&wt&XNUM+RAT?xco1(z):z;
 }
 
 #undef deal
@@ -870,7 +870,7 @@ static F2(jtdealdot){A h,y,z;I at,d,*hv,i,i1,j,k,m,n,p,q,*v,wt,*yv,*zv;UI c,s,t,
   DO(m, s=GMOF(c,x); t=NEXT; if(s)while(s<=t)t=NEXT; j=i+t%c--; k=zv[i]; zv[i]=zv[j]; zv[j]=k;);
   AN(z)=AS(z)[0]=m;
  }
- RETF(at&XNUM+RAT||wt&XNUM+RAT?xco1(z):z);
+ return at&XNUM+RAT||wt&XNUM+RAT?xco1(z):z;
 }
 
 

--- a/jsrc/verbs/vrep.c
+++ b/jsrc/verbs/vrep.c
@@ -50,7 +50,7 @@ static REPF(jtrepbdx){A z;I c,k,m,p;
  m=AN(a);
  void *zvv; void *wvv=voidAV(w); I n=0; // pointer to output area; pointer to input data; number of prefix bytes to skip in first cell
  p=bsum(m,BAV(a));  // p=# 1s in result, i. e. length of result item axis
- if(m==p){RETF(w);}  // if all the bits are 1, we can return very quickly.  It's rare, but so cheap to test for.
+ if(m==p){return w;}  // if all the bits are 1, we can return very quickly.  It's rare, but so cheap to test for.
  PROD(c,wf,AS(w)); PROD(k,wcr-1,AS(w)+wf+1); // c=#cells, k=#atoms per item of cell
  I zn=c*k*p;  // zn=#atoms in result
  k<<=bplg(AT(w));   // k is now # bytes/cell
@@ -261,13 +261,13 @@ I att=SGNTO0(-(AT(a)&B01+SB01))+((UI)(-(AT(a)&CMPX+SCMPX))>>(BW-1-1));  // 0 if 
  if(((-wcr)&(ar-1)&(-(AT(a)&(B01|INT))))<0){I aval = BIV0(a);  // no fast support for float; take all of INT, or 1 bit of B01
   if(!(aval&-2LL)){  // 0 or 1
    if(aval==1)return RETARG(w);   // 1 # y, return y
-   if(!(AT(w)&SPARSE)){GA(z,AT(w),0,AR(w),0); MCISH(AS(z),AS(w),AR(w)) AS(z)[wf]=0; RETF(z);}  // 0 # y, return empty
+   if(!(AT(w)&SPARSE)){GA(z,AT(w),0,AR(w),0); MCISH(AS(z),AS(w),AR(w)) AS(z)[wf]=0; return z;}  // 0 # y, return empty
   }
  }
- if(((1-acr)|(acr-ar))<0){z=rank2ex(a,w,UNUSED_VALUE,MIN(1,acr),wcr,acr,wcr,jtrepeat); PRISTCLRF(w) RETF(z);}  // multiple cells - must losr pristinity  // loop if multiple cells of a
+ if(((1-acr)|(acr-ar))<0){z=rank2ex(a,w,UNUSED_VALUE,MIN(1,acr),wcr,acr,wcr,jtrepeat); PRISTCLRF(w) return z;}  // multiple cells - must losr pristinity  // loop if multiple cells of a
  ASSERT((-acr&-wcr)>=0||(AS(a)[0]==AS(w)[wf]),EVLENGTH);
  z=(*repfn)(jtinplace,a,w,wf,wcr);
  // mark w not pristine, since we pulled from it
  PRISTCLRF(w)
- RETF(z);
+ return z;
 }    /* a#"r w main control */

--- a/jsrc/verbs/vt.c
+++ b/jsrc/verbs/vt.c
@@ -85,7 +85,7 @@ F2(jttake){A s;I acr,af,ar,n,*v,wcr,wf,wr;
   s=rank2ex(a,w,UNUSED_VALUE,MIN(acr,1),wcr,acr,wcr,jttake);  // if multiple x values, loop over them  af>0 or acr>1
   // We extracted from w, so mark it (or its backer if virtual) non-pristine.  There may be replication (if there was fill), so we don't pass pristinity through  We overwrite w because it is no longer in use
   PRISTCLRF(w)
-  RETF(s);
+  return s;
  }
  // canonicalize x
  n=AN(a);    // n = #axes in a
@@ -121,7 +121,7 @@ F2(jttake){A s;I acr,af,ar,n,*v,wcr,wf,wr;
    I* RESTRICT ss=AS(s); ss[0]=tkabs; DO(wr-1, ss[i+1]=ws[i+1];);  // shape of virtual matches shape of w except for #items
    AN(s)=tkabs*wcellsize;  // install # atoms
    // virtual block does not affect pristinity of w
-   RETF(s);
+   return s;
   }
  }
  // full processing for more complex a
@@ -133,7 +133,7 @@ F2(jttake){A s;I acr,af,ar,n,*v,wcr,wf,wr;
  s=tk(s,w);  // go do the general take/drop
  // We extracted from w, so mark it (or its backer if virtual) non-pristine.  There may be replication (if there was fill), so we don't pass pristinity through  We overwrite w because it is no longer in use
  PRISTCLRF(w)
- RETF(s);
+ return s;
 }
 
 F2(jtdrop){A s;I acr,af,ar,d,m,n,*u,*v,wcr,wf,wr;
@@ -147,7 +147,7 @@ F2(jtdrop){A s;I acr,af,ar,d,m,n,*u,*v,wcr,wf,wr;
   s=rank2ex(a,w,UNUSED_VALUE,MIN(acr,1),wcr,acr,wcr,jtdrop);  // if multiple x values, loop over them  af>0 or acr>1
   // We extracted from w, so mark it (or its backer if virtual) non-pristine.  There may be replication, so we don't pass pristinity through  We overwrite w because it is no longer in use
   PRISTCLRF(w)
-  RETF(s);
+  return s;
  }
  n=AN(a); u=AV(a);     // n=#axes to drop, u->1st axis
  // virtual case: scalar a
@@ -168,7 +168,7 @@ F2(jtdrop){A s;I acr,af,ar,d,m,n,*u,*v,wcr,wf,wr;
   I* RESTRICT ss=AS(s); ss[0]=remlen; DO(wr-1, ss[i+1]=ws[i+1];);  // shape of virtual matches shape of w except for #items
   AN(s)=remlen*wcellsize;  // install # atoms
   // virtual block does not affect pristinity
-  RETF(s);
+  return s;
  }
 
    // length error if too many axes
@@ -178,7 +178,7 @@ F2(jtdrop){A s;I acr,af,ar,d,m,n,*u,*v,wcr,wf,wr;
  RZ(s=tk(s,w));
  // We extracted from w, so mark it (or its backer if virtual) non-pristine.  If w was pristine and inplaceable, transfer its pristine status to the result.  We overwrite w because it is no longer in use
  PRISTXFERF(s,w)
- RETF(s);
+ return s;
 }
 
 
@@ -203,13 +203,13 @@ F1(jthead){I wcr,wf,wr;
    A z; RZ(z=virtualip(w,0,wcr));  // allocate the cell.  Now fill in shape & #atoms
     // if w is empty we have to worry about overflow when calculating #atoms
    I zn; PROD(zn,wcr,AS(w)+1) MCISH(AS(z),AS(w)+1,wcr) AN(z)=zn;  // Since z and w may be the same, the copy destroys AS(w).  So calc zn first.  copy shape of CELL of w into z
-   RETF(z);
+   return z;
   }else{
    // frame not 0, or non-virtualable type, or cell is an atom.  Use from.  Note that jt->ranks is still set, so this may produce multiple cells
    // left rank is garbage, but since zeroionei(0) is an atom it doesn't matter
-   RETF(jtfrom(jtinplace,zeroionei(0),w));  // could call jtfromi directly for non-sparse w
+   return jtfrom(jtinplace,zeroionei(0),w);  // could call jtfromi directly for non-sparse w
   }
- }else{RETF(SPARSE&AT(w)?irs2(num(0),take(num( 1),w),0L,0L,wcr,jtfrom):rsh0(w));  // cell of w is empty - create a cell of fills  jt->ranks is still set for use in take.  Left rank is garbage, but that's OK
+ }else{return SPARSE&AT(w)?irs2(num(0),take(num( 1),w),0L,0L,wcr,jtfrom):rsh0(w);  // cell of w is empty - create a cell of fills  jt->ranks is still set for use in take.  Left rank is garbage, but that's OK
  }
  // pristinity from the called verb
 }

--- a/jsrc/verbs/vx.c
+++ b/jsrc/verbs/vx.c
@@ -483,7 +483,7 @@ F1(jtdigits10){A z;B b=0;I c,m,n,*v,*zv,*zv0;X x;
  }
  AN(z)=AS(z)[0]=n=zv-zv0; 
  zv=zv0; v=zv0+n-1; DQ(n>>1, c=*zv; *zv++=*v; *v--=c;); /* reverse in place */
- RETF(z);
+ return z;
 }    /* "."0@": w */
 
 

--- a/jsrc/verbs/vx.c
+++ b/jsrc/verbs/vx.c
@@ -217,7 +217,7 @@ XF2(jtxgcd){I c,d;X p,q,t;
   t=p;
   RZ(p=xrem(p,q));
   q=t;
-  if(!gc3(&p,&q,0L,old))R0;
+  if(!gc3(&p,&q,0L,old))return 0;
  }
  return rifvsdebug(q);
 }

--- a/jsrc/vu.c
+++ b/jsrc/vu.c
@@ -13,7 +13,7 @@ B jtvc1(J jt,I n,US*v){DQ(n, RZ(255>=*v++);); return 1;}
 // if b is 0, raise error if high byte of unicode is not 0
 A jttoc1(J jt,B h,A w){A z;C*wv,*zv;I n;C4*w4;
  ARGCHK1(w);
- if(LIT&AT(w))RCA(w);  // if already ASCII, return
+ if(LIT&AT(w))return w;  // if already ASCII, return
  n=AN(w); wv=CAV(w);    // number of characters, pointer to characters if any
  w4=C4AV(w);
  ASSERT(!n||(C2T+C4T)&AT(w),EVDOMAIN);  // must be empty or unicode
@@ -33,7 +33,7 @@ A jttoc1(J jt,B h,A w){A z;C*wv,*zv;I n;C4*w4;
 
 static F1(jttoc2){A z;C*wv,*zv;I n;C4*w4;US*z2;
  ARGCHK1(w);
- if(C2T&AT(w))RCA(w);
+ if(C2T&AT(w))return w;
  n=AN(w); wv=CAV(w); w4=C4AV(w);
  ASSERT(!n||(LIT+C4T)&AT(w),EVDOMAIN);
  GATV(z,C2T,n,AR(w),AS(w)); zv=CAV(z); z2=USAV(z);

--- a/jsrc/vu.c
+++ b/jsrc/vu.c
@@ -28,7 +28,7 @@ A jttoc1(J jt,B h,A w){A z;C*wv,*zv;I n;C4*w4;
  }
  // copy the low byte of the data (if there is any).  if b==0, verify high byte is 0
  // where low and high are depends on endianness
- RETF(z);
+ return z;
 }    /* convert 2-byte or 4-byte chars to 1-byte chars; 0==h iff high order byte(s) must be 0 */
 
 static F1(jttoc2){A z;C*wv,*zv;I n;C4*w4;US*z2;
@@ -57,7 +57,7 @@ static F1(jttoc2e){A z;I m,n,r;
  ASSERT(0==(m&1),EVLENGTH);
  GATV(z,C2T,n>>1,r,AS(w)); AS(z)[r-1]=m>>1;
  MC(AV(z),AV(w),n);
- RETF(z);
+ return z;
 }    /* convert pairs of 1-byte chars to 2-byte chars */
 
 // extended to C4
@@ -69,7 +69,7 @@ static F1(jtifc2){A z;I n,t,*zv;
  if(t&LIT){UC*v=UAV(w); DQ(n, *zv++=*v++;);}
  else if(t&C2T){US*v=USAV(w); DQ(n, *zv++=*v++;);}
  else          {C4*v=C4AV(w); DQ(n, *zv++=*v++;);}
- RETF(z);
+ return z;
 }    /* integers from 1- or 2-byte or 4-byte chars */
 
 static F1(jtc2fi){A z;I j,n,*v;US*zv;
@@ -77,7 +77,7 @@ static F1(jtc2fi){A z;I j,n,*v;US*zv;
  n=AN(w); v=AV(w);
  GATV(z,C2T,n,AR(w),AS(w)); zv=USAV(z);
  DQ(n, j=*v++; ASSERT(BETWEENC(j,SMIN,SMAX),EVINDEX); *zv++=(US)j;);
- RETF(z);
+ return z;
 }    /* 2-byte chars from integers */
 
 F1(jtuco1){I t;

--- a/jsrc/w.c
+++ b/jsrc/w.c
@@ -100,7 +100,7 @@ A jtunwordil(J jt, A wil, A w, I opts){A z;
  UI dupchar=(opts&1)?'\'':256; *zv='\''; zv+=(opts&1);  // if dup requested, set to look for quotes and install leading quote
  DO(n, C *w0=wv+wilv[i][0]; C *wend=wv+wilv[i][1]; while(w0!=wend){C c=*w0++; *zv++=c; if(c==dupchar)*zv++=c;})  // copy all words, with 1 space between, duplicating where needed
  AS(z)[0]=AN(z)=zv-zv0;  // install length of result
- RETF(z);
+ return z;
 }
 
 // ;: y
@@ -199,11 +199,11 @@ A jtenqueue(J jt,A a,A w,I env){A*v,*x,y,z;B b;C d,e,p,*s,*wi;I i,n,*u,wl;UC c;
     j=4; DO(m, yv[i]=p=v[j]; j+=2; if(AN(p)==k&&!memcmpne(s,NAV(p)->s,k))c=i;);  // move name into argument, remember if matched abc
     yv[m]=v[2]; RZ(yv[m+1]=rifvs(sc(c))); yv[m+2]=z;    // add the 3 ending elements
     x[0]=v[0]; x[1]=v[1]; x[2]=ds(CCASEV); x[3]=y;  // build the sentence
-    RETF(z1);  // that's what we'll execute
+    return z1;  // that's what we'll execute
    }
   }
  }
- RETF(z);
+ return z;
 }    /* produce boxed list of words suitable for parsing */
                                                             
 /* locals in enqueue:                                           */

--- a/jsrc/x15.c
+++ b/jsrc/x15.c
@@ -1040,8 +1040,8 @@ F2(jtmemw){C*u;I m,n,t,*v;
 
 // 15!:15 memu - make a copy of y if it is not writable (inplaceable and not read-only)
 // We have to check jt in case this usage is in a fork that will use the block later
-F1(jtmemu) { F1PREFIP; ARGCHK1(w); if(!((I)jtinplace&JTINPLACEW && (AC(w)<(AFLAG(w)<<((BW-1)-AFROX)))))w=ca(w); if(AT(w)&LAST0)*(C4*)&CAV(w)[AN(w)*bp(AT(w))]=0;  RETF(w); }  // append 0 so that calls from cd append NUL termination
-F2(jtmemu2) { RETF(ca(w)); }  // dyad - force copy willy-nilly
+F1(jtmemu) { F1PREFIP; ARGCHK1(w); if(!((I)jtinplace&JTINPLACEW && (AC(w)<(AFLAG(w)<<((BW-1)-AFROX)))))w=ca(w); if(AT(w)&LAST0)*(C4*)&CAV(w)[AN(w)*bp(AT(w))]=0;  return w; }  // append 0 so that calls from cd append NUL termination
+F2(jtmemu2) { return ca(w); }  // dyad - force copy willy-nilly
 
 F1(jtgh15){A z;I k; RE(k=i0(w)); RZ(z=gah(k,0L)); ACINCR(z); return sc((I)z);}
      /* 15!:8  get header */

--- a/jsrc/xa.c
+++ b/jsrc/xa.c
@@ -109,7 +109,7 @@ F1(jtoutparmq){A z;D*u;I*v;
   v[2]=jt->outmaxbefore;
   v[3]=jt->outmaxafter;
  }
- RETF(z);
+ return z;
 }
 
 F1(jtoutparms){I*v;

--- a/jsrc/xb.c
+++ b/jsrc/xb.c
@@ -22,7 +22,7 @@ F2(jtnouninfo2){A z;
   case 0: *zv++=(AFLAG(w)>>AFNJAX)&1; break;
   }
  )
- RETF(z);
+ return z;
 }
 // a 3!:9 w   noun info
 
@@ -196,7 +196,7 @@ static A jthrep(J jt,B b,B d,A w){A y;C c,*hex="0123456789abcdef",*u,*v;I n,s[2]
   GATVR(z,LIT,2*n,2,s);  
   u=CAV(y); v=CAV(z); 
   DQ(n, c=*u++; *v++=hex[(c&0xf0)>>4]; *v++=hex[c&0x0f];); 
-  RETF(z);
+  return z;
  }
  n=bsizer(jt,d,1,w); s[0]=n>>LGWS(d); s[1]=2*WS(d); 
  GATVR(y,LIT,2*n,2,s);   // allocate entire result
@@ -237,7 +237,7 @@ static F1(jtunhex){A z;C*u;I c,n;UC p,q,*v;
  n=AN(w)>>1; u=CAV(w);
  GATV0(z,LIT,n,1); v=UAV(z);
  DQ(n, p=*u++; q=*u++; *v++=16*unh(p)+unh(q););
- RE(z); RETF(z);
+ RE(z); return z;
 }
 
 static A jtunbinr(J jt,B b,B d,B pre601,I m,A w){A y,z;C*u=(C*)w,*v;I e,j,kk,n,p,r,*s,t,*vv;
@@ -276,7 +276,7 @@ static A jtunbinr(J jt,B b,B d,B pre601,I m,A w){A y,z;C*u=(C*)w,*v;I e,j,kk,n,p
   case CMPXX: RZ(mvw(CAV(z),v,n+n,BU,b,1,1)); break;
   default:   e=n<<bplg(t); ASSERTSYS(e<=allosize(z),"unbinr"); MC(CAV(z),v,e);
  }
- RE(z); RETF(z);
+ RE(z); return z;
 }    /* b iff reverse the bytes; d iff argument is 64-bits */
 
 F1(jtunbin){A q;B b,d;C*v;I c,i,k,m,n,r,t;
@@ -327,15 +327,15 @@ F2(jtic2){A z;I j,m,n,p,*v,*x,zt;I4*y;UI4*y1;S*s;U short*u;
  GA(z,zt,m,1,0); v=AV(z); x=AV(w); 
  switch(j){
   default: ASSERT(0,EVDOMAIN);
-  case -4: y1=(UI4*)x;    DQ(m, *v++=    *y1++;); {RETF(z);}
-  case  4: y1=(UI4*)v;    DQ(n, *y1++=(UI4)*x++;); {RETF(z);}
-  case -3: ICPY(v,x,m); {RETF(z);}
-  case  3: MC(v,x,m);   {RETF(z);}
-  case -2: y=(I4*)x;      DQ(m, *v++=    *y++;); {RETF(z);}
-  case  2: y=(I4*)v;      DQ(n, *y++=(I4)*x++;); {RETF(z);}
-  case -1: s=(S*)x;       DQ(m, *v++=    *s++;); {RETF(z);}
-  case  1: s=(S*)v;       DQ(n, *s++=(S) *x++;); {RETF(z);}
-  case  0: u=(U short*)x; DQ(m, *v++=    *u++;); {RETF(z);}
+  case -4: y1=(UI4*)x;    DQ(m, *v++=    *y1++;); {return z;}
+  case  4: y1=(UI4*)v;    DQ(n, *y1++=(UI4)*x++;); {return z;}
+  case -3: ICPY(v,x,m); {return z;}
+  case  3: MC(v,x,m);   {return z;}
+  case -2: y=(I4*)x;      DQ(m, *v++=    *y++;); {return z;}
+  case  2: y=(I4*)v;      DQ(n, *y++=(I4)*x++;); {return z;}
+  case -1: s=(S*)x;       DQ(m, *v++=    *s++;); {return z;}
+  case  1: s=(S*)v;       DQ(n, *s++=(S) *x++;); {return z;}
+  case  0: u=(U short*)x; DQ(m, *v++=    *u++;); {return z;}
 }}
 
 F2(jtfc2){A z;D*x,*v;I j,m,n,p,zt;float*s;
@@ -349,10 +349,10 @@ F2(jtfc2){A z;D*x,*v;I j,m,n,p,zt;float*s;
  GA(z,zt,m,1,0); v=DAV(z); x=DAV(w);
  switch(j){
   default: ASSERT(0,EVDOMAIN);
-  case -2: MC(v,x,n); {RETF(z);}
-  case  2: MC(v,x,m); {RETF(z);}
-  case -1: s=(float*)x; DQ(m, *v++=       *s++;); {RETF(z);}
-  case  1: s=(float*)v; DQ(n, *s++=(float)*x++;); {RETF(z);}
+  case -2: MC(v,x,n); {return z;}
+  case  2: MC(v,x,m); {return z;}
+  case -1: s=(float*)x; DQ(m, *v++=       *s++;); {return z;}
+  case  1: s=(float*)v; DQ(n, *s++=(float)*x++;); {return z;}
 }}
 
 // w is a box, result is 1 if it contains a  NaN
@@ -374,7 +374,7 @@ F1(jtisnan){A*wv,z;B*u;D*v;I n,t;
  else if(t&CMPX){v=DAV(w); DQ(n, *u++=_isnan(v[0])|_isnan(v[1]); v+=2;);}  // complex - check each half
  else if(t&BOX){wv=AAV(w); DO(n, *u++=isnanq(wv[i]);); RE(0);}  // boxed - check contents
  else memset(u,C0,n);  // other types are never NaN
- RETF(z);
+ return z;
 }
 
 
@@ -485,7 +485,7 @@ static A sfe(J jt,A w,I prec,UC decimalpt,UC zuluflag){
  GATV0(z,LIT,AN(w)*linelen,AR(w)+1) MCISH(AS(z),AS(w),AR(w)) AS(z)[AR(w)]=linelen==7*SZI?7:linelen;
  // If the result will be INT, make it so
  if(linelen==56){AT(z)=INT; AN(z)>>=LGSZI;}
- if(AN(w)==0){RETF(z);}  // handle empty return
+ if(AN(w)==0){return z;}  // handle empty return
  I rows=AN(w);  // number of rows to process
  I *e=IAV(w);  // pointer to nanosecond data
  C *s=CAV(z);  // pointer to result
@@ -543,7 +543,7 @@ static A sfe(J jt,A w,I prec,UC decimalpt,UC zuluflag){
    ((I*)s)[0]=y; ((I*)s)[1]=m; ((I*)s)[2]=d; ((I*)s)[3]=HMS; ((I*)s)[4]=M; ((I*)s)[5]=E; ((I*)s)[6]=N;
   }
  }
-	RETF(z);
+	return z;
 }
 
 // w is LIT array of ISO strings (rank>0, not empty), result is array of INTs with nanosecond time for each string
@@ -640,7 +640,7 @@ gottime: ;
 err:
   s[strglen]=savesentinel;  // restore end-of-string marker
  }
- RETF(z);
+ return z;
 }
 
 
@@ -653,14 +653,14 @@ F1(jtinttoe){A z;I n;
  RZ(w=vi(w));  // verify valid integer
  GATV(z,INT,n,AR(w),AS(w));
  eft(n,IAV(z),IAV(w));
- RETF(z);
+ return z;
 }
 
 // 6!:15 Convert a block of nanosecond times to Y M D h m s nanosec
 F1(jtetoint){
  ARGCHK1(w);
  ASSERT(1,EVNONCE);
- RETF(sfe(jt,w,7*SZI-20,0,0));  // special precision meaning 'store INTs'.  Turns into linelen=56
+ return sfe(jt,w,7*SZI-20,0,0);  // special precision meaning 'store INTs'.  Turns into linelen=56
 }
 
 // 6!:16 convert a block of nanoseconds times to iso8601 format.  Result has an extra axis, long enough to hold the result
@@ -681,7 +681,7 @@ F2(jtetoiso8601){UC decimalpt,zuluflag;I prec;
  }else{
   w=a; decimalpt='.'; zuluflag=' '; prec=0;  // monad: switch argument, set defaults
  }
- RETF(sfe(jt,w,prec,decimalpt,zuluflag));
+ return sfe(jt,w,prec,decimalpt,zuluflag);
 }
 
 // 6!:17 convert a block of iso8601-format strings to nanosecond times.  Result has one INT for each string
@@ -701,6 +701,6 @@ F2(jtiso8601toe){A z;I prec;
  }
  ASSERT(AT(w)&LIT,EVDOMAIN);  // must be LIT
  ASSERT(AR(w),EVRANK);    // must not be an atom
- if(!AN(w)){RETF(df1(z,w,qq(sc(IMIN),zeroionei(1))));}   // return _"1 w on empty w - equivalent
- RETF(efs(jt,w,prec));
+ if(!AN(w)){return df1(z,w,qq(sc(IMIN),zeroionei(1)));}   // return _"1 w on empty w - equivalent
+ return efs(jt,w,prec);
 }

--- a/jsrc/xf.c
+++ b/jsrc/xf.c
@@ -79,7 +79,7 @@ F1(jtjfread){A z;F f;
  RE(f=stdf(w));  // f=file#, or 0 if w is a filename
  if(f)return 1==(I)f?jgets("\001"):3==(I)f?rdns(stdin):rd(vfn(f),0L,-1L);  // if special file, read it all, possibly with error
  RZ(f=jope(w,FREAD_O)); z=rd(f,0L,-1L); fclose(f);  // otherwise open/read/close named file
- RETF(z);
+ return z;
 }
 
 F2(jtjfwrite){B b;F f;

--- a/jsrc/xfmt.c
+++ b/jsrc/xfmt.c
@@ -567,6 +567,6 @@ F2(jtfmt22){A z;I mode,r,j;
  return AS(z)[0]?razeh(z):lamin1(z);
 } /* 8!:2 dyad */
 
-F1(jtfmt01){ARGCHK1(w); RETF(fmt02(AR(w)?reshape(sc(AS(w)[AR(w)-1]),ds(CACE)):ds(CACE),w));} /* 8!:0 monad */
-F1(jtfmt11){ARGCHK1(w); RETF(fmt12(AR(w)?reshape(sc(AS(w)[AR(w)-1]),ds(CACE)):ds(CACE),w));} /* 8!:1 monad */
-F1(jtfmt21){ARGCHK1(w); RETF(fmt22(AR(w)?reshape(sc(AS(w)[AR(w)-1]),ds(CACE)):ds(CACE),w));} /* 8!:2 monad */
+F1(jtfmt01){ARGCHK1(w); return fmt02(AR(w)?reshape(sc(AS(w)[AR(w)-1]),ds(CACE)):ds(CACE),w);} /* 8!:0 monad */
+F1(jtfmt11){ARGCHK1(w); return fmt12(AR(w)?reshape(sc(AS(w)[AR(w)-1]),ds(CACE)):ds(CACE),w);} /* 8!:1 monad */
+F1(jtfmt21){ARGCHK1(w); return fmt22(AR(w)?reshape(sc(AS(w)[AR(w)-1]),ds(CACE)):ds(CACE),w);} /* 8!:2 monad */

--- a/jsrc/xu.c
+++ b/jsrc/xu.c
@@ -755,7 +755,7 @@ F1(jttoutf16){A z;I n,t,q,b=0,j; UC* wv; US* c2v; C4* c4v; A c4; I *v;
  else if(LIT&t) // u16 from u8
  {
   DQ(n, if(127<*wv++){b=1;break;});
-  if(!b)RCA(w);  // ascii list unchanged ascii scalar as list
+  if(!b)return w;  // ascii list unchanged ascii scalar as list
   q=mtowsize(UAV(w),n);
   ASSERT(q>=0,EVDOMAIN);
   GATV0(z,C2T,q,1);
@@ -765,7 +765,7 @@ F1(jttoutf16){A z;I n,t,q,b=0,j; UC* wv; US* c2v; C4* c4v; A c4; I *v;
  {
   c2v=USAV(w);
   DQ(n, if(127<*c2v++){b=1;break;});
-  if(b)RCA(w); // u16 unchanged
+  if(b)return w; // u16 unchanged
   GATV0(z,LIT,n,1);
   wv=UAV(z);
   c2v=USAV(w);
@@ -798,7 +798,7 @@ A jttoutf8a(J jt,A w,A prxthornuni){A z;I n,t,q;  // prxthornuni is unused
 PROLOG(0000);
 ARGCHK1(w); ASSERT(1>=AR(w),EVRANK); n=AN(w); t=AT(w);
 if(!n) {GATV(z,LIT,n,AR(w),AS(w)); return z;}; // empty lit list
-if(t&LIT)RCA(w); // char unchanged
+if(t&LIT)return w; // char unchanged
 ASSERT(t&(C2T+C4T), EVDOMAIN);
 if(t&C2T)
 {
@@ -822,7 +822,7 @@ F1(jttoutf8){A z;I n,t,q,j; A c4; C4* c4v; I *v;
 PROLOG(0000);
 ARGCHK1(w); ASSERT(1>=AR(w),EVRANK); n=AN(w); t=AT(w);
 if(!n) {GATV(z,LIT,n,AR(w),AS(w)); return z;}; // empty lit list
-if(t&LIT)RCA(w); // char unchanged
+if(t&LIT)return w; // char unchanged
 ASSERT(t&(NUMERIC+JCHAR), EVDOMAIN);
 if(NUMERIC&t)
 {
@@ -857,7 +857,7 @@ F1(jttoutf16x){A z;I n,t,q;
 PROLOG(0000);
 ARGCHK1(w); ASSERT(1>=AR(w),EVRANK); n=AN(w); t=AT(w);
 if(!n) {GATV(z,C2T,n,AR(w),AS(w)); return z;}; // empty list
-if(t&C2T)RCA(w);
+if(t&C2T)return w;
 ASSERT(t&LIT+C4T,EVDOMAIN);
 if(t&C4T)
 {
@@ -905,7 +905,7 @@ F1(jttoutf32){A z;I n,t,q,b=0,j; UC* wv; US* c2v; C4* c4v; I* v;
  else if(LIT&t) // u32 from u8
  {
   DQ(n, if(127<*wv++){b=1;break;});
-  if(!b)RCA(w);  // ascii list unchanged ascii scalar as list
+  if(!b)return w;  // ascii list unchanged ascii scalar as list
   q=mtousize(UAV(w),n);
   ASSERT(q>=0,EVDOMAIN);
   GATV0(z,C4T,q,1);
@@ -957,7 +957,7 @@ F1(jttoutf32){A z;I n,t,q,b=0,j; UC* wv; US* c2v; C4* c4v; I* v;
 F1(jttou32){A z;I n,t,b=0,j; UC* wv; US* c2v; C4* c4v; I* v; UC* c1v;
  PROLOG(0000);
  ARGCHK1(w); n=AN(w); t=AT(w); wv=UAV(w);
- if(C4T&AT(w))RCA(w);  // if already C4T, return
+ if(C4T&AT(w))return w;  // if already C4T, return
  ASSERT(!n||(NUMERIC+JCHAR)&AT(w),EVDOMAIN);  // must be empty or unicode
  if(!n) {GATV(z,C4T,n,AR(w),AS(w)); return z;}; // empty list
  if(NUMERIC&t)
@@ -992,7 +992,7 @@ if(!n) {GATV(z,LIT,n,AR(w),AS(w)); return z;}; // empty list
 ASSERT(t&LIT,EVDOMAIN);
 // convert to utf-16
 q=mtowsize(wv,n);
-if(q<0)RCA(w);
+if(q<0)return w;
 GATV0(z,C2T,q,1);
 c2v=USAV(z);
 mtow(wv,n,c2v);


### PR DESCRIPTION
Resolves #53 

Replaced:
- `RETF(x)` -> `return x` 
- `RCA(x)` -> `return x`
- `R0` -> `return 0` (or with semicolon at the end, where necessary)