### PR TITLE
write markdown tables in RST file

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# rst files which have been created by pre-processor
+source/__output__

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -52,7 +52,7 @@ add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
                    # Other docs files you want to track should go here (or in some variable)
                    ${CMAKE_CURRENT_SOURCE_DIR}/source/index.rst
                    ${DOXYGEN_INDEX_FILE}
-                   MAIN_DEPENDENCY ${SPHINX_SOURCE}/__output__/conf.py
+                   MAIN_DEPENDENCY ${SPHINX_SOURCE}/conf.py
                    COMMENT "Generating documentation with Sphinx")
 
 # Nice named target so we can run the job easily

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,16 +39,20 @@ set(SPHINX_INDEX_FILE ${SPHINX_BUILD}/index.html)
 # - The Sphinx config has been updated
 add_custom_command(OUTPUT ${SPHINX_INDEX_FILE}
                    COMMAND 
+                     ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/preprocessor.py
+                     --input ${SPHINX_SOURCE}
+                     --output ${SPHINX_SOURCE}/__output__
+                     &&
                      ${SPHINX_EXECUTABLE} -b html
                      # Tell Breathe where to find the Doxygen output
                      -Dbreathe_projects.jsrc=${DOXYGEN_OUTPUT_DIR}/xml
-                   ${SPHINX_SOURCE} ${SPHINX_BUILD}
+                   ${SPHINX_SOURCE}/__output__ ${SPHINX_BUILD}
                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                    DEPENDS
                    # Other docs files you want to track should go here (or in some variable)
                    ${CMAKE_CURRENT_SOURCE_DIR}/source/index.rst
                    ${DOXYGEN_INDEX_FILE}
-                   MAIN_DEPENDENCY ${SPHINX_SOURCE}/conf.py
+                   MAIN_DEPENDENCY ${SPHINX_SOURCE}/__output__/conf.py
                    COMMENT "Generating documentation with Sphinx")
 
 # Nice named target so we can run the job easily

