### PR TITLE
Misc removals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=logical-not-parent
 # Enable warnings
 add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wall>)
 add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wextra>)
+add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wunused-macros>)
+add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-error=unused-macros>) # Some false positives / only cover current build configuration
 
 # Exclude some warnings
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-misleading-indentation>)

--- a/jsrc/adverbs/ao.c
+++ b/jsrc/adverbs/ao.c
@@ -81,10 +81,6 @@ static A jtobqfslash(J jt,    A w,A self){A y,z;B b=0,p;C er,id,*wv;I c,d,k,m,m1
  return b?z:oblique(w,self);
 }    /* f//.y for atomic f */
 
-
-#define TYMESF(x)       {LD t=*u--*(LD)*v++; x=(I)t; BOV(t<IMIN||IMAX<t);}
-#define ACCUMF          {B p;I y; TYMESF(y); p=0>x; x+=y; BOV(p==0>y&&p!=0>x);}
-
 #define PMCASE(t,c,d)   (65536*(c)+256*(d)+(t))
 
 #define PMLOOP(Tw,Tz,zt,expr0,expr)  \
@@ -126,9 +122,7 @@ static A jtobqfslash(J jt,    A w,A self){A y,z;B b=0,p;C er,id,*wv;I c,d,k,m,m1
   case PMCASE(RATX, CPLUS,  CSTAR   ): PMLOOP(Q,Q,RAT,  x=qtymes(*u--,*v++), x=qplus(x,qtymes(*u--,*v++))); break;
   case PMCASE(INTX, CBW0110,CBW0001 ): PMLOOP(I,I,INT,  x=*u--&*v++, x^=*u--&*v++); break;
   case PMCASE(INTX, CPLUS,  CSTAR   ): 
-/*
-   er=0; PMLOOP(I,I,INT, TYMESF(x), ACCUMF);
-*/
+
   // here for +//.@(*/)
   {A a1,y;I*aa,i,*u,*ww=(I*)wv,*v,*yv,*zv;VA2 adocv; VARPS adocvsum;
    b=1;

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -16,21 +16,6 @@
 #define __GNUC_PATCHLEVEL__ 1
 #endif
 
-#if defined(__aarch64__)||defined(_M_ARM64)
-#include <arm_neon.h>
-#endif
-
-#if defined(__arm__)
-#if defined(__ARM_NEON)
-#include <arm_neon.h>
-typedef double float64x2_t __attribute__ ((vector_size (16)));
-#else
-#include <stdint.h>
-typedef int64_t int64x2_t __attribute__ ((vector_size (16)));
-typedef double float64x2_t __attribute__ ((vector_size (16)));
-#endif
-#endif
-
 #ifndef SYS // include js.h only once - dtoa.c
 #include "js.h"
 #endif

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -31,9 +31,6 @@ typedef double float64x2_t __attribute__ ((vector_size (16)));
 #endif
 #endif
 
-#undef VOIDARG
-#define VOIDARG
-
 #ifndef SYS // include js.h only once - dtoa.c
 #include "js.h"
 #endif

--- a/jsrc/k.c
+++ b/jsrc/k.c
@@ -8,8 +8,7 @@
 
 #define CVCASE(a,b)     (((a)<<3)+(b))   // The main cases fit in low 8 bits of mask
 
-// FEQ/FIEQ are used in bcvt, where FUZZ may be set to 0 to ensure only exact values are demoted to lower precision
-#define FEQ(u,v,fuzz)    (ABS((u)-(v))<=fuzz*MAX(ABS(u),ABS(v)))
+// FIEQ are used in bcvt, where FUZZ may be set to 0 to ensure only exact values are demoted to lower precision
 #define FIEQ(u,v,fuzz)   (ABS((u)-(v))<=fuzz*ABS(v))  // used when v is known to be exact integer.  It's close enough, maybe ULP too small on the high end
 
 static B jtC1fromC2(J jt,A w,void*yv){UC*x;US c,*v;

--- a/jsrc/m.c
+++ b/jsrc/m.c
@@ -4,8 +4,6 @@
 /* Memory Management                                                       */
 
 
-#define __cdecl
-
 #include "j.h"
 
 #define ALIGNTOCACHE 0   // set to 1 to align each block to cache-line boundary.  Will reduce cache usage for headers
@@ -940,4 +938,3 @@ A jtexta(J jt,I t,I r,I c,I m){A z;I m1;
 
 // forcetomemory does nothing, but it does take an array as argument.  This will spook the compiler out of trying to assign parts of the array to registers.
 void forcetomemory(void * w){return; }
-

--- a/jsrc/parsing/p.c
+++ b/jsrc/parsing/p.c
@@ -60,16 +60,6 @@ PT cases[] = {
  NAME+NOUN, ASGN,      CAVN, ANY,       0,      jtvis,    0,2,1,
  LPAR,      CAVN,      RPAR, ANY,       0,    jtvpunc,  0,2,0,
 };
-#define PN 0
-#define PA 1
-#define PC 2
-#define PV 3
-#define PM 4  // MARK
-#define PNM 5  // NAME
-#define PL 6
-#define PR 7
-#define PS 8  // ASGN without ASGNNAME
-#define PSN 9 // ASGN+ASGNNAME
 
 // Tables to convert parsing type to mask of matching parse-table rows for each of the stack positions
 // the AND of these gives the matched row (the end-of-table row is always matched)
@@ -677,4 +667,3 @@ failparse:  // If there was an error during execution or name-stacking, exit wit
  }
 
 }
-

--- a/jsrc/verbs/vg.c
+++ b/jsrc/verbs/vg.c
@@ -24,7 +24,6 @@
 /* merge sort with special code for n<:5                                */
 /*                                                                      */
 /************************************************************************/
-#define VS(i,j)          (0<CALL1(jt->workareas.compare.comp,u[i],u[j]))
 #define XC(i,j)          {q=u[i]; u[i]=u[j]; u[j]=q;}
 #define P3(i,j,k)        {ui=u[i]; uj=u[j]; uk=u[k]; u[0]=ui; u[1]=uj; u[2]=uk;}
 

--- a/jsrc/verbs/vgsort.c
+++ b/jsrc/verbs/vgsort.c
@@ -246,14 +246,6 @@ static A jtsorti1(J jt,I m,I n,A w){A x,y,z;I*wv;I i,*xv,*zv;void *yv;
 #define SORTQNAME sortiq1
 #define SORTQTYPE I
 #define SORTQSCOPE
-#define SORTQSET256 _mm256_set_epi64x
-#define SORTQTYPE256 __m256i
-#define SORTQCASTTOPD _mm256_castsi256_pd
-#define SORTQCMP256 _mm256_cmpgt_epi64
-#define SORTQCMPTYPE 
-#define SORTQMASKLOAD _mm256_maskload_epi64
-#define SORTQULOAD _mm256_loadu_si256
-#define SORTQULOADTYPE __m256i*
 #include "vgsortq.h"
 
 static A jtsortiq(J jt,I m,I n,A w){FPREFIP;  // m=#sorts, n=#items in each sort, w is block
@@ -340,14 +332,6 @@ static A jtsortu1(J jt,I m,I n,A w){A x,y,z;C4 *xu,*wv,*zu;I i;void *yv;
 #define SORTQNAME sortdq1
 #define SORTQTYPE D
 #define SORTQSCOPE static
-#define SORTQCASTTOPD 
-#define SORTQSET256 _mm256_set_pd
-#define SORTQTYPE256 __m256d
-#define SORTQCMP256(a,b) _mm256_cmp_pd(a,b)
-#define SORTQCMPTYPE ,_CMP_GT_OQ
-#define SORTQMASKLOAD _mm256_maskload_pd
-#define SORTQULOAD _mm256_loadu_pd
-#define SORTQULOADTYPE D*
 #include "vgsortq.h"
 
 static A jtsortdq(J jt,I m,I n,A w){FPREFIP;  // m=#sorts, n=#items in each sort, w is block

--- a/jsrc/verbs/vgsortq.h
+++ b/jsrc/verbs/vgsortq.h
@@ -160,12 +160,4 @@ finmedxchg:  // exchanges if any are done, and xchgx0/xchgx1 are set
 #undef SORTQSCOPE
 #undef SORTQNAME
 #undef SORTQTYPE
-#undef SORTQSET256
-#undef SORTQTYPE256
-#undef SORTQCASTTOPD
 #undef SORTQAND256
-#undef SORTQCMP256
-#undef SORTQCMPTYPE 
-#undef SORTQMASKLOAD
-#undef SORTQULOAD
-#undef SORTQULOADTYPE

--- a/jsrc/verbs/vsb.c
+++ b/jsrc/verbs/vsb.c
@@ -31,7 +31,6 @@ typedef enum {
 #define LEFT(a)         NODEM(a,left)
 #define RIGHT(a)        NODEM(a,right)
 #define ORDER(a)        NODEM(a,order)
-#define INDEX(a)        NODEM(a,i)
 #define COLOR(a)        NODEM(a,color)
 #define DOWN(a)         NODEM(a,down)
 #define UP(a)           NODEM(a,up)


### PR DESCRIPTION
This removes misc macros (most of them unused) and ARM NEON include.

`-Wunused-macros` was useful in finding unused macros. I added it to the warnings in the CMakeLists.txt, but not as an error. It seems to give some false positives, likely because it only checks the current build configuration.