### PR TITLE
Add workaround for compile error on stricter C++ compilers

### DIFF
--- a/jsrc/CMakeLists.txt
+++ b/jsrc/CMakeLists.txt
@@ -91,6 +91,7 @@ target_sources(j PRIVATE
         i.c
         io.c
         j.c
+        ja_wrappers.c
         jdlllic.c
         k.c
         m.c

--- a/jsrc/ja_wrappers.c
+++ b/jsrc/ja_wrappers.c
@@ -1,0 +1,11 @@
+#include "j.h"
+#include "ja.h"
+#include "ja_wrappers.h"
+
+A jtirs2_wrap_dyadic(J jt, A a, A w, A fs, I l, I r, AD* (*f2)(J, A, A)) {
+    return jtirs2(jt, a, w, fs, l, r, (AF)f2);
+}
+
+A jtrank2ex_wrap_dyadic(J jt, AD *RESTRICT a, AD *RESTRICT w, A fs, I lr, I rr, I lcr, I rcr, AD* (*f2)(J, A, A)) {
+    return jtrank2ex(jt, a, w, fs, REX2R(lr, rr, lcr, rcr), (AF)f2);
+}

--- a/jsrc/ja_wrappers.h
+++ b/jsrc/ja_wrappers.h
@@ -1,0 +1,12 @@
+/* Wrappers for stricter C++ compilers */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+A jtirs2_wrap_dyadic(J jt, A a, A w, A fs, I l, I r, AD* (*f2)(J, A, A));
+A jtrank2ex_wrap_dyadic(J jt, AD *RESTRICT a, AD *RESTRICT w, A fs, I lr, I rr, I lcr, I rcr, AD* (*f2)(J, A, A));
+
+#ifdef __cplusplus
+}
+#endif

--- a/jsrc/verbs/dyadic/take_drop.cpp
+++ b/jsrc/verbs/dyadic/take_drop.cpp
@@ -4,6 +4,8 @@
 
 #include "array.hpp"
 
+#include "ja_wrappers.h"
+
 /** @file */
 
 A
@@ -79,7 +81,7 @@ jttks(J jt, array a, array w) { // take_sparse
 
     if (b) {
         jt->fill = SPA(wp, e);
-        x        = jtirs2(jt, jtvec(jt, INT, r - m, m + u), SPA(wp, x), 0L, 1L, -1L, reinterpret_cast<AF>(jttake));
+        x        = jtirs2_wrap_dyadic(jt, jtvec(jt, INT, r - m, m + u), SPA(wp, x), 0L, 1L, -1L, jttake);
         jt->fill = 0;
         RZ(x);
     }  // fill cannot be virtual
@@ -213,7 +215,7 @@ jttake(J jt, A a, A w) {
     wf  = wr - wcr;
     RESETRANK;
     if (((af - 1) & (acr - 2)) >= 0) {
-        s = rank2ex(a, w, UNUSED_VALUE, MIN(acr, 1), wcr, acr, wcr, reinterpret_cast<AF>(jttake));  // if multiple x values, loop over them
+        s = jtrank2ex_wrap_dyadic(jt, a, w, UNUSED_VALUE, MIN(acr, 1), wcr, acr, wcr, jttake);  // if multiple x values, loop over them
                                                                               // af>0 or acr>1
         // We extracted from w, so mark it (or its backer if virtual) non-pristine.  There may be replication (if there
         // was fill), so we don't pass pristinity through  We overwrite w because it is no longer in use
@@ -314,7 +316,7 @@ jtdrop(J jt, A a, A w) {
     // special case: if a is atomic 0, and cells of w are not atomic
     if ((-wcr & (ar - 1)) < 0 && (IAV(a)[0] == 0)) return w;  // 0 }. y, return y
     if (((af - 1) & (acr - 2)) >= 0) {
-        s = rank2ex(a, w, UNUSED_VALUE, MIN(acr, 1), wcr, acr, wcr, reinterpret_cast<AF>(jtdrop));  // if multiple x values, loop over them
+        s = jtrank2ex_wrap_dyadic(jt, a, w, UNUSED_VALUE, MIN(acr, 1), wcr, acr, wcr, jtdrop);  // if multiple x values, loop over them
                                                                               // af>0 or acr>1
         // We extracted from w, so mark it (or its backer if virtual) non-pristine.  There may be replication, so we
         // don't pass pristinity through  We overwrite w because it is no longer in use
@@ -427,7 +429,7 @@ jthead(J jt, A w) {
             return jtfrom(jtinplace, zeroionei(0), w);  // could call jtfromi directly for non-sparse w
         }
     } else {
-        return SPARSE & AT(w) ? jtirs2(jt, num(0), jttake(jt, num(1), w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))
+        return SPARSE & AT(w) ? jtirs2_wrap_dyadic(jt, num(0), jttake(jt, num(1), w), 0L, 0L, wcr, jtfrom)
                               : jtrsh0(jt, w);  // cell of w is empty - create a cell of fills  jt->ranks is still set
                                                 // for use in take.  Left rank is garbage, but that's OK
     }
@@ -445,7 +447,7 @@ jttail(J jt, A w) {
     return !wcr || AS(w)[wf] ? jtfrom(jtinplace, num(-1), w)
                              :  // if cells are atoms, or if the cells are nonempty arrays, result is last cell(s) scaf
                                 // should generate virtual block here for speed
-             SPARSE & AT(w) ? jtirs2(jt, num(0), jttake(jt, num(-1), w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))
+             SPARSE & AT(w) ? jtirs2_wrap_dyadic(jt, num(0), jttake(jt, num(-1), w), 0L, 0L, wcr, jtfrom)
                             : jtrsh0(jt, w);
     // pristinity from other verbs
 }


### PR DESCRIPTION
G++ 10.2 triggered this problem, but there might be more. To work around
this problem, create a C file that does the casting and call that
instead.

This fixes my build problems described in #162, but it feels like a terrible hack.