--- a/docs/scripts/preprocessor.py
+++ b/docs/scripts/preprocessor.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python3
+
+"""
+preprocessor for sphinx files
+- reads in all .rst files in input directory
+- writes processed .rst files to output directory
+
+by copying files to output directory, we aren't
+modifying the  original .rst files in any way.
+
+preprocessor steps:
+- format tables
+"""
+
+import argparse
+import shutil
+import os
+
+
+def find_markdown_tables(lines):
+    """
+    return (row_start, row_end) for all markdown tables.
+    """
+    tpos = []
+    md_table_idx = None
+    for idx, line in enumerate(lines):
+        if line.startswith("|"):
+            if not md_table_idx:
+                md_table_idx = idx
+        else: # end of md table
+            if md_table_idx is not None:
+                tpos.append((md_table_idx, idx - 1))
+                md_table_idx = None
+    if md_table_idx is not None:
+        tpos.append((md_table_idx, idx))
+    return tpos
+
+
+def get_markdown_row_data(row):
+    """
+    get row (or header) data from markdown row (or header)
+
+    row
+        | apples | red | a |
+
+    data
+        ['apples', 'red', 'a']
+    """
+    data = row.split("|")
+    data = data[0:len(data)-1]
+    data = [e.strip() for e in data if e.strip()]
+    return data
+
+
+def convert_table(table, in_format="md", out_format="rst-2"):
+    """
+    md format
+        | fruit | color | startswith |
+        | ----- | ----- | ---------- |
+        | apples | red | a |
+        | oranges | orange | o |
+    
+    rst-1 format
+        +---------+--------+------------+
+        | fruit   | color  | startswith |
+        +=========+========+============+
+        | apples  | red    | a          |
+        +---------+--------+------------+
+        | oranges | orange | o          |
+        +---------+--------+------------+
+
+    rst-2 format
+        =======  ====== ==========
+        fruit    color  startswith
+        =======  ====== ==========
+        apples   red    a
+        oranges  orange o
+        =======  =====  ==========
+    """
+    if in_format == "md" and out_format=="rst-2":
+        header = get_markdown_row_data(table[0])
+        # NOTE: skip table[1]
+        rows = [get_markdown_row_data(row) for row in table[2:]]
+        cols = [[row[col_idx] for row in rows] for col_idx in range(len(header))]
+        rst_table = []
+        separator = ' '.join(
+            ['=' * max(len(header[col_idx]), len(max(col, key=len))) for col_idx, col in enumerate(cols)],
+        )
+        rst_table.append(separator)
+        data = []
+        for col_idx, col in enumerate(cols):
+            length = max(len(header[col_idx]), len(max(col, key=len)))
+            data.append(header[col_idx] + ' ' * (length - len(header[col_idx])))
+        rst_table.append(' '.join(data))
+        rst_table.append(separator)
+        for row in rows:
+            data = []
+            for col_idx, col in enumerate(cols):
+                length = max(len(header[col_idx]), len(max(col, key=len)))
+                data.append(row[col_idx] + ' ' * (length - len(row[col_idx])))
+            rst_table.append(' '.join(data))
+        rst_table.append(separator)
+        return rst_table
+
+    raise Exception("Conversion from {} to {} not implemented".format(
+        in_format, out_format
+    ))
+
+
+def get_processed_lines(lines):
+    """
+    replace all md tables in lines with rst-2 tables
+    
+    - additional processing can be added later if needed
+    """
+    tpos = find_markdown_tables(lines)
+    for pos in tpos:
+        md_table = lines[pos[0]:pos[1]+1]
+        rst_table = convert_table(md_table, in_format="md", out_format="rst-2")
+        # replace md_table with rst_table
+        lines = lines[0:pos[0]] + \
+            rst_table + \
+            lines[pos[1]+1:]
+    return lines
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", help="Input Sphinx source directory")
+    parser.add_argument("--output", help="Output Sphinx source directory")
+    args = parser.parse_args()
+
+    try:
+        shutil.rmtree(args.output)
+    except:
+        pass
+
+    shutil.copytree(args.input, args.output)
+
+    for root, dirs, files in os.walk(args.output):
+        for file in files:
+            if file.endswith('.rst'):
+                with open('{}/{}'.format(root, file)) as f:
+                    data = f.read()
+                lines = data.splitlines()
+                lines = get_processed_lines(lines)
+                with open('{}/{}'.format(root, file), 'w') as f:
+                    f.write('\n'.join(lines))
+    
+    print("preprocessor step finished")

--- a/docs/scripts/preprocessor.py
+++ b/docs/scripts/preprocessor.py
@@ -15,25 +15,20 @@ preprocessor steps:
 import argparse
 import shutil
 import os
+import itertools
 
 
 def find_markdown_tables(lines):
     """
     return (row_start, row_end) for all markdown tables.
     """
-    tpos = []
-    md_table_idx = None
-    for idx, line in enumerate(lines):
-        if line.startswith("|"):
-            if not md_table_idx:
-                md_table_idx = idx
-        else: # end of md table
-            if md_table_idx is not None:
-                tpos.append((md_table_idx, idx - 1))
-                md_table_idx = None
-    if md_table_idx is not None:
-        tpos.append((md_table_idx, idx))
-    return tpos
+    indices = [idx for idx, line in enumerate(lines) if line.startswith("|")]
+    nindices = len(indices)
+    indices_type = ["end" if i + 1 == nindices or indices[i+1] - indices[i] > 1
+                    else "start" if i == 0 or indices[i] - indices[i-1] > 1
+                    else "mid" for i in range(nindices)]
+    return list(zip([indices[i] for i in range(nindices) if indices_type[i] == "start"],
+                    [indices[i] for i in range(nindices) if indices_type[i] == "end"]))
 
 
 def get_markdown_row_data(row):
