### PR TITLE
Fix build for mac

### DIFF
--- a/jsrc/jconsole.c
+++ b/jsrc/jconsole.c
@@ -161,9 +161,8 @@ int main(int argc, char* argv[])
  printf("Hello YouTube Viewers, all 22 of you!\n");
 
  setlocale(LC_ALL, "");
+ setlocale(LC_NUMERIC, "C");
 
- locale_t loc;
- if ((loc = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0))) uselocale(loc);
  void* callbacks[] ={Joutput,0,Jinput,0,(void*)SMCON}; int type;
  int i,poslib=0,poslibpath=0,posnorl=0,posprmpt=0; // assume all absent
  for(i=1;i<argc;i++){
@@ -233,6 +232,5 @@ int main(int argc, char* argv[])
  jefirst(type,input);
  while(1){jedo((char*)Jinput(jt,(forceprmpt||_isatty(_fileno(stdin)))?(C*)"   ":(C*)""));}
  jefree();
- if(loc)freelocale(loc);
  return 0;
 }

--- a/jsrc/verbs/vfrom.c
+++ b/jsrc/verbs/vfrom.c
@@ -209,11 +209,10 @@ static B jtaindex1(J jt,A a,A w,I wf,A*ind){A z;I c,i,k,n,t,*v,*ws;
  PROD(n,AR(a)-1,AS(a));  v=AV(a); // n now=number of 1-cells of a   v=running pointer through a
  // Go through a fast verification pass.  If all values nonnegative and valid, return original a
  if(t&INT){  // if it's INT already, we don't need to move it.
-  switch(c){I c0,c1,c2;
+  switch(c){
   case 2:
-   c0=ws[0], c1=ws[1]; break;
   case 3:
-   c0=ws[0], c1=ws[1], c2=ws[2]; break;
+   i = 0; break;
   default:
    for(i=n;i>0;--i){DO(c, k=*v; ++v;); if(k<0)break;} break; 
   }


### PR DESCRIPTION
I had couple of errors building this on mac, this should fix those. I'm not 100% sure if the locale change is equivalent to the previous, but at least locally the tests passed.

- `newlocale`, `uselocale` and `locale_t` were defined in `xlocale.h`
  - replaced with `setlocale(LC_NUMERIC, "C")`

- `jsrc/verbs/vfrom.c` used `i` uninitialised in some cases
  - set `i = 0` in those cases, as the loops would have done previously
  - also removed unused assignments and variables