### PR TITLE
Use correct variable name in TODO message

### DIFF
--- a/jsrc/verbs/dyadic/take_drop.cpp
+++ b/jsrc/verbs/dyadic/take_drop.cpp
@@ -86,7 +86,7 @@ jttks(J jt, array a, array w) { // take_sparse
     else
         x = SPA(wp, x);
     
-    // TODO: rename b when we figure out what it is doing
+    // TODO: rename c when we figure out what it is doing
     if (auto const c = std::mismatch(u, u + m, s).first != u + m; c) {
         A j;
         C *xv, *yv;


### PR DESCRIPTION
There is no mention of `b` in the related statement, but it does introduce `c`. It looks very much like like a copy-paste of a few lines above, where the update of the variable name has been forgotten.