@@ -46,10 +41,7 @@ def get_markdown_row_data(row):
     data
         ['apples', 'red', 'a']
     """
-    data = row.split("|")
-    data = data[0:len(data)-1]
-    data = [e.strip() for e in data if e.strip()]
-    return data
+    return [e.strip() for e in row.split("|")[1:-1] if e.strip()]
 
 
 def convert_table(table, in_format="md", out_format="rst-2"):
@@ -59,7 +51,7 @@ def convert_table(table, in_format="md", out_format="rst-2"):
         | ----- | ----- | ---------- |
         | apples | red | a |
         | oranges | orange | o |
-    
+
     rst-1 format
         +---------+--------+------------+
         | fruit   | color  | startswith |
@@ -77,30 +69,26 @@ def convert_table(table, in_format="md", out_format="rst-2"):
         oranges  orange o
         =======  =====  ==========
     """
-    if in_format == "md" and out_format=="rst-2":
+    if in_format == "md" and out_format == "rst-2":
         header = get_markdown_row_data(table[0])
-        # NOTE: skip table[1]
         rows = [get_markdown_row_data(row) for row in table[2:]]
-        cols = [[row[col_idx] for row in rows] for col_idx in range(len(header))]
-        rst_table = []
-        separator = ' '.join(
-            ['=' * max(len(header[col_idx]), len(max(col, key=len))) for col_idx, col in enumerate(cols)],
+        cols = [[row[col_idx] for row in rows]
+                for col_idx in range(len(header))]
+        tbl_separator = ' '.join(
+            ['=' * max(len(header[col_idx]), len(max(col, key=len)))
+             for col_idx, col in enumerate(cols)],
         )
-        rst_table.append(separator)
-        data = []
-        for col_idx, col in enumerate(cols):
-            length = max(len(header[col_idx]), len(max(col, key=len)))
-            data.append(header[col_idx] + ' ' * (length - len(header[col_idx])))
-        rst_table.append(' '.join(data))
-        rst_table.append(separator)
-        for row in rows:
-            data = []
-            for col_idx, col in enumerate(cols):
-                length = max(len(header[col_idx]), len(max(col, key=len)))
-                data.append(row[col_idx] + ' ' * (length - len(row[col_idx])))
-            rst_table.append(' '.join(data))
-        rst_table.append(separator)
-        return rst_table
+        tbl_header = ' '.join([
+            header[idx] + ' ' * (max(len(header[idx]), len(max(col, key=len))) - len(header[idx]))
+            for idx, col in enumerate(cols)
+        ])
+        tbl_rows = [
+            ' '.join([
+                row[idx] + ' ' * (max(len(header[idx]), len(max(col, key=len))) - len(row[idx]))
+                for idx, col in enumerate(cols)
+            ]) for row in rows
+        ]
+        return [tbl_separator] + [tbl_header] + [tbl_separator] + tbl_rows + [tbl_separator]
 
     raise Exception("Conversion from {} to {} not implemented".format(
         in_format, out_format
@@ -110,18 +98,24 @@ def convert_table(table, in_format="md", out_format="rst-2"):
 def get_processed_lines(lines):
     """
     replace all md tables in lines with rst-2 tables
-    
+
     - additional processing can be added later if needed
     """
     tpos = find_markdown_tables(lines)
-    for pos in tpos:
-        md_table = lines[pos[0]:pos[1]+1]
-        rst_table = convert_table(md_table, in_format="md", out_format="rst-2")
-        # replace md_table with rst_table
-        lines = lines[0:pos[0]] + \
-            rst_table + \
-            lines[pos[1]+1:]
-    return lines
+    
+    if not tpos:
+        return lines
+    
+    chunks = [[(0, tpos[0][0] - 1)]] + \
+        [[pos] if idx == 0
+         else [(tpos[idx-1][1] + 1, pos[0] - 1), pos] for idx, pos in enumerate(tpos)] + \
+        [[(tpos[-1][1] + 1, len(lines) - 1)]]
+    
+    return list(itertools.chain.from_iterable([
+        convert_table(lines[chunk[0]:chunk[1]+1], "md", "rst-2") if chunk in tpos \
+        else lines[chunk[0]:chunk[1]+1] \
+        for chunk in list(itertools.chain(*chunks))
+    ]))
 
 
 if __name__ == "__main__":
@@ -143,9 +137,8 @@ if __name__ == "__main__":
             if file.endswith('.rst'):
                 with open('{}/{}'.format(root, file)) as f:
                     data = f.read()
-                lines = data.splitlines()
-                lines = get_processed_lines(lines)
+                lines = get_processed_lines(data.splitlines())
                 with open('{}/{}'.format(root, file), 'w') as f:
                     f.write('\n'.join(lines))
-    
+
     print("preprocessor step finished")

--- a/docs/scripts/preprocessor.py
+++ b/docs/scripts/preprocessor.py
@@ -41,7 +41,7 @@ def get_markdown_row_data(row):
     data
         ['apples', 'red', 'a']
     """
-    return [e.strip() for e in row.split("|")[1:-1] if e.strip()]
+    return [e.strip() for e in row.split("|")[1:-1]]
 
 
 def convert_table(table, in_format="md", out_format="rst-2"):
@@ -125,11 +125,7 @@ if __name__ == "__main__":
     parser.add_argument("--output", help="Output Sphinx source directory")
     args = parser.parse_args()
 
-    try:
-        shutil.rmtree(args.output)
-    except:
-        pass
-
+    shutil.rmtree(args.output, ignore_errors=True)
     shutil.copytree(args.input, args.output)
 
     for root, dirs, files in os.walk(args.output):

--- a/docs/source/verbs.rst
+++ b/docs/source/verbs.rst
@@ -17,4 +17,13 @@ Tally
 Dyadic
 ******
 
+******
+Tables
+******
 
+Write markdown table in RST file.
+
+| fruit | color | startswith |
+| ----- | ----- | ---------- |
+| apples | red | a |
+| oranges | orange | o |


### PR DESCRIPTION
tldr; We can now use markdown table syntax in RST file. Command for building docs is same as before (i.e. ``cmake -G \"Ninja Multi-Config\" -B build -DDOCS:STRING=YES && ninja -C build -f build-Release.ninja``). This was achieved by modifying cmake docs command from `` ${SPHINX_EXECUTABLE} -b html`` to ``${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/preprocessor.py --input ${SPHINX_SOURCE} --output ${SPHINX_SOURCE}/__output__ && ${SPHINX_EXECUTABLE} -b html``. Preprocessor may be useful for other custom RST syntax in future. Additional RST parsing can be added to ``docs/scripts/preprocessor.py`` in future.

Resolves https://github.com/codereport/jsource/issues/120.

Now, we can write tables in RST file using markdown syntax. This is pretty much as simple as it can get re. writing the tables. Supporting this requires additional step before the docs build, because markdown syntax isn't allowed in final RST file.

```rst

Verbs
=====
.. toctree::
.. contents::
   
*******
Monadic
*******

Tally
#####

.. doxygenfunction:: tally

******
Dyadic
******

******
Tables
******

Write markdown table in RST file.

| fruit | color | startswith |
| ----- | ----- | ---------- |
| apples | red | a |
| oranges | orange | o |
```

So, when building the docs, I added a preprocessor step (to existing CMAKE build docs command). The preprocessor scans all the RST files and creates parsed copy of each RST file in ``docs/source__out__``. I have added that folder to ``.gitignore``.

For above example, the parsed RST would be:

```rst

Verbs
=====
.. toctree::
.. contents::
   
*******
Monadic
*******

Tally
#####

.. doxygenfunction:: tally

******
Dyadic
******

******
Tables
******

Write markdown table in RST file.

======= ====== ==========
fruit   color  startswith
======= ====== ==========
apples  red    a         
oranges orange o         
======= ====== ==========
```

Notice that markdown table has been replaced with valid RST (type 2) table. 

Then after building you will get a nice table.

![Screenshot_2021-02-07_13-04-13](https://user-images.githubusercontent.com/4649987/107155212-19b6c380-6945-11eb-907d-6c697e7c4ff8.png)
