### PR TITLE
Remove unused macro two_to_the_31

### DIFF
--- a/jsrc/verbs/vrand.c
+++ b/jsrc/verbs/vrand.c
@@ -46,7 +46,6 @@ lcg(I n, I* v, I seed) {
 #define GBN 56
 
 #define mod_diff(x, y) (((x) - (y)) & 0x7fffffffL) /* difference modulo 2^31 */
-#define two_to_the_31 (0x80000000L)
 
 static UI
 jtgb_flip_cycle(J jt) {


### PR DESCRIPTION
Thank you compiler for pointing that out ;)
```
[68/131] Building C object jsrc/CMakeFiles/j.dir/Debug/verbs/vrand.c.o
../jsrc/verbs/vrand.c:49: warning: macro "two_to_the_31" is not used [-Wunused-macros]
   49 | #define two_to_the_31 (0x80000000L)
```