### PR TITLE
Fix compiling in GCC 8+ -Wno-cast-function-type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,10 @@ add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=sequence-point>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=strict-overflow>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=logical-not-parentheses>)
-add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=cast-function-type>)
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
+    # this warning was added in gcc 8 https://debarshiray.wordpress.com/2019/04/01/about-wextra-and-wcast-function-type/
+    add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=cast-function-type>)
+endif ()
 
 # Enable warnings
 add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wall>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,9 @@ add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=strict-overflow>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=logical-not-parentheses>)
 if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
     # this warning was added in gcc 8 https://debarshiray.wordpress.com/2019/04/01/about-wextra-and-wcast-function-type/
-    add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=cast-function-type>)
+
+    add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-cast-function-type>) #disable warning
+    # add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=cast-function-type>) #disable errors from warning
 endif ()
 
 # Enable warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=sequence-point>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=strict-overflow>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=logical-not-parentheses>)
+add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=cast-function-type>)
 
 # Enable warnings
 add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wall>)


### PR DESCRIPTION
adding this exception for the werror lets me compile again on gcc10

i think this resolves https://github.com/codereport/jsource/issues/126 ?