### PR TITLE
Remove some non-portable headers

### DIFF
--- a/jsrc/fnmatch.h
+++ b/jsrc/fnmatch.h
@@ -45,10 +45,6 @@
 #define	FNM_PATHNAME	0x02	/* Slash must be matched by slash. */
 #define	FNM_PERIOD	0x04	/* Period must be matched by period. */
 
-#include <sys/cdefs.h>
-
-__BEGIN_DECLS
-int	 fnmatch __P((const char *, const char *, int));
-__END_DECLS
+int fnmatch (const char *, const char *, int);
 
 #endif /* !_FNMATCH_H_ */

--- a/jsrc/io.c
+++ b/jsrc/io.c
@@ -114,7 +114,6 @@ A recursive JDo may use a DD, but only if it is fully contained in the string
 
 #include <stdlib.h>
 #include <stdio.h>
-#include <sys/types.h>
 #include <fcntl.h>
 #include <ctype.h>
 #include <unistd.h>

--- a/jsrc/io.c
+++ b/jsrc/io.c
@@ -115,7 +115,6 @@ A recursive JDo may use a DD, but only if it is fully contained in the string
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <ctype.h>
 #include <unistd.h>

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -16,7 +16,6 @@
 #define __GNUC_PATCHLEVEL__ 1
 #endif
 
-#include <memory.h>
 #include <sys/types.h>
 
 #include <stdint.h>

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -16,7 +16,6 @@
 #define __GNUC_PATCHLEVEL__ 1
 #endif
 
-#include <sys/types.h>
 
 #include <stdint.h>
 #include <float.h>

--- a/jsrc/jconsole.c
+++ b/jsrc/jconsole.c
@@ -11,9 +11,6 @@
 #include <signal.h>
 #include <stdint.h>
 #include <locale.h>
-#ifdef __MACH__
-#include <xlocale.h>
-#endif
 
 #include "j.h"
 #include "jeload.h"

--- a/jsrc/jt.h
+++ b/jsrc/jt.h
@@ -3,8 +3,6 @@
 /*                                                                         */
 /* Definitions for jt ("jthis")                                            */
 
-#include <sys/stat.h>
-
 /*
 All allocated and variable data for a J instance is accessed through its JST structure.
 

--- a/jsrc/xenos/x.c
+++ b/jsrc/xenos/x.c
@@ -3,8 +3,6 @@
 /*                                                                         */
 /* Xenos aka Foreign: External, Experimental, & Extra                      */
 
-#include <unistd.h>
-
 #include "j.h"
 #include "x.h"
 

--- a/jsrc/xenos/x.c
+++ b/jsrc/xenos/x.c
@@ -3,7 +3,6 @@
 /*                                                                         */
 /* Xenos aka Foreign: External, Experimental, & Extra                      */
 
-#include <sys/types.h>
 #include <unistd.h>
 
 #include "j.h"

--- a/jsrc/xenos/x15.c
+++ b/jsrc/xenos/x15.c
@@ -41,7 +41,6 @@ otherwise the regs may be used and the parameter lost.
 
 
 #include <stdlib.h>
-#include <unistd.h>
 typedef unsigned char       BYTE;
 #define CALLBACK
 #include <stdint.h>

--- a/jsrc/xenos/x15.c
+++ b/jsrc/xenos/x15.c
@@ -64,10 +64,9 @@ typedef double complex double_complex;
 
 #include <dlfcn.h>
 
-#undef MAX     /* defined in sys/param.h */
-#undef MIN     /* defined in sys/param.h */
-
-#include <sys/param.h>
+I max(I a, I b) {
+  return a > b ? a : b;
+}
 
 typedef void *HMODULE;
 typedef char *LPSTR;
@@ -890,11 +889,11 @@ static B jtcdexec1(J jt,CCT*cc,C*zv0,C*wu,I wk,I wt,I wd){A*wv=(A*)wu,x,y,*zv;B 
  C* enda=&CAV(a)[AN(a)]; C endc=*enda; *enda=0; cc=jtcdparse(jt,a,0); *enda=endc; RZ(cc); // should do outside rank2 loop?
  n=cc->n;
  I nn; CDASSERT(n==SHAPEN(w,wr-1,nn),DECOUNT);
- if(cc->zbx){GATV(z,BOX,m*(1+n),MAX(1,wr),ws); AS(z)[AR(z)-1]=1+n;}
- else{CDASSERT('*'!=cc->zl,DEDEC); GA(z,cc->zt,m,MAX(0,wr-1),ws);}
+ if(cc->zbx){GATV(z,BOX,m*(1+n),max(1,wr),ws); AS(z)[AR(z)-1]=1+n;}
+ else{CDASSERT('*'!=cc->zl,DEDEC); GA(z,cc->zt,m,max(0,wr-1),ws);}
  // z is always nonrecursive
  if(m&&n&&!(wt&BOX)){
-  t=0; tv=cc->tletter; DQ(n, k=cdjtype(*tv++); t=MAX(t,k););
+  t=0; tv=cc->tletter; DQ(n, k=cdjtype(*tv++); t=max(t,k););
   CDASSERT(HOMO(t,wt),DEPARM);
   if(!(wt&B01+INT+FL+LIT+C2T+C4T))RZ(w=jtcvt(jt,wt=t,w));
  }

--- a/jsrc/xenos/xd.c
+++ b/jsrc/xenos/xd.c
@@ -4,7 +4,6 @@
 /* Xenos: file directory, attributes, & permission                         */
 
 
-#include <sys/types.h>
 #include <unistd.h>
 
 #include "j.h"

--- a/jsrc/xenos/xf.c
+++ b/jsrc/xenos/xf.c
@@ -11,7 +11,6 @@
 #include <dlfcn.h>
 #endif
 
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fts.h>

--- a/jsrc/xenos/xf.c
+++ b/jsrc/xenos/xf.c
@@ -10,7 +10,9 @@
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #endif
+
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <fts.h>
 

--- a/jsrc/xenos/xf.c
+++ b/jsrc/xenos/xf.c
@@ -11,6 +11,7 @@
 #include <dlfcn.h>
 #endif
 
+#include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fts.h>

--- a/jsrc/xenos/xl.c
+++ b/jsrc/xenos/xl.c
@@ -15,9 +15,6 @@ typedef long long INT64;
 #define LOCK 1
 #include <unistd.h>
 #include <fcntl.h>
-#include <sys/file.h>
-
-// extern int _locking(int,int,long);
 
 static B jtdolock(J jt,B lk,F f,I i,I n){I e;long c;fpos_t v; fpos_t q;
  c=fgetpos(f,(fpos_t*)&q);


### PR DESCRIPTION
This removes or reduces the scope of some non-portable headers. They were either unused or easy to replace.

I will create an issue for the rest of the non-portable headers I found.