### PR TITLE
Add Ruby example to code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Calculating the first 10 odd numbers:
 |C++|`transform(iota(0, 10), [](auto e) { return e * 2 + 1; })`|[Godbolt](https://godbolt.org/z/5r7aEo)|
 |C#|`Enumerable.Range(0, 10).Select((int i) => { return i * 2 + 1; })`||
 |Java|`IntStream.range(0, 10).map(x -> x * 2 + 1).toArray();`||
+|Ruby|`(0..9).map { \|i\| i * 2 + 1 }`|[Try It Online](https://tio.run/##KypNqvz/v0BBw0BPz1JTLzexQKFaoSazRiFTQUvBSEFbwVCh9v9/AA)|
 
 ## Getting started & Building:
 For building this repository, please see [`CONTRIBUTING.md`](https://github.com/codereport/jsource/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
The way Ruby code uses anonymous lambdas is visually pretty different
from the listed code snippets. This might make the behaviour a bit more
clear for people mainly using Ruby. And personally, I think the syntax
is pretty neat.