### PR TITLE
Refactor Bnum lookups

### DIFF
--- a/jsrc/adverbs/a.c
+++ b/jsrc/adverbs/a.c
@@ -65,7 +65,7 @@ jtbdot2(J jt, A a, A w, A self) {
 
 static A
 jtbdot1(J jt, A w, A self) {
-    return jtbdot2(jt, num(0), w, self);
+    return jtbdot2(jt, jfalse, w, self);
 }
 
 static A

--- a/jsrc/adverbs/ab.c
+++ b/jsrc/adverbs/ab.c
@@ -162,7 +162,7 @@ BITWISE(jtbitwiseshifta, I, BWSHIFTA)
 
 A
 jtbitwise1(J jt, A w, A self) {
-    return CALL2(FAV(self)->valencefns[1], zeroionei(0), w, self);
+    return CALL2(FAV(self)->valencefns[1], num(0), w, self);
 }  // inplaceable - don't touch jt
 
 static AHDR2FN* bwC[16] = {(AHDR2FN*)bw0000CC,

--- a/jsrc/adverbs/af.c
+++ b/jsrc/adverbs/af.c
@@ -248,7 +248,7 @@ jtfixa(J jt, A a, A w) {
     }
 } /* 0=a if fix names; 1=a if fix names only if does not contain $: */
 
-// On internal calls, self is an integer whose value contains flags.  Otherwise zeroionei is used
+// On internal calls, self is an integer whose value contains flags.  Otherwise num is used
 A
 jtfix(J jt, A w, A self) {
     PROLOG(0005);
@@ -259,7 +259,7 @@ jtfix(J jt, A w, A self) {
     }
     // only verbs/noun can get in through the parser, but internally we also vet adv/conj
     ASSERT(AT(w) & NAME + VERB + ADV + CONJ, EVDOMAIN);
-    self = AT(self) & NOUN ? self : zeroionei(0);  // default to 0 if noun not given
+    self = AT(self) & NOUN ? self : num(0);  // default to 0 if noun not given
     // To avoid infinite recursion we keep an array of names that we have looked up.  We create that array here,
     // initialized to empty.  To pass it into fixa, we create a faux INT block to hold the value, and use AM in that
     // block to point to the list of names

--- a/jsrc/adverbs/ai.c
+++ b/jsrc/adverbs/ai.c
@@ -52,7 +52,7 @@ jtinvfork(J jt, A w) {
     c = 1 && NOUN & AT(f);
     b = c || consf(f);
     ASSERT(b != consf(h), EVDOMAIN);
-    RZ(k = c ? f : df1(gi, num(0), b ? f : h));
+    RZ(k = c ? f : df1(gi, jfalse, b ? f : h));
     RZ(gi = invrecur(b ? jtamp(jt, k, g) : jtamp(jt, g, k)));
     RZ(fi = invrecur(b ? h : f));
     if (CAMP == ID(gi)) {
@@ -117,7 +117,7 @@ jtbminv(J jt, A w) {
     ws = AS(w);
     wv = AAV(w);
     if (1 >= wr) return jtraze(jt, w);
-    if (!wn) return jtiota(jt, jtreshape(jt, jtsc(jt, wr), num(0)));
+    if (!wn) return jtiota(jt, jtreshape(jt, jtsc(jt, wr), jfalse));
     GATV0(x, INT, wr, 1);
     u = AV(x);
     memset(u, C0, wr * SZI);
@@ -310,7 +310,7 @@ jtinvamp(J jt, A w) {
             }
             break;
         case CQQ:
-            if (ng && jtequ(jt, x, num(1)) && jtequ(jt, f, jteval(jt, "i.\"1"))) return jthook(jt, ds(CFROM), ds(CEQ));
+            if (ng && jtequ(jt, x, jtrue) && jtequ(jt, f, jteval(jt, "i.\"1"))) return jthook(jt, ds(CFROM), ds(CEQ));
             break;
         case CBSLASH:
             if (nf && (n = jti0(jt, x), 0 > n) && (d = ID(u->fgh[0]), (d & -2) == CLEFT))
@@ -478,7 +478,7 @@ jtinv(J jt, A w, I recur) {
             p = jti0(jt, f);
             q = jti0(jt, g);
             if (3 == p && 1 == q) return jtforeign(jt, f, num(2));
-            if (3 == p && 2 == q) return jtforeign(jt, f, num(1));
+            if (3 == p && 2 == q) return jtforeign(jt, f, jtrue);
             if (3 == p && 3 == q) return jtforeign(jt, f, num(2));
             break;
         case CHOOK:
@@ -512,11 +512,11 @@ jtneutral(J jt, A w) {
     x = zeroionei(0);
     b = jtequ(jt, y, CALL2(v->valencefns[1], x, y, w));
     RESETERR;
-    if (b) return num(0);
+    if (b) return jfalse;
     x = zeroionei(1);
     b = jtequ(jt, y, CALL2(v->valencefns[1], x, y, w));
     RESETERR;
-    if (b) return num(1);
+    if (b) return jtrue;
     RZ(x = jtscf(jt, infm));
     b = jtequ(jt, y, CALL2(v->valencefns[1], y, x, w));
     RESETERR;
@@ -528,11 +528,11 @@ jtneutral(J jt, A w) {
     x = zeroionei(0);
     b = jtequ(jt, y, CALL2(v->valencefns[1], y, x, w));
     RESETERR;
-    if (b) return num(0);
+    if (b) return jfalse;
     x = zeroionei(1);
     b = jtequ(jt, y, CALL2(v->valencefns[1], y, x, w));
     RESETERR;
-    if (b) return num(1);
+    if (b) return jtrue;
     ASSERT(0, EVDOMAIN);
 } /* neutral of arbitrary rank-0 function */
 
@@ -565,7 +565,7 @@ jtiden(J jt, A w) {
         case CLT:
         case CPLUSDOT:
         case CJDOT:
-        case CRDOT: x = num(0); break;
+        case CRDOT: x = jfalse; break;
         case CSTAR:
         case CDIV:
         case CEXP:
@@ -574,7 +574,7 @@ jtiden(J jt, A w) {
         case CEQ:
         case CGE:
         case CLE:
-        case CSTARDOT: x = num(1); break;
+        case CSTARDOT: x = jtrue; break;
         case CMAX: x = jtscf(jt, infm); break;
         case CMIN: x = ainf; break;
         case CUNDER:;
@@ -585,8 +585,8 @@ jtiden(J jt, A w) {
             if (CAMP == ID(f) && (u = FAV(f), NOUN & AT(u->fgh[0]) && !AR(u->fgh[0]) && CSTILE == ID(u->fgh[1])))
                 switch (ID(g)) {
                     case CSTAR:
-                    case CEXP: x = num(1); break;
-                    case CPLUS: x = num(0);
+                    case CEXP: x = jtrue; break;
+                    case CPLUS: x = jfalse;
                 }
             break;
         case CBDOT:;  // canned inverses for (bt b.)

--- a/jsrc/adverbs/ai.c
+++ b/jsrc/adverbs/ai.c
@@ -256,7 +256,7 @@ jtinvamp(J jt, A w) {
         case CQCO:
             if (nf) {
                 ASSERT(!AR(x), EVRANK);
-                return jtobverse(jt, jteval(jt, all1(lt(x, zeroionei(0))) ? "*/@(^/)\"2" : "(p:@i.@# */ .^ ])\"1"), w);
+                return jtobverse(jt, jteval(jt, all1(lt(x, num(0))) ? "*/@(^/)\"2" : "(p:@i.@# */ .^ ])\"1"), w);
             }
             break;
         case CFIT:
@@ -351,7 +351,7 @@ jtinvamp(J jt, A w) {
             break;
         case CPOLY:
             if (nf && 1 == AR(x) && 2 == AN(x) && NUMERIC & AT(x) &&
-                !jtequ(jt, zeroionei(0), jttail(jt, x))) {  // linear polynomial only
+                !jtequ(jt, num(0), jttail(jt, x))) {  // linear polynomial only
                 RZ(y = jtrecip(jt, jttail(jt, x)));
                 return jtamp(jt, apip(tymes(y, jtnegate(jt, jthead(jt, x))), y), h);
             }
@@ -489,7 +489,7 @@ jtinv(J jt, A w, I recur) {
     // But only fix once, at the top recursion level, (1) to avoid an infinite loop if
     // there is a circular reference that leaves names in the fixed form of w; (2) to avoid
     // repeated fixing of lower branches, which will only be tried again when higher levels are fixed
-    if (!recur && !nameless(w)) return invrecur(jtfix(jt, w, zeroionei(0)));
+    if (!recur && !nameless(w)) return invrecur(jtfix(jt, w, num(0)));
     ASSERT(0, EVDOMAIN);
 }
 
@@ -509,11 +509,11 @@ jtneutral(J jt, A w) {
     b = jtequ(jt, y, CALL2(v->valencefns[1], x, y, w));
     RESETERR;
     if (b) return x;
-    x = zeroionei(0);
+    x = num(0);
     b = jtequ(jt, y, CALL2(v->valencefns[1], x, y, w));
     RESETERR;
     if (b) return jfalse;
-    x = zeroionei(1);
+    x = num(1);
     b = jtequ(jt, y, CALL2(v->valencefns[1], x, y, w));
     RESETERR;
     if (b) return jtrue;
@@ -525,11 +525,11 @@ jtneutral(J jt, A w) {
     b = jtequ(jt, y, CALL2(v->valencefns[1], y, x, w));
     RESETERR;
     if (b) return x;
-    x = zeroionei(0);
+    x = num(0);
     b = jtequ(jt, y, CALL2(v->valencefns[1], y, x, w));
     RESETERR;
     if (b) return jfalse;
-    x = zeroionei(1);
+    x = num(1);
     b = jtequ(jt, y, CALL2(v->valencefns[1], y, x, w));
     RESETERR;
     if (b) return jtrue;
@@ -540,7 +540,7 @@ A
 jtiden(J jt, A w) {
     A f, g, x = 0;
     V *u, *v;
-    RZ(w = jtfix(jt, w, zeroionei(0)));
+    RZ(w = jtfix(jt, w, num(0)));
     ASSERT(VERB & AT(w), EVDOMAIN);
     v = FAV(w);
     f = v->fgh[0];
@@ -611,7 +611,7 @@ A
 jtidensb(J jt, A w) {
     A f, g, x = 0, w0 = w;
     V* v;
-    RZ(w = jtfix(jt, w, zeroionei(0)));
+    RZ(w = jtfix(jt, w, num(0)));
     ASSERT(VERB & AT(w), EVDOMAIN);
     v = FAV(w);
     f = v->fgh[0];

--- a/jsrc/adverbs/ai.c
+++ b/jsrc/adverbs/ai.c
@@ -599,7 +599,7 @@ jtiden(J jt, A w) {
                 bi = -1;
                 bi = INV0 & (1LL << bt) ? 0 : bi;
                 bi = INV1 & (1LL << bt) ? 1 : bi;
-                x  = num(bi);
+                x  = numbool(bi);
             }
             break;
     }

--- a/jsrc/adverbs/am.c
+++ b/jsrc/adverbs/am.c
@@ -431,7 +431,7 @@ jtjstd(J jt, A w, A ind, I *cellframelen) {
     ws = AS(w);
     b  = -AN(ind) & SGNIF(AT(ind), BOXX);  // b<0 = indexes are boxed and nonempty
     if (!wr) {
-        x             = jtfrom(jt, ind, zeroionei(0));
+        x             = jtfrom(jt, ind, num(0));
         *cellframelen = 0;
         return x;
     }                                // if w is an atom, the best you can get is indexes of 0.  No axes are used
@@ -466,7 +466,7 @@ jtjstd(J jt, A w, A ind, I *cellframelen) {
         ASSERT(1 >= r, EVINDEX);                             // not a table
         ASSERT(n <= wr, EVINDEX);                            // not too many axes
         DQ(n, if (!jtequ(jt, ds(CACE), v[i])) break; --n;);  // discard trailing (boxed) empty axes
-        j = zeroionei(0);                                    // init list to a single 0 offset
+        j = num(0);                                          // init list to a single 0 offset
         for (i = 0; i < n; ++i) {  // for each axis, grow the cartesian product of the specified offsets
             x = v[i];
             d = ws[i];

--- a/jsrc/adverbs/am1.c
+++ b/jsrc/adverbs/am1.c
@@ -257,7 +257,7 @@ jtscube(J jt, A z, A i1, A p) {
     zp = PAV(z);
     a  = SPA(zp, a);
     y  = SPA(zp, i);
-    return !AN(a) && !*AS(y) ? jttake(jt, num(1), mtm) : jtover(jt, jtscubb(jt, z, i1), jtscubc(jt, z, i1, p));
+    return !AN(a) && !*AS(y) ? jttake(jt, jtrue, mtm) : jtover(jt, jtscubb(jt, z, i1), jtscubc(jt, z, i1, p));
 } /* new rows for the index matrix of z */
 
 static A

--- a/jsrc/adverbs/ao.c
+++ b/jsrc/adverbs/ao.c
@@ -277,9 +277,9 @@ jtkeysp(J jt, A a, A w, A self) {
     *AS(q) = n; /* q=: 0 by}1$.n;0;1 */
     p      = PAV(q);
     SPB(p, a, iv0);
-    SPB(p, e, num(1));
+    SPB(p, e, jtrue);
     SPB(p, i, by);
-    SPB(p, x, jtreshape(jt, tally(jt, by), num(0)));
+    SPB(p, x, jtreshape(jt, tally(jt, by), jfalse));
     RZ(z = jtover(jt, df1(b, jtrepeat(jt, q, w), VAV(self)->fgh[0]), x));
     z = j ? jtcdot2(jt, jtbox(jt, IX(1 + j)), z) : z;
     EPILOG(z);

--- a/jsrc/adverbs/ap.c
+++ b/jsrc/adverbs/ap.c
@@ -622,7 +622,7 @@ jtinfix(J jt, A a, A w, A self) {
         // Create fill-cell of shape s; apply u to it
         RZ(df1(x, jtreshape(jt, s, jtfiller(jt, w)), fs));
         // Prepend leading axis of 0 to the result
-        z = jtreshape(jt, jtover(jt, zeroionei(0), shape(jt, x)), x);
+        z = jtreshape(jt, jtover(jt, num(0), shape(jt, x)), x);
     }
     EPILOG(z);
 }
@@ -657,7 +657,7 @@ jtginfix(J jt, A a, A w, A self) {
         RZ(s = AR(w) ? shape(jt, w) : jtca(jt, iv0));
         AV(s)[0] = ABS(m);
         RZ(df1(x, jtreshape(jt, s, jtfiller(jt, w)), *hv));
-        return jtreshape(jt, jtover(jt, zeroionei(0), shape(jt, x)), x);
+        return jtreshape(jt, jtover(jt, num(0), shape(jt, x)), x);
     }
 }
 
@@ -864,14 +864,14 @@ jtinfixprefix2(J jt, A a, A w, A self) {
         // for prefix, 0 items of fill
         // for infix +, invabs items of fill
         // for infix -, 0 items of fill
-        RZ(z = jtreitem(jt, zeroionei(0), w));  // create 0 items of the type of w
+        RZ(z = jtreitem(jt, num(0), w));  // create 0 items of the type of w
         if (ilnval >= 0) {
             ilnval = (ilnval == IMAX) ? (wi + 1) : ilnval;
             RZ(z = jttake(jt, jtsc(jt, ilnval), z));
         }  // if items needed, create them.  For compatibility, treat _ as 1 more than #items in w
         WITHDEBUGOFF(zz = CALL1(f1, z, fs);) if (EMSK(jt->jerr) & EXIGENTERROR) RZ(zz);
         RESETERR;
-        RZ(zz = jtreshape(jt, jtover(jt, zeroionei(0), shape(jt, zz ? zz : mtv)), zz ? zz : zeroionei(0)));
+        RZ(zz = jtreshape(jt, jtover(jt, num(0), shape(jt, zz ? zz : mtv)), zz ? zz : num(0)));
     }
 
     // result is now in zz
@@ -909,7 +909,7 @@ jtpscan(J jt, A w, A self) {
     SETICFR(w, f, r, n);  // wn=0 doesn't matter
     // If there are 0 or 1 items, or w is empty, return the input unchanged, except: if rank 0, return (($w),1)($,)w -
     // if atomic op, do it right here, otherwise call the routine to get the shape of result cell
-    if (((1 - n) & -wn) >= 0) { return r ? w : jtreshape(jt, apip(shape(jt, w), zeroionei(1)), w); }  // n<2 or wn=0
+    if (((1 - n) & -wn) >= 0) { return r ? w : jtreshape(jt, apip(shape(jt, w), num(1)), w); }  // n<2 or wn=0
     VARPS adocv;
     varps(adocv, self, wt, 1);  // fetch info for f/\ and this type of arg
     if (!adocv.f)

--- a/jsrc/adverbs/ar.c
+++ b/jsrc/adverbs/ar.c
@@ -1025,7 +1025,7 @@ jtredcateach(J jt, A w, A self) {
     SETICFR(w, f, r, n);
     if (!r || 1 >= n) return jtreshape(jt, jtrepeat(jt, ne(jtsc(jt, f), IX(wr)), shape(jt, w)), n ? w : ds(CACE));
     if (!(BOX & AT(w)))
-        return df1(z, jtcant2(jt, jtsc(jt, f), w), jtqq(jt, ds(CBOX), zeroionei(1)));  // handle unboxed args
+        return df1(z, jtcant2(jt, jtsc(jt, f), w), jtqq(jt, ds(CBOX), num(1)));  // handle unboxed args
     // bug: ,&.>/ y does scalar replication wrong
     // wv=AN(w)+AAV(w); DQ(AN(w), if(AN(*--wv)&&AR(*wv)&&n1&&n2) ASSERT(0,EVNONCE); if((!AR(*wv))&&n1)n2=1;
     // if(AN(*wv)&&1<AR(*wv))n1=1;);
@@ -1107,7 +1107,7 @@ A
 jtaslash1(J jt, C c, A w) {
     RZ(w);
     A z;
-    return df1(z, w, jtqq(jt, jtslash(jt, ds(c)), zeroionei(1)));
+    return df1(z, w, jtqq(jt, jtslash(jt, ds(c)), num(1)));
 }
 A
 jtatab(J jt, C c, A a, A w) {

--- a/jsrc/adverbs/ar.c
+++ b/jsrc/adverbs/ar.c
@@ -309,12 +309,12 @@ jtredsp1a(J jt, C id, A z, A e, I n, I r, I* s) {
         case CMIN: return n ? minimum(z, e) : jtca(jt, e);
         case CMAX: return n ? maximum(z, e) : jtca(jt, e);
         case CPLUS:
-            if (n && jtequ(jt, e, num(0))) return z;
+            if (n && jtequ(jt, e, jfalse)) return z;
             DO(r, d *= s[i];);
             t = tymes(e, d >= FLIMAX ? jtscf(jt, d - n) : jtsc(jt, (I)d - n));
             return n ? plus(z, t) : t;
         case CSTAR:
-            if (n && jtequ(jt, e, num(1))) return z;
+            if (n && jtequ(jt, e, jtrue)) return z;
             DO(r, d *= s[i];);
             t = expn2(e, d >= FLIMAX ? jtscf(jt, d - n) : jtsc(jt, (I)d - n));
             return n ? tymes(z, t) : t;
@@ -405,18 +405,18 @@ jtredspd(J jt, A w, A self, C id, VARPSF ado, I cv, I f, I r, I zt) {
     RE(0);
     switch (id) {
         case CPLUS:
-            if (!jtequ(jt, e, num(0))) RZ(e = tymes(e, jtsc(jt, n)));
+            if (!jtequ(jt, e, jfalse)) RZ(e = tymes(e, jtsc(jt, n)));
             break;
         case CSTAR:
-            if (!jtequ(jt, e, num(1)) && !jtequ(jt, e, num(0))) RZ(e = expn2(e, jtsc(jt, n)));
+            if (!jtequ(jt, e, jtrue) && !jtequ(jt, e, jfalse)) RZ(e = expn2(e, jtsc(jt, n)));
             break;
         case CEQ:
             ASSERT(B01 & AT(x), EVNONCE);
-            if (!BAV(e)[0] && 0 == (n & 1)) e = num(1);
+            if (!BAV(e)[0] && 0 == (n & 1)) e = jtrue;
             break;
         case CNE:
             ASSERT(B01 & AT(x), EVNONCE);
-            if (BAV(e)[0] && 1 == (n & 1)) e = num(0);
+            if (BAV(e)[0] && 1 == (n & 1)) e = jfalse;
     }
     if (TYPESNE(AT(e), AT(zx))) {
         t = jtmaxtype(jt, AT(e), AT(zx));
@@ -490,11 +490,11 @@ jtredspsprep(J jt, C id, I f, I zt, A a, A e, A x, A y, I* zm, I** zdv, B** zpv,
     }
     switch (id) {
         case CPLUS:
-        case CPLUSDOT: j = !jtequ(jt, e, num(0)); break;
+        case CPLUSDOT: j = !jtequ(jt, e, jfalse); break;
         case CSTAR:
-        case CSTARDOT: j = !jtequ(jt, e, num(1)); break;
-        case CMIN: j = !jtequ(jt, e, zt & B01 ? num(1) : zt & INT ? jtsc(jt, IMAX) : ainf); break;
-        case CMAX: j = !jtequ(jt, e, zt & B01 ? num(0) : zt & INT ? jtsc(jt, IMIN) : jtscf(jt, infm)); break;
+        case CSTARDOT: j = !jtequ(jt, e, jtrue); break;
+        case CMIN: j = !jtequ(jt, e, zt & B01 ? jtrue  : zt & INT ? jtsc(jt, IMAX) : ainf); break;
+        case CMAX: j = !jtequ(jt, e, zt & B01 ? jfalse : zt & INT ? jtsc(jt, IMIN) : jtscf(jt, infm)); break;
         case CEQ: j = !*BAV(e); break;
         case CNE: j = *BAV(e); break;
     }
@@ -513,7 +513,7 @@ jtredspse(J jt, C id, I wm, I xt, A e, A zx, A sn, A* ze, A* zzx) {
     A b;
     B nz;
     I t, zt;
-    RZ(b = ne(num(0), sn));
+    RZ(b = ne(jfalse, sn));
     nz = !all0(b);
     zt = AT(zx);
     switch (id) {
@@ -526,10 +526,10 @@ jtredspse(J jt, C id, I wm, I xt, A e, A zx, A sn, A* ze, A* zzx) {
             RZ(e = jtbcvt(jt, 1, expn2(e, jtsc(jt, wm))));
             break;
         case CPLUSDOT:
-            if (nz) RZ(zx = gcd(zx, jtfrom(jt, b, jtover(jt, num(0), e))));
+            if (nz) RZ(zx = gcd(zx, jtfrom(jt, b, jtover(jt, jfalse, e))));
             break;
         case CSTARDOT:
-            if (nz) RZ(zx = lcm(zx, jtfrom(jt, b, jtover(jt, num(1), e))));
+            if (nz) RZ(zx = lcm(zx, jtfrom(jt, b, jtover(jt, jtrue, e))));
             break;
         case CMIN:
             if (nz)
@@ -537,7 +537,7 @@ jtredspse(J jt, C id, I wm, I xt, A e, A zx, A sn, A* ze, A* zzx) {
                                 jtfrom(jt,
                                        b,
                                        jtover(jt,
-                                              zt & B01   ? num(1)
+                                              zt & B01   ? jtrue
                                               : zt & INT ? jtsc(jt, IMAX)
                                                          : ainf,
                                               e))));
@@ -548,20 +548,20 @@ jtredspse(J jt, C id, I wm, I xt, A e, A zx, A sn, A* ze, A* zzx) {
                                 jtfrom(jt,
                                        b,
                                        jtover(jt,
-                                              zt & B01   ? num(0)
+                                              zt & B01   ? jfalse
                                               : zt & INT ? jtsc(jt, IMIN)
                                                          : jtscf(jt, infm),
                                               e))));
             break;
         case CEQ:
             ASSERT(B01 & xt, EVNONCE);
-            if (nz) RZ(zx = eq(zx, eq(num(0), residue(num(2), sn))));
-            if (!(wm & 1)) e = num(1);
+            if (nz) RZ(zx = eq(zx, eq(jfalse, residue(num(2), sn))));
+            if (!(wm & 1)) e = jtrue;
             break;
         case CNE:
             ASSERT(B01 & xt, EVNONCE);
-            if (nz) RZ(zx = ne(zx, eq(num(1), residue(num(2), sn))));
-            if (!(wm & 1)) e = num(0);
+            if (nz) RZ(zx = ne(zx, eq(jtrue, residue(num(2), sn))));
+            if (!(wm & 1)) e = jfalse;
             break;
     }
     if (TYPESNE(AT(e), AT(zx))) {
@@ -687,9 +687,9 @@ jtreducesp(J jt, A w, A self) {
     varps(adocv, self, wt, 0);
     if (2 == n && !(adocv.f && strchr(fca, id))) {
         A x;
-        IRS2(num(0), w, 0L, 0, r, jtfrom, x);
+        IRS2(jfalse, w, 0L, 0, r, jtfrom, x);
         A y;
-        IRS2(num(1), w, 0L, 0, r, jtfrom, y);
+        IRS2(jtrue, w, 0L, 0, r, jtfrom, y);
         return df2(z, x, y, g);  // rank has been reset for this call
     }
     // original rank still set

--- a/jsrc/adverbs/as.c
+++ b/jsrc/adverbs/as.c
@@ -470,8 +470,8 @@ jtomask(J jt, A a, A w) {
     SETIC(w, n);
     r = jtsc(jt, 0 > m ? (n + p - 1) / p : MAX(0, 1 + n - m));
     c = tally(jt, w);
-    x = jtreshape(jt, jtsc(jt, p), num(0));
-    y = jtreshape(jt, 0 > m ? c : r, num(1));
+    x = jtreshape(jt, jtsc(jt, p), jfalse);
+    y = jtreshape(jt, 0 > m ? c : r, jtrue);
     return reshapeW(jtover(jt, r, c), jtover(jt, x, y));
 }
 

--- a/jsrc/adverbs/as.c
+++ b/jsrc/adverbs/as.c
@@ -438,7 +438,7 @@ jtsscan(J jt, A w, A self) {
     y     = FAV(self)->fgh[0];  // y is f/
     if (((n - 2) | (wn - 1)) < 0) {
         if (FAV(FAV(y)->fgh[0])->flag & VISATOMIC2) {
-            return r ? w : jtreshape(jt, apip(shape(jt, w), zeroionei(1)), w);
+            return r ? w : jtreshape(jt, apip(shape(jt, w), num(1)), w);
         } else
             return IRS1(w, self, r, jtsuffix, z);
     }  // if empty arg, or just 1 cell in selected axis, convert to f/\ which handles the short arg

--- a/jsrc/adverbs/au.c
+++ b/jsrc/adverbs/au.c
@@ -105,7 +105,7 @@ jtprimitive(J jt, A w) {
     A x = w;
     V *v;
     v = VAV(w);
-    if (CTILDE == v->id && NOUN & AT(v->fgh[0])) RZ(x = jtfix(jt, w, zeroionei(0)));
+    if (CTILDE == v->id && NOUN & AT(v->fgh[0])) RZ(x = jtfix(jt, w, num(0)));
     return !VAV(x)->fgh[0];
 } /* 1 iff w is a primitive */
 

--- a/jsrc/array.hpp
+++ b/jsrc/array.hpp
@@ -30,11 +30,6 @@ xor_replicate_sign(int64_t x) noexcept -> int64_t {
     return x < 0 ? (-1 * x) - 1 : x;
 }
 
-[[nodiscard]] constexpr auto
-zero_or_one(int64_t n) noexcept -> bool {
-    return n == 0 || n == 1;
-}
-
 // TODO: refactor me
 [[nodiscard]] inline auto
 refactorme_num(int64_t n) {

--- a/jsrc/array.hpp
+++ b/jsrc/array.hpp
@@ -33,6 +33,11 @@ xor_replicate_sign(int64_t x) noexcept -> int64_t {
     return x < 0 ? (-1 * x) - 1 : x;
 }
 
+[[nodiscard]] constexpr auto
+applicable_for_num(int64_t n) noexcept -> bool {
+    return NUMMIN <= n && n <= NUMMAX;
+}
+
 /**
  * @param n C representation of number, valid range [NUMMIN, NUMMAX]
  * @return  The J representation of the integer
@@ -100,7 +105,7 @@ make_array(J jt, int64_t n, rank_t r, shape_t s) -> array {
 template <typename T>
 [[nodiscard]] inline auto
 make_scalar_integer(J jt, T k) -> array {
-    if (xor_replicate_sign(k) <= NUMMAX) return num(k);
+    if (applicable_for_num(k)) return num(k);
     array z = make_array<T, copy_shape_0>(jt, 1, 0);
     set_value_at(z, 0, k);
     return z;

--- a/jsrc/array.hpp
+++ b/jsrc/array.hpp
@@ -33,7 +33,7 @@ xor_replicate_sign(int64_t x) noexcept -> int64_t {
 // TODO: refactor me
 [[nodiscard]] inline auto
 refactorme_num(int64_t n) {
-    return reinterpret_cast<array>(Bnum + 2 + n - NUMMIN);
+    return reinterpret_cast<array>(Bnum + n - NUMMIN);
 }
 
 [[nodiscard]] inline auto

--- a/jsrc/array.hpp
+++ b/jsrc/array.hpp
@@ -41,12 +41,6 @@ refactorme_num(int64_t n) {
     return reinterpret_cast<array>(Bnum + 2 + n - NUMMIN);
 }
 
-// TODO: refactor me
-[[nodiscard]] inline auto
-refactorme_zeroionei(int64_t n) {
-    return reinterpret_cast<array>(Bnum + (n));
-}
-
 [[nodiscard]] inline auto
 pointer_to_values(array x) -> int64_t* {
     return reinterpret_cast<int64_t*>(reinterpret_cast<C*>(x) + x->kchain.k);
@@ -105,7 +99,7 @@ make_array(J jt, int64_t n, rank_t r, shape_t s) -> array {
 template <typename T>
 [[nodiscard]] inline auto
 make_scalar_integer(J jt, T k) -> array {
-    if (xor_replicate_sign(k) <= NUMMAX) return !zero_or_one(k) ? refactorme_num(k) : zeroionei(k);
+    if (xor_replicate_sign(k) <= NUMMAX) return refactorme_num(k);
     array z = make_array<T, copy_shape_0>(jt, 1, 0);
     set_value_at(z, 0, k);
     return z;

--- a/jsrc/array.hpp
+++ b/jsrc/array.hpp
@@ -21,18 +21,6 @@ item_count(array w) {
     return AR(w) ? AS(w)[0] : 1;
 }
 
-// TODO: rename (propogate_sign_bit)
-[[nodiscard]] constexpr inline auto
-replicate_sign(int64_t x) noexcept -> int64_t {
-    return x < 0 ? -1 : 0;
-}
-
-// TODO: rename
-[[nodiscard]] constexpr auto
-xor_replicate_sign(int64_t x) noexcept -> int64_t {
-    return x < 0 ? (-1 * x) - 1 : x;
-}
-
 [[nodiscard]] constexpr auto
 applicable_for_num(int64_t n) noexcept -> bool {
     return NUMMIN <= n && n <= NUMMAX;

--- a/jsrc/array.hpp
+++ b/jsrc/array.hpp
@@ -30,7 +30,10 @@ xor_replicate_sign(int64_t x) noexcept -> int64_t {
     return x < 0 ? (-1 * x) - 1 : x;
 }
 
-// TODO: refactor me
+/**
+ * @param n C representation of number, valid range [NUMMIN, NUMMAX]
+ * @return  The J representation of the integer
+ */
 [[nodiscard]] inline auto
 refactorme_num(int64_t n) {
     return reinterpret_cast<array>(Bnum + n - NUMMIN);

--- a/jsrc/array.hpp
+++ b/jsrc/array.hpp
@@ -5,6 +5,9 @@ extern "C" {
 #include "j.h"
 }
 
+// C macros that have been replaced by C++ inline methods
+#undef num
+
 using array   = A;           // potentially rename to j_array?
 using shape_t = long long*;  // TODO figure out how to turn this into int64_t
 using rank_t  = unsigned short;
@@ -35,8 +38,8 @@ xor_replicate_sign(int64_t x) noexcept -> int64_t {
  * @return  The J representation of the integer
  */
 [[nodiscard]] inline auto
-refactorme_num(int64_t n) {
-    return reinterpret_cast<array>(Bnum + n - NUMMIN);
+num(int64_t n) {
+    return reinterpret_cast<array>(Bnum[n - NUMMIN]);
 }
 
 [[nodiscard]] inline auto
@@ -97,7 +100,7 @@ make_array(J jt, int64_t n, rank_t r, shape_t s) -> array {
 template <typename T>
 [[nodiscard]] inline auto
 make_scalar_integer(J jt, T k) -> array {
-    if (xor_replicate_sign(k) <= NUMMAX) return refactorme_num(k);
+    if (xor_replicate_sign(k) <= NUMMAX) return num(k);
     array z = make_array<T, copy_shape_0>(jt, 1, 0);
     set_value_at(z, 0, k);
     return z;

--- a/jsrc/conjunctions/ca.c
+++ b/jsrc/conjunctions/ca.c
@@ -388,7 +388,7 @@ jtatop(J jt, A a, A w) {
             }
             break;  // f//.@(g/) for atomic fg
         case CQQ:
-            if (d == CTHORN && CEXEC == ID(av->fgh[0]) && av->fgh[1] == num(0)) {
+            if (d == CTHORN && CEXEC == ID(av->fgh[0]) && av->fgh[1] == jfalse) {
                 f1 = jtdigits10;
                 flag &= ~VJTFLGOK1;
             }
@@ -433,8 +433,8 @@ jtatop(J jt, A a, A w) {
             cb   = FAV(av->fgh[0])->id;
             A cr = av->fgh[1];
             cr   = (cb & ~2) == CIOTA ? cr : 0;
-            n    = cr == num(0) ? 0 : n;
-            n    = cr == num(1) ? 1 : n;
+            n    = cr == jfalse ? 0 : n;
+            n    = cr == jtrue ? 1 : n;
         }  // i.&0  already has combining op, set n if 0 or 1
         f2 = n >= 0 ? atcomp : f2;
         f2 = (REPSGN(~n) & d) == CFIT ? atcomp0 : f2;  // if valid comparison type, switch to it
@@ -565,8 +565,8 @@ jtatco(J jt, A a, A w) {
         case CAMP: {
             m   = (e & ~2) == CIOTA ? e : m;
             I j = -1;
-            j   = g == num(0) ? 0 : j;
-            j   = g == num(1) ? 1 : j;
+            j   = g == jfalse ? 0 : j;
+            j   = g == jtrue  ? 1 : j;
             m |= j;
             break;
         }             // i.@0/1@:g    i:@0/1@:g
@@ -793,7 +793,7 @@ jtamp(J jt, A a, A w) {
             if ((-AN(a) & -AR(a)) < 0) {
                 // c holds the pseudochar for the v op.  If v is u!.n, replace c with the pseudochar for n
                 // Also set b if the fit is !.0
-                if (b = c == CFIT && v->fgh[1] == num(0)) c = ID(v->fgh[0]);
+                if (b = c == CFIT && v->fgh[1] == jfalse) c = ID(v->fgh[0]);
                 mode = -1;
                 mode = c == CIOTA ? IIDOT : mode;
                 mode = c == CICO ? IICO : mode;
@@ -845,7 +845,7 @@ jtamp(J jt, A a, A w) {
                 // Also set b if the fit is !.0
                 c = v->id;
                 p = v->flag & 255;
-                if (b = c == CFIT && v->fgh[1] == num(0)) c = ID(v->fgh[0]);
+                if (b = c == CFIT && v->fgh[1] == jfalse) c = ID(v->fgh[0]);
                 if (7 == (p & 7))
                     mode = II0EPS + (p >> 3); /* (e.i.0:)  etc. */
                 else

--- a/jsrc/conjunctions/ca.c
+++ b/jsrc/conjunctions/ca.c
@@ -201,7 +201,7 @@ atcomp(J jt, A a, A w, A self) {
         I postflags = jt->workareas.compsc.postflags;
         z           = f(jt, a, w, self);
         if (z) {
-            if (postflags & 2) { z = num((IAV(z)[0] != AN(AR(a) >= AR(w) ? a : w)) ^ (postflags & 1)); }
+            if (postflags & 2) { z = numbool((IAV(z)[0] != AN(AR(a) >= AR(w) ? a : w)) ^ (postflags & 1)); }
         }
     } else
         z = jtupon2(jt, a, w, self);
@@ -218,7 +218,7 @@ atcomp0(J jt, A a, A w, A self) {
         I postflags = jt->workareas.compsc.postflags;
         z           = f(jt, a, w, self);
         if (z) {
-            if (postflags & 2) { z = num((IAV(z)[0] != AN(AR(a) >= AR(w) ? a : w)) ^ (postflags & 1)); }
+            if (postflags & 2) { z = numbool((IAV(z)[0] != AN(AR(a) >= AR(w) ? a : w)) ^ (postflags & 1)); }
         }
     } else
         z = jtupon2(jt, a, w, self);

--- a/jsrc/conjunctions/cc.c
+++ b/jsrc/conjunctions/cc.c
@@ -349,14 +349,14 @@ jtcut2bx(J jt, A a, A w, A self) {
         m  = ws[i];
         ASSERT(1 >= AR(b), EVRANK);
         if (!bn && m) {
-            xv[i] = num(0);
+            xv[i] = jfalse;
             RZ(yv[i] = jtincorp(jt, jtsc(jt, m)));
         } else {
             if (!(B01 & AT(b))) RZ(b = jtcvt(jt, B01, b));
             if (!AR(b)) {
                 if (BAV(b)[0]) {
                     RZ(xv[i] = jtincorp(jt, IX(m)));
-                    RZ(yv[i] = jtincorp(jt, jtreshape(jt, jtsc(jt, m), num(0 < q))));
+                    RZ(yv[i] = jtincorp(jt, jtreshape(jt, jtsc(jt, m), 0 < q ? jtrue : jfalse)));
                 } else
                     xv[i] = yv[i] = mtv;
                 continue;
@@ -581,7 +581,7 @@ jtcut2sx(J jt, A a, A w, A self) {
     RZ(a = a == mark ? jteps(jt, w, jttake(jt, numbool(pfx ? 1 : -1), w)) : DENSE & AT(a) ? jtsparse1(jt, a) : a);
     ASSERT(n == AS(a)[0], EVLENGTH);
     ap = PAV(a);
-    if (!(jtequ(jt, num(0), SPA(ap, e)) && AN(SPA(ap, a)))) return jtcut2(jt, jtcvt(jt, B01, a), w, self);
+    if (!(jtequ(jt, jfalse, SPA(ap, e)) && AN(SPA(ap, a)))) return jtcut2(jt, jtcvt(jt, B01, a), w, self);
     vf = VAV(fs);
     if (VGERL & sv->flag) {
         h  = sv->fgh[2];
@@ -782,7 +782,7 @@ jtidenv0(J jt, A a, A w, V *sv, I zt, A *zz) {
     A fs, y, z;
     *zz = 0;
     fs  = sv->fgh[0];
-    RE(df1(y, num(0), jtiden(jt, VAV(fs)->fgh[0])));
+    RE(df1(y, jfalse, jtiden(jt, VAV(fs)->fgh[0])));
     if (TYPESLT(zt, AT(y))) {
         *zz = df1(z, jtcut2(jt, a, w, jtcut(jt, ds(CBOX), sv->fgh[1])), jtamp(jt, fs, ds(COPE)));
         return 0;

--- a/jsrc/conjunctions/cc.c
+++ b/jsrc/conjunctions/cc.c
@@ -578,7 +578,7 @@ jtcut2sx(J jt, A a, A w, A self) {
     neg = 0 > m;
     pfx = m == 1 || m == -1;
     b   = neg && pfx;  // m = n from u;.n
-    RZ(a = a == mark ? jteps(jt, w, jttake(jt, num(pfx ? 1 : -1), w)) : DENSE & AT(a) ? jtsparse1(jt, a) : a);
+    RZ(a = a == mark ? jteps(jt, w, jttake(jt, numbool(pfx ? 1 : -1), w)) : DENSE & AT(a) ? jtsparse1(jt, a) : a);
     ASSERT(n == AS(a)[0], EVLENGTH);
     ap = PAV(a);
     if (!(jtequ(jt, num(0), SPA(ap, e)) && AN(SPA(ap, a)))) return jtcut2(jt, jtcvt(jt, B01, a), w, self);
@@ -994,7 +994,7 @@ jtcut2(J jt, A a, A w, A self) {
                 at = (wt + B01) & ~B01;  // monadic forms: if w is an immediate type we can handle, and the length is a
                                          // machine-word length, use w unchanged
             } else {
-                RZ(a = n ? jteps(jt, w, jttake(jt, num(pfx ? 1 : -1), w)) : mtv);
+                RZ(a = n ? jteps(jt, w, jttake(jt, numbool(pfx ? 1 : -1), w)) : mtv);
                 ak = 1;
                 at = B01;
             }  // any other w, replace by w e. {.w (or {: w).  Set ak to the length of a cell of a, in bytes.  Empty
@@ -1477,7 +1477,7 @@ jtrazecut2(J jt, A a, A w, A self) {
         sep = v[(wi - 1) & (pfx - 1)];
     }  // monad.  Create char list of frets: here if 1-byte list/atom
     else {
-        RZ(a = wi ? jteps(jt, w, jttake(jt, num((pfx << 1) - 1), w)) : mtv);
+        RZ(a = wi ? jteps(jt, w, jttake(jt, numbool((pfx << 1) - 1), w)) : mtv);
         v   = CAV(a);
         sep = C1;
     }  // here if other types/shapes

--- a/jsrc/conjunctions/cc.c
+++ b/jsrc/conjunctions/cc.c
@@ -52,7 +52,7 @@ jtcut02(J jt, A a, A w, A self) {
 
     I wr = AR(w);                                           // rank of w
     RZ(a = jtvib(jt, a));                                   // audit for valid integers
-    if (1 >= AR(a)) RZ(a = jtlamin2(jt, zeroionei(0), a));  // default list to be lengths starting at origin
+    if (1 >= AR(a)) RZ(a = jtlamin2(jt, num(0), a));        // default list to be lengths starting at origin
     as = AS(a);
     m  = AR(a) - 2;
     PROD(n, m, as);
@@ -61,7 +61,7 @@ jtcut02(J jt, A a, A w, A self) {
     ASSERT((-(as[m] ^ 2) | (wr - c)) >= 0, EVLENGTH);  // shapes must end with 2,c where c does not exceed rank of r
     if (!n) {                                          /* empty result; figure out result type */
         z = CALL1(f1, w, fs);
-        if (z == 0) z = zeroionei(0);  // use zero as fill result if error
+        if (z == 0) z = num(0);  // use zero as fill result if error
         GA(zz, AT(z), n, m + AR(z), 0);
         I *zzs = AS(zz);
         I *zs  = AS(z);
@@ -484,8 +484,8 @@ jtcut2bx(J jt, A a, A w, A self) {
             /* note: fall through */                                                                                 \
         default:                                                                                                     \
             if (!m) {                                                                                                \
-                y = jtreitem(jt, zeroionei(0), w);                                                                   \
-                return jtiota(jt, jtover(jt, zeroionei(0), shape(jt, h ? df1(z, y, *hv) : CALL1(f1, y, fs))));       \
+                y = jtreitem(jt, num(0), w);                                                                         \
+                return jtiota(jt, jtover(jt, num(0), shape(jt, h ? df1(z, y, *hv) : CALL1(f1, y, fs))));             \
             }                                                                                                        \
             GATV0(z, BOX, m, 1);                                                                                     \
             za = AAV(z);                                                                                             \
@@ -1415,10 +1415,10 @@ jtcut2(J jt, A a, A w, A self) {
         } else {
             // No frets.  Apply the operand to 0 items; return (0,$result) $ result (or $,'' if error on fill-cell). The
             // call is non-inplaceable
-            RZ(z = jtreitem(jt, zeroionei(0), w));  // create 0 items of the type of w
+            RZ(z = jtreitem(jt, num(0), w));  // create 0 items of the type of w
             WITHDEBUGOFF(zz = CALL1(f1, z, fs);) if (EMSK(jt->jerr) & EXIGENTERROR) RZ(zz);
             RESETERR;
-            RZ(zz = jtreshape(jt, jtover(jt, zeroionei(0), shape(jt, zz ? zz : mtv)), zz ? zz : zeroionei(0)));
+            RZ(zz = jtreshape(jt, jtover(jt, num(0), shape(jt, zz ? zz : mtv)), zz ? zz : num(0)));
         }
     }
     EPILOG(zz);

--- a/jsrc/conjunctions/cf.c
+++ b/jsrc/conjunctions/cf.c
@@ -232,7 +232,7 @@ jtfolkcomp(J jt, A a, A w, A self) {
         I postflags = jt->workareas.compsc.postflags;
         z           = f(jt, a, w, self);
         if (z) {
-            if (postflags & 2) { z = num((IAV(z)[0] != AN(AR(a) >= AR(w) ? a : w)) ^ (postflags & 1)); }
+            if (postflags & 2) { z = numbool((IAV(z)[0] != AN(AR(a) >= AR(w) ? a : w)) ^ (postflags & 1)); }
         }
     } else if (jtcap(jt, fs))
         CAP2 else FOLK2;
@@ -252,7 +252,7 @@ jtfolkcomp0(J jt, A a, A w, A self) {
         I postflags = jt->workareas.compsc.postflags;
         z           = f(jt, a, w, self);
         if (z) {
-            if (postflags & 2) { z = num((IAV(z)[0] != AN(AR(a) >= AR(w) ? a : w)) ^ (postflags & 1)); }
+            if (postflags & 2) { z = numbool((IAV(z)[0] != AN(AR(a) >= AR(w) ? a : w)) ^ (postflags & 1)); }
         }
     } else if (jtcap(jt, fs))
         CAP2 else FOLK2;
@@ -630,8 +630,8 @@ jthklvl2(J jt, A a, A w, A self) {
     F2RANK(0, RMAX, jthklvl2, self);
     I comparand;
     RE(comparand = jti0(jt, a));  // get value to compare against
-    return num(((VAV(self)->flag >> VFHKLVLGTX) & 1) ^
-               levelle(w, comparand - (VAV(self)->flag & VFHKLVLDEC)));  // decrement for < or >:; complement for > >:
+    return numbool(((VAV(self)->flag >> VFHKLVLGTX) & 1) ^
+                   levelle(w, comparand - (VAV(self)->flag & VFHKLVLDEC)));  // decrement for < or >:; complement for > >:
 }
 
 A

--- a/jsrc/conjunctions/cf.c
+++ b/jsrc/conjunctions/cf.c
@@ -356,7 +356,7 @@ jtfolk(J jt, A f, A g, A h) {
                 p = fv->fgh[0];
                 q = fv->fgh[1];
                 if (CLEFT == ID(q) && CQQ == ID(p) &&
-                    (v = VAV(p), x = v->fgh[0], CLT == ID(x) && v->fgh[1] == num(1))) {
+                    (v = VAV(p), x = v->fgh[0], CLT == ID(x) && v->fgh[1] == jtrue)) {
                     f2 = jtsfrom;
                     flag &= ~(VJTFLGOK2);
                 }

--- a/jsrc/conjunctions/ch.c
+++ b/jsrc/conjunctions/ch.c
@@ -83,7 +83,7 @@ jthgeom2(J jt, A a, A w, A self) {
     av = AV(a);
     n  = 0;
     DO(an, j = av[i]; ASSERT(0 <= j, EVDOMAIN); if (n < j) n = j;);
-    if (!n) return tymes(zeroionei(0), a);
+    if (!n) return tymes(num(0), a);
     h  = sv->fgh[2];
     hv = AAV(h);
     b  = VERB & (AT(sv->fgh[0]) | AT(sv->fgh[1])) || CMPX & (AT(w) | AT(hv[0]) | AT(hv[1]));
@@ -94,7 +94,7 @@ jthgeom2(J jt, A a, A w, A self) {
     else {
         j = 10;
         t = mtv;
-        z = zeroionei(1);
+        z = num(1);
         while (z && !jtequ(jt, z, t)) {
             t = z;
             z = jthgv(jt, 0, j, w, self);
@@ -122,8 +122,8 @@ jtcancel(J jt, A a, A w) {
     w = jtravel(jt, w);
     y = jtnub(jt, w);
     df1(d, w, f);
-    a = jtrepeat(jt, maximum(jfalse, minus(c, jtfrom(jt, jtindexof(jt, y, x), jtover(jt, d, zeroionei(0))))), x);
-    w = jtrepeat(jt, maximum(jfalse, minus(d, jtfrom(jt, jtindexof(jt, x, y), jtover(jt, c, zeroionei(0))))), y);
+    a = jtrepeat(jt, maximum(jfalse, minus(c, jtfrom(jt, jtindexof(jt, y, x), jtover(jt, d, num(0))))), x);
+    w = jtrepeat(jt, maximum(jfalse, minus(d, jtfrom(jt, jtindexof(jt, x, y), jtover(jt, c, num(0))))), y);
     return link(a, w);
 }
 

--- a/jsrc/conjunctions/ch.c
+++ b/jsrc/conjunctions/ch.c
@@ -31,7 +31,7 @@ jthgv(J jt, B b, I n, A w, A self) {
         case 2: y = divide(tymes(c, jtascan(jt, CSTAR, e)), jtascan(jt, CSTAR, d)); break;
         case 3: y = divide(tymes(c, jtascan(jt, CSTAR, e)), d);
     }
-    return b ? jtover(jt, num(0), jtascan(jt, CPLUS, y)) : jtaslash(jt, CPLUS, y);
+    return b ? jtover(jt, jfalse, jtascan(jt, CPLUS, y)) : jtaslash(jt, CPLUS, y);
 } /* verb or complex cases */
 
 static A
@@ -122,8 +122,8 @@ jtcancel(J jt, A a, A w) {
     w = jtravel(jt, w);
     y = jtnub(jt, w);
     df1(d, w, f);
-    a = jtrepeat(jt, maximum(num(0), minus(c, jtfrom(jt, jtindexof(jt, y, x), jtover(jt, d, zeroionei(0))))), x);
-    w = jtrepeat(jt, maximum(num(0), minus(d, jtfrom(jt, jtindexof(jt, x, y), jtover(jt, c, zeroionei(0))))), y);
+    a = jtrepeat(jt, maximum(jfalse, minus(c, jtfrom(jt, jtindexof(jt, y, x), jtover(jt, d, zeroionei(0))))), x);
+    w = jtrepeat(jt, maximum(jfalse, minus(d, jtfrom(jt, jtindexof(jt, x, y), jtover(jt, c, zeroionei(0))))), y);
     return link(a, w);
 }
 

--- a/jsrc/conjunctions/cip.c
+++ b/jsrc/conjunctions/cip.c
@@ -631,15 +631,15 @@ jtipbx(J jt, A a, A w, C c, C d) {
         // unsupported g.  Set c0/c1 to invalid and execute g to find x0/x1
         c0 = c1 = -1;
         g       = ds(d);
-        RZ(df2(x0, num(0), w, g));
-        RZ(df2(x1, num(0), w, g));
+        RZ(df2(x0, jfalse, w, g));
+        RZ(df2(x1, jfalse, w, g));
     } else {
-        RZ(x0 = c0 == IPBX0   ? jtreshape(jt, jtsc(jt, n), num(0))
-                : c0 == IPBX1 ? jtreshape(jt, jtsc(jt, c == CNE ? AN(w) : n), num(1))
+        RZ(x0 = c0 == IPBX0   ? jtreshape(jt, jtsc(jt, n), jfalse)
+                : c0 == IPBX1 ? jtreshape(jt, jtsc(jt, c == CNE ? AN(w) : n), jtrue)
                 : c0 == IPBXW ? w
                               : jtnot(jt, w));
-        RZ(x1 = c1 == IPBX0   ? jtreshape(jt, jtsc(jt, n), num(0))
-                : c1 == IPBX1 ? jtreshape(jt, jtsc(jt, c == CNE ? AN(w) : n), num(1))
+        RZ(x1 = c1 == IPBX0   ? jtreshape(jt, jtsc(jt, n), jfalse)
+                : c1 == IPBX1 ? jtreshape(jt, jtsc(jt, c == CNE ? AN(w) : n), jtrue)
                 : c1 == IPBXW ? w
                               : jtnot(jt, w));
     }
@@ -711,7 +711,7 @@ jtminors(J jt, A w) {
     A d, z;
     RZ(d = jtapvwr(jt, 3L, -1L, 1L));
     AV(d)[0] = 0;
-    return jtdrop(jt, d, df2(z, num(1), w, jtbsdot(jt, ds(CLEFT))));  // 0 0 1 }. 1 [\. w
+    return jtdrop(jt, d, df2(z, jtrue, w, jtbsdot(jt, ds(CLEFT))));  // 0 0 1 }. 1 [\. w
 }
 
 static A

--- a/jsrc/conjunctions/cl.c
+++ b/jsrc/conjunctions/cl.c
@@ -88,7 +88,7 @@ jtscfn(J jt, A w, A self) {
         AS(AKASA(self))[0] = n;
     }                                                          // if current buffer is full, reallocate.  ext resets AS
     AAV(AKASA(self))[AS(AKASA(self))[0]++] = jtincorp(jt, w);  // copy in new result pointer
-    return num(0);                                             // harmless good return
+    return jfalse;                                             // harmless good return
 }
 
 // u S: n - like L: except for calling the logger
@@ -101,7 +101,7 @@ jtlevs1(J jt, A w, A self) {
     } else {
         STACKCHKOFL RZ(jtevery(jt, w, self));
     }  // since this recurs, check stack
-    return num(0);
+    return jfalse;
 }
 
 static A
@@ -121,7 +121,7 @@ jtlevs2(J jt, A a, A w, A self) {
     }  // since this recurs, check stack
        // We do this with the if statement rather than a computed branch in the hope that the CPU can detect patterns in
     // the conditions. There may be a structure in the user's data that could be detected for branch prediction.
-    return num(0);
+    return jfalse;
 }
 
 static A

--- a/jsrc/conjunctions/cpdtsp.c
+++ b/jsrc/conjunctions/cpdtsp.c
@@ -332,12 +332,12 @@ jtpdtsp(J jt, A a, A w) {
         if (SPARSE & AT(a)) {
             p  = PAV(a);
             x  = SPA(p, a);
-            ab = AR(a) == AN(x) && jtequ(jt, num(0), SPA(p, e));
+            ab = AR(a) == AN(x) && jtequ(jt, jfalse, SPA(p, e));
         }
         if (SPARSE & AT(w)) {
             p  = PAV(w);
             x  = SPA(p, a);
-            wb = AR(w) == AN(x) && jtequ(jt, num(0), SPA(p, e));
+            wb = AR(w) == AN(x) && jtequ(jt, jfalse, SPA(p, e));
         }
     }
     if (ab && 1 == AR(a) && wb && 1 == AR(w)) return jtpdtspvv(jt, a, w);

--- a/jsrc/conjunctions/cr.c
+++ b/jsrc/conjunctions/cr.c
@@ -130,7 +130,7 @@ jtrank1ex(J jt, AD *RESTRICT w, A fs, I rr, AF f1) {
         WITHDEBUGOFF(z = CALL1(f1, virtw, fs);)
         if (jt->jerr) {
             if (EMSK(jt->jerr) & EXIGENTERROR) RZ(z);
-            z = num(0);
+            z = jfalse;
             RESETERR;
         }  // use 0 as result if error encountered
         GA(zz, AT(z), 0L, wf + AR(z), 0L);
@@ -282,7 +282,7 @@ jtrank1ex0(J jt, AD *RESTRICT w, A fs, AF f1) {
             WITHDEBUGOFF(z = CALL1(f1, virtw, fs);)  // normal execution on fill-cell
             if (jt->jerr) {
                 if (EMSK(jt->jerr) & EXIGENTERROR) RZ(z);
-                z = num(0);
+                z = jfalse;
                 RESETERR;
             }  // use 0 as result if error encountered
         } else {
@@ -544,7 +544,7 @@ jtrank2ex(J jt, AD *RESTRICT a, AD *RESTRICT w, A fs, UI lrrrlcrrcr, AF f2) {
         WITHDEBUGOFF(z = CALL2(f2, virta, virtw, fs);)
         if (jt->jerr != 0) {
             if (EMSK(jt->jerr) & EXIGENTERROR) RZ(z);
-            z = num(0);
+            z = jfalse;
             RESETERR;
         }  // use 0 as result if error encountered
         GA(zz, AT(z), 0L, lof + lif + AR(z), 0L);
@@ -762,7 +762,7 @@ jtrank2ex0(J jt, AD *RESTRICT a, AD *RESTRICT w, A fs, AF f2) {
             WITHDEBUGOFF(z = CALL2(f2, virta, virtw, fs);)  // normal execution on fill-cell
             if (jt->jerr) {
                 if (EMSK(jt->jerr) & EXIGENTERROR) RZ(z);
-                z = num(0);
+                z = jfalse;
                 RESETERR;
             }  // use 0 as result if error encountered
         } else {

--- a/jsrc/conjunctions/crs.c
+++ b/jsrc/conjunctions/crs.c
@@ -47,7 +47,7 @@ jtsprinit(J jt, I f, I r, I* s, I t, P* p) {
     SPB(zp, a, a1);
     SPB(zp, e, jtca(jt, SPA(p, e)));
     SPB(zp, i, jtiota(jt, jtv2(jt, 0L, n)));  // empty so cannot be readonly
-    SPB(zp, x, jtrepeat(jt, num(0), SPA(p, x)));
+    SPB(zp, x, jtrepeat(jt, jfalse, SPA(p, x)));
     return z;
 } /* initialize an argument cell */
 

--- a/jsrc/conjunctions/cv.c
+++ b/jsrc/conjunctions/cv.c
@@ -115,13 +115,13 @@ static A
 jtfitf1(J jt, A w, A self) {
     V* sv = FAV(self);
     A z;
-    return df1(z, w, jtfit(jt, jtfix(jt, sv->fgh[0], zeroionei(0)), sv->fgh[1]));
+    return df1(z, w, jtfit(jt, jtfix(jt, sv->fgh[0], num(0)), sv->fgh[1]));
 }
 static A
 jtfitf2(J jt, A a, A w, A self) {
     V* sv = FAV(self);
     A z;
-    return df2(z, a, w, jtfit(jt, jtfix(jt, sv->fgh[0], zeroionei(0)), sv->fgh[1]));
+    return df2(z, a, w, jtfit(jt, jtfix(jt, sv->fgh[0], num(0)), sv->fgh[1]));
 }
 
 // Fit conjunction u!.n

--- a/jsrc/conjunctions/cv.c
+++ b/jsrc/conjunctions/cv.c
@@ -33,7 +33,7 @@ jtfitct(J jt, A a, A w, I cno) {
     sv = FAV(a);
     // Get the tolerance, as a float
     D d;
-    if (w == num(0))
+    if (w == jfalse)
         d = 0.0;
     else {
         if (!(AT(w) & FL)) RZ(w = jtcvt(jt, FL, w));

--- a/jsrc/conjunctions/cx.c
+++ b/jsrc/conjunctions/cx.c
@@ -1484,11 +1484,11 @@ jtcolon(J jt, A a, A w) {
     }
     switch (n) {
         case 3:
-            return jtfdef(jt, 0, CCOLON, VERB, xn1, jtxdefn, num(n), 0L, h, flag | VJTFLGOK1 | VJTFLGOK2, RMAX, RMAX, RMAX);
-        case 1: return jtfdef(jt, 0, CCOLON, ADV, b ? xop1 : xadv, 0L, num(n), 0L, h, flag, RMAX, RMAX, RMAX);
-        case 2: return jtfdef(jt, 0, CCOLON, CONJ, 0L, b ? jtxop2 : jtxdefn, num(n), 0L, h, flag, RMAX, RMAX, RMAX);
+            return jtfdef(jt, 0, CCOLON, VERB, xn1, jtxdefn, numbool(n), 0L, h, flag | VJTFLGOK1 | VJTFLGOK2, RMAX, RMAX, RMAX);
+        case 1: return jtfdef(jt, 0, CCOLON, ADV, b ? xop1 : xadv, 0L, numbool(n), 0L, h, flag, RMAX, RMAX, RMAX);
+        case 2: return jtfdef(jt, 0, CCOLON, CONJ, 0L, b ? jtxop2 : jtxdefn, numbool(n), 0L, h, flag, RMAX, RMAX, RMAX);
         case 4:
-            return jtfdef(jt, 0, CCOLON, VERB, xn1, jtxdefn, num(n), 0L, h, flag | VJTFLGOK1 | VJTFLGOK2, RMAX, RMAX, RMAX);
+            return jtfdef(jt, 0, CCOLON, VERB, xn1, jtxdefn, numbool(n), 0L, h, flag | VJTFLGOK1 | VJTFLGOK2, RMAX, RMAX, RMAX);
         case 13: return jtvtrans(jt, w);
         default: ASSERT(0, EVDOMAIN);
     }

--- a/jsrc/conjunctions/cx.c
+++ b/jsrc/conjunctions/cx.c
@@ -466,7 +466,7 @@ jtxdefn(J jt, A a, A w, A self) {
                 parseline(t);
                 // Check for assert.  Since this is only for T-blocks we tolerate the test (rather than duplicating
                 // code)
-                if (ci->type == CASSERT && jt->assert &&t && !(NOUN & AT(t) && all1(eq(num(1), t))))
+                if (ci->type == CASSERT && jt->assert &&t && !(NOUN & AT(t) && all1(eq(jtrue, t))))
                     t = jtpee(jt, line,
                             ci,
                             EVASSERT,
@@ -1352,7 +1352,7 @@ jtcolon(J jt, A a, A w) {
     }
     RE(n = jti0(jt, a));  // m : n; set n=value of a argument
     I col0;               // set if it was m : 0
-    if (col0 = jtequ(jt, w, num(0))) {
+    if (col0 = jtequ(jt, w, jfalse)) {
         RZ(w = jtcolon0(jt, n));
     }  // if m : 0, read up to the ) .  If 0 : n, return the string unedited
     if (!n) {

--- a/jsrc/debugging/dc.c
+++ b/jsrc/debugging/dc.c
@@ -33,7 +33,7 @@ static SYMWALK(jtdloc,
     *zv++ = jtincorp(jt, jtsfn(jt, 0, si->dca));              /* 0 name                     */
     *zv++ = jtincorp(jt, jtsc(jt, si->dcj));                  /* 1 error number             */
     *zv++ = jtincorp(jt, jtsc(jt, lnumsi(si)));               /* 2 line number              */
-    *zv++ = num(ADV & AT(fs) ? 1 : CONJ & AT(fs) ? 2 : 3);    /* 3 name class               */
+    *zv++ = numbool(ADV & AT(fs) ? 1 : CONJ & AT(fs) ? 2 : 3);/* 3 name class               */
     *zv++ = jtincorp(jt, jtlrep(jt, fs));                     /* 4 linear rep.              */
     *zv++ = 0;                                                /* 5 script name, filled in later              */
     *zv++ = jtincorp(jt, q);                                  /* 6 argument list            */

--- a/jsrc/format/f.c
+++ b/jsrc/format/f.c
@@ -808,7 +808,7 @@ jtths(J jt, A w) {
     d = jtaii(jt, z);
     v = CAV(z) - d;
     DQ(m, memcpy(v += d, u += n, n););
-    if (2 < AR(z)) RZ(z = jtmatth1(jt, z, zeroionei(0)));  // no prxthornuni
+    if (2 < AR(z)) RZ(z = jtmatth1(jt, z, num(0)));  // no prxthornuni
     s = AS(z);
     d = *(1 + s);
     v = 1 + CAV(z);
@@ -817,7 +817,7 @@ jtths(J jt, A w) {
     return z;
 }
 
-// ": y, returning character array.  If jt->prxthornuni is set, LIT and C2T types return.  prxthornuni is zeroionei[0 or
+// ": y, returning character array.  If jt->prxthornuni is set, LIT and C2T types return.  prxthornuni is num[0 or
 // 1] C2T when there are unicodes present
 static A
 jtthorn1main(J jt, A w, A prxthornuni) {
@@ -917,7 +917,7 @@ jtthorn1u(J jt, A w) {
 A
 jtthorn1(J jt, A w) {
     A z;
-    A prxthornuni = zeroionei(!(AT(w) & (LIT + C2T + C4T)));
+    A prxthornuni = num(!(AT(w) & (LIT + C2T + C4T)));
     z             = jtthorn1main(jt, w, prxthornuni);
     if (z && AT(z) & (C2T + C4T))
         z = rank2ex(z, prxthornuni, UNUSED_VALUE, MIN(AR(z), 1L), 0, MIN(AR(z), 1L), 0, RoutineD);

--- a/jsrc/io.c
+++ b/jsrc/io.c
@@ -164,7 +164,7 @@ jtinpl(J jt, B b, I n, C* s) {
     if (n && (c = s[n - 1], CLF == c || CCR == c)) --n;  // discard trailing [CR], CRLF, CRCR
     ASSERT(!*jt->adbreak, EVINPRUPT);
     if (!b) { /* 1==b means literal input */
-        if (n && COFF == s[n - 1]) jtjoff(jt, num(0));
+        if (n && COFF == s[n - 1]) jtjoff(jt, jfalse);
         c = jt->bx[9];
         if ((UC)c > 127)
             DO(

--- a/jsrc/j.c
+++ b/jsrc/j.c
@@ -52,10 +52,10 @@ A mnuvxynam[6] = {0, 0, 0, 0, 0, 0};  // name blocks for all arg names
 I validitymask[16] = {-1, -1, 0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0, 0, 0};  // native ss2/neon register is s64x2
 
 I Bnum[22][8] =
-  {  // the numbers we keep at hand.  0 and 1 are B01, the rest INT; but the first 2 are integer forms of 0 and 1
+  {  // the numbers we keep at hand.
     CBAIVAL(INT, 0),  CBAIVAL(INT, 1),  CBAIVAL(INT, -10), CBAIVAL(INT, -9), CBAIVAL(INT, -8), CBAIVAL(INT, -7),
     CBAIVAL(INT, -6), CBAIVAL(INT, -5), CBAIVAL(INT, -4),  CBAIVAL(INT, -3), CBAIVAL(INT, -2), CBAIVAL(INT, -1),
-    CBAIVAL(B01, 0),  CBAIVAL(B01, 1),  CBAIVAL(INT, 2),   CBAIVAL(INT, 3),  CBAIVAL(INT, 4),  CBAIVAL(INT, 5),
+    CBAIVAL(INT, 0),  CBAIVAL(INT, 1),  CBAIVAL(INT, 2),   CBAIVAL(INT, 3),  CBAIVAL(INT, 4),  CBAIVAL(INT, 5),
     CBAIVAL(INT, 6),  CBAIVAL(INT, 7),  CBAIVAL(INT, 8),   CBAIVAL(INT, 9)};
 
 I Bbool[2][8] = { // The booleans

--- a/jsrc/j.c
+++ b/jsrc/j.c
@@ -16,6 +16,9 @@ struct Bd2 {
 #define CREBLOCKATOMV2(name, t, v1, v2) \
     struct Bd2 B##name = {{AKXR(0), (t)&TRAVERSIBLE, 0, (t), ACPERMANENT, 1, 0}, {v1, v2}};
 CREBLOCKATOMV2(a0j1, CMPX, 0.0, 1.0)  // 0j1
+// TODO: This should probably return an AD instead of the current I[8] that just happens to share
+//       the memory layout of AD. The current implementation is bound to break if that layout is
+//       ever changed.
 #define CBAIVAL(t, v) \
     { 7 * SZI, (t)&TRAVERSIBLE, 0, (t), ACPERMANENT, 1, 0, (v) }
 #define CREBLOCKATOMI(name, t, v) I B##name[8] = CBAIVAL(t, v);

--- a/jsrc/j.c
+++ b/jsrc/j.c
@@ -58,6 +58,9 @@ I Bnum[22][8] =
     CBAIVAL(B01, 0),  CBAIVAL(B01, 1),  CBAIVAL(INT, 2),   CBAIVAL(INT, 3),  CBAIVAL(INT, 4),  CBAIVAL(INT, 5),
     CBAIVAL(INT, 6),  CBAIVAL(INT, 7),  CBAIVAL(INT, 8),   CBAIVAL(INT, 9)};
 
+I Bbool[2][8] = { // The booleans
+    CBAIVAL(B01, 0),  CBAIVAL(B01, 1) };
+
 struct Bd1 Bnumvr[3] = {  // floating-point 0, 1, and 2, used for constants
   {{AKXR(0), FL& TRAVERSIBLE, 0, FL, ACPERMANENT, 1, 0}, 0.0},
   {{AKXR(0), FL& TRAVERSIBLE, 0, FL, ACPERMANENT, 1, 0}, 1.0},

--- a/jsrc/j.c
+++ b/jsrc/j.c
@@ -51,12 +51,12 @@ A mnuvxynam[6] = {0, 0, 0, 0, 0, 0};  // name blocks for all arg names
 // and &validitymask[0] as a V* with ID of 0
 I validitymask[16] = {-1, -1, 0, 0, -1, -1, 0, 0, -1, -1, 0, 0, 0, 0, 0, 0};  // native ss2/neon register is s64x2
 
-I Bnum[22][8] =
+I Bnum[20][8] =
   {  // the numbers we keep at hand.
-    CBAIVAL(INT, 0),  CBAIVAL(INT, 1),  CBAIVAL(INT, -10), CBAIVAL(INT, -9), CBAIVAL(INT, -8), CBAIVAL(INT, -7),
-    CBAIVAL(INT, -6), CBAIVAL(INT, -5), CBAIVAL(INT, -4),  CBAIVAL(INT, -3), CBAIVAL(INT, -2), CBAIVAL(INT, -1),
-    CBAIVAL(INT, 0),  CBAIVAL(INT, 1),  CBAIVAL(INT, 2),   CBAIVAL(INT, 3),  CBAIVAL(INT, 4),  CBAIVAL(INT, 5),
-    CBAIVAL(INT, 6),  CBAIVAL(INT, 7),  CBAIVAL(INT, 8),   CBAIVAL(INT, 9)};
+    CBAIVAL(INT, -10), CBAIVAL(INT, -9), CBAIVAL(INT, -8), CBAIVAL(INT, -7), CBAIVAL(INT, -6), CBAIVAL(INT, -5),
+    CBAIVAL(INT, -4),  CBAIVAL(INT, -3), CBAIVAL(INT, -2), CBAIVAL(INT, -1), CBAIVAL(INT, 0),  CBAIVAL(INT, 1),
+    CBAIVAL(INT, 2),   CBAIVAL(INT, 3),  CBAIVAL(INT, 4),  CBAIVAL(INT, 5),  CBAIVAL(INT, 6),  CBAIVAL(INT, 7),
+    CBAIVAL(INT, 8),   CBAIVAL(INT, 9)};
 
 I Bbool[2][8] = { // The booleans
     CBAIVAL(B01, 0),  CBAIVAL(B01, 1) };

--- a/jsrc/j.c
+++ b/jsrc/j.c
@@ -58,8 +58,9 @@ I Bnum[20][8] =
     CBAIVAL(INT, 2),   CBAIVAL(INT, 3),  CBAIVAL(INT, 4),  CBAIVAL(INT, 5),  CBAIVAL(INT, 6),  CBAIVAL(INT, 7),
     CBAIVAL(INT, 8),   CBAIVAL(INT, 9)};
 
-I Bbool[2][8] = { // The booleans
-    CBAIVAL(B01, 0),  CBAIVAL(B01, 1) };
+// The booleans
+A const jfalse = (A)(I[8])CBAIVAL(B01, 0);
+A const jtrue = (A)(I[8])CBAIVAL(B01, 1);
 
 struct Bd1 Bnumvr[3] = {  // floating-point 0, 1, and 2, used for constants
   {{AKXR(0), FL& TRAVERSIBLE, 0, FL, ACPERMANENT, 1, 0}, 0.0},

--- a/jsrc/je.h
+++ b/jsrc/je.h
@@ -822,7 +822,6 @@ extern D jnan; /* "nan" name conflict under Solaris       */
 extern A mnuvxynam[6];
 extern void moveparseinfotosi(J);
 extern I Bnum[][8];
-#define zeroionei(n) ((A)(Bnum + (n)))
 #define num(n) ((A)(Bnum + 2 + (n)-NUMMIN))
 extern I Bbool[][8];
 #define jfalse ((A)(Bbool[0]))

--- a/jsrc/je.h
+++ b/jsrc/je.h
@@ -824,6 +824,10 @@ extern void moveparseinfotosi(J);
 extern I Bnum[][8];
 #define zeroionei(n) ((A)(Bnum + (n)))
 #define num(n) ((A)(Bnum + 2 + (n)-NUMMIN))
+// Implementation of jtrue and jfalse is temporary, and should be updated once we
+// extract the booleans from Bnum
+#define jfalse num(0)
+#define jtrue  num(1)
 #define I1mem (Bnum[1][7])  // 1 stored in memory
 extern struct Bd1 Bnumvr[];
 #define numvr(n) ((A)(Bnumvr + (n)))
@@ -854,6 +858,6 @@ extern PRIM sfn0overself;
 #define numbool(n) (        \
     (n) == -12 ? num(-12) : \
     (n) == -11 ? num(-11) : \
-    (n) == 0   ? num(0)   : \
-    (n) == 1   ? num(1)   : \
+    (n) == 0   ? jfalse   : \
+    (n) == 1   ? jtrue    : \
                num((n)))

--- a/jsrc/je.h
+++ b/jsrc/je.h
@@ -823,9 +823,8 @@ extern A mnuvxynam[6];
 extern void moveparseinfotosi(J);
 extern I Bnum[][8];
 #define num(n) ((A)(Bnum + (n)-NUMMIN))
-extern I Bbool[][8];
-#define jfalse ((A)(Bbool[0]))
-#define jtrue  ((A)(Bbool[1]))
+extern A const jfalse;
+extern A const jtrue;
 #define I1mem (Bnum[1-NUMMIN][7])  // 1 stored in memory
 extern struct Bd1 Bnumvr[];
 #define numvr(n) ((A)(Bnumvr + (n)))

--- a/jsrc/je.h
+++ b/jsrc/je.h
@@ -840,3 +840,20 @@ extern A zpath;
 extern I iotavec[IOTAVECLEN];  // ascending integers, starting at IOTAVECBEGIN
 extern VARPSA rpsnull;
 extern PRIM sfn0overself;
+
+/**
+ * @brief This is the old implementation of `num`, that may return a boolean.
+ *        Some code depends on this behaviour. This code might be up for
+ *        refactoring, but at this moment we don't know enough about it.
+ *
+ * @param n C representation of number, valid range [NUMMIN, NUMMAX]
+ * @return  The J representation of the integer, unless n is in [0, 1], then
+ *          the boolean (false, true) is returned. Except for the values -12
+ *          and -11, those return 0 and 1 instead.
+ */
+#define numbool(n) (        \
+    (n) == -12 ? num(-12) : \
+    (n) == -11 ? num(-11) : \
+    (n) == 0   ? num(0)   : \
+    (n) == 1   ? num(1)   : \
+               num((n)))

--- a/jsrc/je.h
+++ b/jsrc/je.h
@@ -822,11 +822,11 @@ extern D jnan; /* "nan" name conflict under Solaris       */
 extern A mnuvxynam[6];
 extern void moveparseinfotosi(J);
 extern I Bnum[][8];
-#define num(n) ((A)(Bnum + 2 + (n)-NUMMIN))
+#define num(n) ((A)(Bnum + (n)-NUMMIN))
 extern I Bbool[][8];
 #define jfalse ((A)(Bbool[0]))
 #define jtrue  ((A)(Bbool[1]))
-#define I1mem (Bnum[1][7])  // 1 stored in memory
+#define I1mem (Bnum[1-NUMMIN][7])  // 1 stored in memory
 extern struct Bd1 Bnumvr[];
 #define numvr(n) ((A)(Bnumvr + (n)))
 extern struct Bd1 Bonehalf;

--- a/jsrc/je.h
+++ b/jsrc/je.h
@@ -824,10 +824,9 @@ extern void moveparseinfotosi(J);
 extern I Bnum[][8];
 #define zeroionei(n) ((A)(Bnum + (n)))
 #define num(n) ((A)(Bnum + 2 + (n)-NUMMIN))
-// Implementation of jtrue and jfalse is temporary, and should be updated once we
-// extract the booleans from Bnum
-#define jfalse num(0)
-#define jtrue  num(1)
+extern I Bbool[][8];
+#define jfalse ((A)(Bbool[0]))
+#define jtrue  ((A)(Bbool[1]))
 #define I1mem (Bnum[1][7])  // 1 stored in memory
 extern struct Bd1 Bnumvr[];
 #define numvr(n) ((A)(Bnumvr + (n)))

--- a/jsrc/k.c
+++ b/jsrc/k.c
@@ -440,7 +440,7 @@ jtccvt(J jt, I tflagged, A w, A *y) {
             P *wp, *yp;
             case 1: RZ(w = jtdenseit(jt, w)); break;  // sparse to dense
             case 2:
-                RZ(*y = jtsparseit(jt, jtcvt(jt, DTYPE(t), w), IX(r), jtcvt(jt, DTYPE(t), num(0))));
+                RZ(*y = jtsparseit(jt, jtcvt(jt, DTYPE(t), w), IX(r), jtcvt(jt, DTYPE(t), jfalse)));
                 jt->ranks = oqr;
                 return 1;  // dense to sparse; convert type first (even if same dtype)
             case 3:        // sparse to sparse

--- a/jsrc/parsing/p.c
+++ b/jsrc/parsing/p.c
@@ -157,7 +157,7 @@ jtpparen(J jt, PSTK *stack) {
 static A
 jtisf(J jt, A a, A w, A self) {
     RZ(jtsymbis(jt, jtonm(jt, a), CALL1(FAV(self)->valencefns[0], w, 0L), ABACK(self)));
-    return num(0);
+    return jfalse;
 }
 
 // assignment, single or multiple

--- a/jsrc/parsing/pv.c
+++ b/jsrc/parsing/pv.c
@@ -111,7 +111,7 @@ jtswapc(J jt, A w) {
 TA
 jtvmonad(J jt, I b, I e, TA *stack, A locsyms, I tmonad, I tsubst, TA *ttab, I *ttabi, I ttabi0) {
     A fs;
-    TA y, z = {num(1), 0};
+    TA y, z = {jtrue, 0};
     V *v;
     y  = stack[e];
     fs = stack[b].a;
@@ -145,7 +145,7 @@ jtvdyad(J jt, I b, I e, TA *stack, A locsyms, I tmonad, I tsubst, TA *ttab, I *t
     A fs, sf, xt, yt;
     B xl, xr, yl, yr;
     I xi = -1, yi = -1;
-    TA x, y, z = {num(1), 0};
+    TA x, y, z = {jtrue, 0};
     V *u = 0, *v = 0;
     fs = stack[e - 1].a;
     x  = stack[b];
@@ -447,8 +447,8 @@ jtvtrans(J jt, A w) {
         I tmonad = AM(y);
         ttabi    = c;
         RZ(locsyms = jtstcreate(jt, 2, 40, 0L, 0L));  // not necessary to set global pointers
-        jtsymbis(jt, mnuvxynam[5], num(1), locsyms);
-        if (!tmonad) jtsymbis(jt, mnuvxynam[4], num(1), locsyms);
+        jtsymbis(jt, mnuvxynam[5], jtrue, locsyms);
+        if (!tmonad) jtsymbis(jt, mnuvxynam[4], jtrue, locsyms);
         z = jttparse(jt, y, locsyms, tmonad, 0 == i, ttab, &ttabi, c);
         RESETERR;
         if (i && !z) z = jtcolon(jt, numbool(4 - tmonad), w);

--- a/jsrc/parsing/pv.c
+++ b/jsrc/parsing/pv.c
@@ -451,7 +451,7 @@ jtvtrans(J jt, A w) {
         if (!tmonad) jtsymbis(jt, mnuvxynam[4], num(1), locsyms);
         z = jttparse(jt, y, locsyms, tmonad, 0 == i, ttab, &ttabi, c);
         RESETERR;
-        if (i && !z) z = jtcolon(jt, num(4 - tmonad), w);
+        if (i && !z) z = jtcolon(jt, numbool(4 - tmonad), w);
     }
 
     EPILOG(z);

--- a/jsrc/px.c
+++ b/jsrc/px.c
@@ -32,7 +32,7 @@ jtev2(J jt, A a, A w, C* s) {
 A
 jteva(J jt, A w, C* s) {
     A z;
-    return df1(z, w, jtcolon(jt, num(1), jtcstr(jt, s)));
+    return df1(z, w, jtcolon(jt, jtrue, jtcstr(jt, s)));
 }
 A
 jtevc(J jt, A a, A w, C* s) {
@@ -83,7 +83,7 @@ jtimmea(J jt, A w) {
     z = jtimmex(jt, w);  // check for DD, but don't allow continuation read
     ASSERT(
       jt->asgn || !z || !(AT(z) & NOUN) ||
-        (t = eq(num(1), z), all1(AT(z) & SPARSE ? df1(z1, t, jtatop(jt, jtslash(jt, ds(CSTARDOT)), ds(CCOMMA))) : t)),
+        (t = eq(jtrue, z), all1(AT(z) & SPARSE ? df1(z1, t, jtatop(jt, jtslash(jt, ds(CSTARDOT)), ds(CCOMMA))) : t)),
       EVASSERT);  // apply *./@, if sparse
     return z;
 }

--- a/jsrc/representations/r.c
+++ b/jsrc/representations/r.c
@@ -45,7 +45,7 @@ jtdrr(J jt, A w) {
     if (evoke(w)) return jtdrr(jt, jtsfne(jt, w));  // turn nameref into string or verb; then take rep
     if (fs) RZ(df = fl & VGERL ? jtevery(jt, jtfxeach(jt, fs, (A)&jtfxself[0]), (A)&drrself) : jtdrr(jt, fs));
     if (gs) RZ(dg = fl & VGERR ? jtevery(jt, jtfxeach(jt, gs, (A)&jtfxself[0]), (A)&drrself) : jtdrr(jt, gs));
-    if (ex) RZ(dg = jtunparsem(jt, num(0), w));
+    if (ex) RZ(dg = jtunparsem(jt, jfalse, w));
     m += !b && !xop || hs && xop;
     GATV0(z, BOX, m, 1);
     x = AAV(z);
@@ -103,7 +103,7 @@ jtaro(J jt, A w) {
     GATV0(y, BOX, m, 1);
     u = AAV(y);
     if (0 < m) RZ(u[0] = jtincorp(jt, jtaro(jt, fs)));
-    if (1 < m) RZ(u[1] = jtincorp(jt, jtaro(jt, ex ? jtunparsem(jt, num(0), w) : xop ? hs : gs)));
+    if (1 < m) RZ(u[1] = jtincorp(jt, jtaro(jt, ex ? jtunparsem(jt, jfalse, w) : xop ? hs : gs)));
     if (2 < m) RZ(u[2] = jtincorp(jt, jtaro(jt, hs)));
     s = xop               ? jtaro(jt, gs)
         : VDDOP & v->flag ? (hv = AV(hs), jtaro(jt, jtforeign(jt, jtsc(jt, hv[0]), jtsc(jt, hv[1]))))
@@ -496,7 +496,7 @@ jtunparsem(J jt, A a, A w) {
         if (p) RZ(*zv++ = chrcolon);
         DO(dn, *zv++ = jtunDD(jt, AAV(ds)[i]););
     }
-    if (a == num(0)) {
+    if (a == jfalse) {
         RZ(z = jtope(jt, z));
         if (1 == AR(z)) z = jttable(jt, z);
     }

--- a/jsrc/representations/rl.c
+++ b/jsrc/representations/rl.c
@@ -367,21 +367,21 @@ jtlnum(J jt, A w, A *ltext) {
     n = AN(w);
     if (7 < n || 1 < n && 1 < AR(w)) {
         // see if we can use a clever encoding
-        d = minus(jtfrom(jt, num(1), t), b = jtfrom(jt, num(0), t));
+        d = minus(jtfrom(jt, jtrue, t), b = jtfrom(jt, jfalse, t));
         p = jtequ(jt, t, plus(b, tymes(d, IX(n))));
         if (p) {
-            if (jtequ(jt, d, num(0))) return jtover(jt, lsh(w), lnum1(b));
+            if (jtequ(jt, d, jfalse)) return jtover(jt, lsh(w), lnum1(b));
             GAT0(y, BOX, 6, 1);
             v    = AAV(y);
             v[0] = v[1] = v[2] = v[3] = mtv;
             if (p = !(jtequ(jt, b, jtsc(jt, n - 1)) && jtequ(jt, d, num(-1)))) {
-                if (!jtequ(jt, b, num(0))) {
+                if (!jtequ(jt, b, jfalse)) {
                     v[0] = lnum1(b);
                     v[1] = jtspellout(jt, CPLUS);
                 }
                 if (jtequ(jt, d, num(-1)))
                     v[1] = jtspellout(jt, CMINUS);
-                else if (!jtequ(jt, d, num(1))) {
+                else if (!jtequ(jt, d, jtrue)) {
                     v[2] = lnum1(d);
                     v[3] = jtspellout(jt, CSTAR);
                 }
@@ -630,7 +630,7 @@ jtlcolon(J jt, A w, A *ltext) {
     A *v, x, y;
     C *s, *s0;
     I m, n;
-    RZ(y = jtunparsem(jt, num(1), w));
+    RZ(y = jtunparsem(jt, jtrue, w));
     n = AN(y);
     v = AAV(y);
     RZ(x = lrr(VAV(w)->fgh[0]));

--- a/jsrc/representations/rt.c
+++ b/jsrc/representations/rt.c
@@ -297,7 +297,7 @@ jttrr(J jt, A w) {
     if (1 < m)
         RZ(x[1] = jtincorp(jt,
                            fl & VGERR ? jttreach(jt, jtfxeach(jt, gs, (A)&jtfxself[0]))
-                           : ex       ? jttrr(jt, jtunparsem(jt, num(0), w))
+                           : ex       ? jttrr(jt, jtunparsem(jt, jfalse, w))
                                       : jttrr(jt, gs)));
     if (2 < m) RZ(x[2] = jtincorp(jt, jttrr(jt, hs)));
     s = xop ? jtspellout(jt, '0')

--- a/jsrc/sl.c
+++ b/jsrc/sl.c
@@ -555,7 +555,7 @@ static SYMWALK(jtlocmap1,
     A g, q, x, y, *yv, z, *zv;
     I c = -1, d, j = 0, m, *qv, *xv;
     ASSERT(!AR(w), EVRANK);
-    RE(g = jtequ(jt, w, zeroionei(0)) ? jt->stloc : jtequ(jt, w, zeroionei(1)) ? jt->locsyms : jtlocale(jt, 0, w));
+    RE(g = jtequ(jt, w, num(0)) ? jt->stloc : jtequ(jt, w, num(1)) ? jt->locsyms : jtlocale(jt, 0, w));
     ASSERT(g != 0, EVLOCALE);
     RZ(q = jtlocmap1(jt, g));
     qv = AV(q);

--- a/jsrc/sn.c
+++ b/jsrc/sn.c
@@ -150,7 +150,7 @@ jtsfn(J jt, B b, A w) {
 A
 jtsfne(J jt, A w) {
     A wn = FAV(w)->fgh[0];
-    if (AT(wn) & NAMEBYVALUE) return jtfix(jt, w, zeroionei(0));
+    if (AT(wn) & NAMEBYVALUE) return jtfix(jt, w, num(0));
     return jtsfn(jt, 0, wn);
 }
 

--- a/jsrc/u.c
+++ b/jsrc/u.c
@@ -451,7 +451,7 @@ jtsc4(J jt, I t, I v) {
 }  // return scalar with a given I-length type (numeric or box)
 A
 jtscb(J jt, B b) {
-    return num(b);
+    return b ? jtrue : jfalse;
 }  // A block for boolean
 A
 jtscc(J jt, C c) {

--- a/jsrc/u.c
+++ b/jsrc/u.c
@@ -437,7 +437,7 @@ jtsc(J jt, I k) {
 A
 jtscib(J jt, I k) {
     A z;
-    if ((k ^ REPSGN(k)) <= NUMMAX) return num(k);
+    if ((k ^ REPSGN(k)) <= NUMMAX) return numbool(k);
     GAT0(z, INT, 1, 0);
     IAV(z)[0] = k;
     return z;

--- a/jsrc/u.c
+++ b/jsrc/u.c
@@ -426,9 +426,7 @@ A
 jtsc(J jt, I k) {
     A z;
     if ((k ^ REPSGN(k)) <= NUMMAX) {
-        z = num(k);
-        z = k & ~1 ? z : zeroionei(k);
-        return z;
+        return num(k);
     }
     GAT0(z, INT, 1, 0);
     IAV(z)[0] = k;
@@ -577,7 +575,7 @@ jtvib(J jt, A w) {
     I i, n, *zv;
     if (AT(w) & INT) return w;  // handle common non-failing cases quickly: INT and boolean
     if (AT(w) & B01) {
-        if (!AR(w)) return zeroionei(BAV(w)[0]);
+        if (!AR(w)) return num(BAV(w)[0]);
         return jtcvt(jt, INT, w);
     }
     if (w == ainf) return imax;  // sentence words of _ always use the same block, so catch that too

--- a/jsrc/verbs/dyadic/take_drop.cpp
+++ b/jsrc/verbs/dyadic/take_drop.cpp
@@ -9,7 +9,7 @@
 A
 jtbehead(J jt, A w) {
     FPREFIP;
-    return jtdrop(jtinplace, zeroionei(1), w);
+    return jtdrop(jtinplace, num(1), w);
 }
 A
 jtcurtail(J jt, A w) {
@@ -422,9 +422,9 @@ jthead(J jt, A w) {
             return z;
         } else {
             // frame not 0, or non-virtualable type, or cell is an atom.  Use from.  Note that jt->ranks is still set,
-            // so this may produce multiple cells left rank is garbage, but since zeroionei(0) is an atom it doesn't
+            // so this may produce multiple cells left rank is garbage, but since num(0) is an atom it doesn't
             // matter
-            return jtfrom(jtinplace, zeroionei(0), w);  // could call jtfromi directly for non-sparse w
+            return jtfrom(jtinplace, num(0), w);  // could call jtfromi directly for non-sparse w
         }
     } else {
         return SPARSE & AT(w) ? jtirs2(jt, jfalse, jttake(jt, jtrue, w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))

--- a/jsrc/verbs/dyadic/take_drop.cpp
+++ b/jsrc/verbs/dyadic/take_drop.cpp
@@ -19,7 +19,7 @@ jtcurtail(J jt, A w) {
 
 A
 jtshift1(J jt, A w) {
-    return jtdrop(jt, num(-1), jtover(jt, num(1), w));
+    return jtdrop(jt, num(-1), jtover(jt, jtrue, w));
 }
 
 static A
@@ -427,7 +427,7 @@ jthead(J jt, A w) {
             return jtfrom(jtinplace, zeroionei(0), w);  // could call jtfromi directly for non-sparse w
         }
     } else {
-        return SPARSE & AT(w) ? jtirs2(jt, num(0), jttake(jt, num(1), w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))
+        return SPARSE & AT(w) ? jtirs2(jt, jfalse, jttake(jt, jtrue, w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))
                               : jtrsh0(jt, w);  // cell of w is empty - create a cell of fills  jt->ranks is still set
                                                 // for use in take.  Left rank is garbage, but that's OK
     }
@@ -445,7 +445,7 @@ jttail(J jt, A w) {
     return !wcr || AS(w)[wf] ? jtfrom(jtinplace, num(-1), w)
                              :  // if cells are atoms, or if the cells are nonempty arrays, result is last cell(s) scaf
                                 // should generate virtual block here for speed
-             SPARSE & AT(w) ? jtirs2(jt, num(0), jttake(jt, num(-1), w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))
+             SPARSE & AT(w) ? jtirs2(jt, jfalse, jttake(jt, num(-1), w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))
                             : jtrsh0(jt, w);
     // pristinity from other verbs
 }

--- a/jsrc/verbs/v.c
+++ b/jsrc/verbs/v.c
@@ -7,12 +7,12 @@
 
 A
 jtisempty(J jt, A w) {
-    if ((AT(w) & SPARSE) != 0) return jteps(jt, zeroionei(0), shape(jt, w));
+    if ((AT(w) & SPARSE) != 0) return jteps(jt, num(0), shape(jt, w));
     return AN(w) == 0 ? jtrue : jfalse;
 }  // 0 e. $
 A
 jtisnotempty(J jt, A w) {
-    if ((AT(w) & SPARSE) != 0) return jtnot(jt, jteps(jt, zeroionei(0), shape(jt, w)));
+    if ((AT(w) & SPARSE) != 0) return jtnot(jt, jteps(jt, num(0), shape(jt, w)));
     return AN(w) == 0 ? jfalse : jtrue;
 }  // *@#@,
 A

--- a/jsrc/verbs/v.c
+++ b/jsrc/verbs/v.c
@@ -8,16 +8,16 @@
 A
 jtisempty(J jt, A w) {
     if ((AT(w) & SPARSE) != 0) return jteps(jt, zeroionei(0), shape(jt, w));
-    return num(AN(w) == 0);
+    return AN(w) == 0 ? jtrue : jfalse;
 }  // 0 e. $
 A
 jtisnotempty(J jt, A w) {
     if ((AT(w) & SPARSE) != 0) return jtnot(jt, jteps(jt, zeroionei(0), shape(jt, w)));
-    return num(AN(w) != 0);
+    return AN(w) == 0 ? jfalse : jtrue;
 }  // *@#@,
 A
 jtisitems(J jt, A w) {
-    return num(!AR(w) | !!AS(w)[0]);
+    return (!AR(w) | !!AS(w)[0]) ? jtrue : jfalse;
 }  // *@#   *@:#
 A
 jtnatoms(J jt, A w) {

--- a/jsrc/verbs/v0.c
+++ b/jsrc/verbs/v0.c
@@ -92,7 +92,7 @@ jtcfr(J jt, A w) {
         c = wv[0];
         r = wv[1];
     } else {
-        c = num(1);
+        c = jtrue;
         r = wv[0];
     }
     ASSERT(((AR(c) - 1) & (AR(r) - 2)) < 0, EVRANK);
@@ -432,14 +432,14 @@ jtrfc(J jt, A w) {
     t   = AT(w);  // n=#coeffs, t=type
     if (n) {
         ASSERT(t & (DENSE & NUMERIC), EVDOMAIN);  // coeffs must be dense numeric
-        RZ(r = jtjico2(jt, ne(w, num(0)), num(1)));
+        RZ(r = jtjico2(jt, ne(w, jfalse), jtrue));
         m = AV(r)[0];
         m = (m == n) ? 0 : m;  // r=block for index of last nonzero; m=degree of polynomial (but 0 if all zeros)
-        ASSERT(m || jtequ(jt, num(0), jthead(jt, w)), EVDOMAIN);  // error if unsolvable constant polynomial
+        ASSERT(m || jtequ(jt, jfalse, jthead(jt, w)), EVDOMAIN);  // error if unsolvable constant polynomial
     }
     // switch based on degree of polynomial
     switch (m) {
-        case 0: return link(num(0), mtv);  // degree 0 - return 0;''
+        case 0: return link(jfalse, mtv);  // degree 0 - return 0;''
         case 1:
             r = jtravel(jt, jtnegate(jt, jtaslash(jt, CDIV, jttake(jt, num(2), w))));
             break;  // linear - return solution, whatever its type
@@ -471,7 +471,7 @@ jtpoly1(J jt, A w) {
     ASSERT(2 == *(1 + AS(x)), EVLENGTH);
     RZ(IRS1(x, 0L, 1L, jthead, c));                                    // c = {."1>y = list of coefficients
     RZ(IRS1(x, 0L, 1L, jttail, e));                                    // e = {:"1>y = list of exponents
-    ASSERT(jtequ(jt, e, floor1(e)) && all1(le(num(0), e)), EVDOMAIN);  // insist on nonnegative integral exponents
+    ASSERT(jtequ(jt, e, floor1(e)) && all1(le(jfalse, e)), EVDOMAIN);  // insist on nonnegative integral exponents
     return jtevc(jt, c, e, "u v}(1+>./v)$0");                                // evaluate c 2 : 'u v}(1+>./v)$0' e
 }
 
@@ -552,7 +552,7 @@ jtpoly2(J jt, A a, A w, A self) {
         A* av = AAV(a);
         if (postfn) return jtupon2cell(jt, a, w, self);  // revert if ^@:p.   must do before a is modified
         ASSERT(2 >= an, EVLENGTH);
-        c = 1 == an ? num(1) : av[0];
+        c = 1 == an ? jtrue : av[0];
         a = av[1 != an];  // c=mplr, a=roots
         if ((an ^ 1) + (AR(a) ^ 2) == 0)
             return jtpoly2a(jt, a, w);  // if coeff is 1 and exponent-list is a table, go do multinomial

--- a/jsrc/verbs/v1.c
+++ b/jsrc/verbs/v1.c
@@ -283,7 +283,7 @@ jtmatchs(J jt, A a, A w) {
     wcr = wr < wcr ? wr : wcr;
     RESETRANK;
     if (ar > acr || wr > wcr) return rank2ex(a, w, UNUSED_VALUE, acr, wcr, acr, wcr, jtmatchs);
-    if (ar != wr || memcmpne(AS(a), AS(w), r * SZI) || !HOMO(AT(a), AT(w))) return num(0);
+    if (ar != wr || memcmpne(AS(a), AS(w), r * SZI) || !HOMO(AT(a), AT(w))) return jfalse;
     GATV0(x, B01, r, 1L);
     b = BAV(x);
     memset(b, C0, r);
@@ -321,19 +321,19 @@ jtmatchs(J jt, A a, A w) {
     qv = BAV(q);
     memset(pv, C1, m);
     DO(n, j = *v++; if (j < m) pv[j] = qv[i] = 0; else qv[i] = 1;);
-    if (memchr(pv, C1, m) && !all1(eq(we, jtrepeat(jt, p, ax)))) return num(0);
-    if (memchr(qv, C1, n) && !all1(eq(ae, jtrepeat(jt, q, wx)))) return num(0);
+    if (memchr(pv, C1, m) && !all1(eq(we, jtrepeat(jt, p, ax)))) return jfalse;
+    if (memchr(qv, C1, n) && !all1(eq(ae, jtrepeat(jt, q, wx)))) return jfalse;
     j = 0;
     DO(m, if (pv[i])++ j;);
     k = 0;
     DO(n, if (qv[i])++ k; qv[i] = !qv[i];);
-    if (!jtequ(jt, jtfrom(jt, jtrepeat(jt, q, x), ax), jtrepeat(jt, q, wx))) return num(0);
+    if (!jtequ(jt, jtfrom(jt, jtrepeat(jt, q, x), ax), jtrepeat(jt, q, wx))) return jfalse;
     x = SPA(ap, a);
     v = AV(x);
     s = AS(a);
     d = 1.0;
     DO(AN(x), d *= s[v[i]];);
-    return d == m + k && d == n + j || jtequ(jt, ae, we) ? num(1) : num(0);
+    return d == m + k && d == n + j || jtequ(jt, ae, we) ? jtrue : jfalse;
 } /* a -:"r w on sparse arrays */
 
 // x -:"r y or x -.@-:"r y depending on LSB of jt
@@ -344,7 +344,7 @@ jtmatch(J jt, A a, A w) {
     I eqis0   = (I)jt & 1;
     jt        = (J)((I)jt & ~1);
     I isatoms = (-AN(a)) & (-AN(w));  // neg if both args have atoms
-    if ((SPARSE & (AT(a) | AT(w))) != 0) return ne(num(eqis0), jtmatchs(jt, a, w));
+    if ((SPARSE & (AT(a) | AT(w))) != 0) return ne(eqis0 ? jtrue : jfalse, jtmatchs(jt, a, w));
     af = AR(a) - (I)(jt->ranks >> RANKTX);
     af = af < 0 ? 0 : af;
     wf = AR(w) - (I)((RANKT)jt->ranks);

--- a/jsrc/verbs/v1.c
+++ b/jsrc/verbs/v1.c
@@ -378,8 +378,8 @@ jtmatch(J jt, A a, A w) {
     // There are atoms.  If there is only 1 cell to compare, do it quickly
     if (wf == 0) {
         I nocall = (-(a != w) & ((AN(a) ^ AN(w)) - 1));
-        return num((nocall >= 0 ? SGNTO0(nocall) + (a == w) : ((B(*)())jtmatchsub)(jt, a, w, 0 MATCHSUBDEFAULTS)) ^
-                   eqis0);  // SGNTO0 to prevent misbranch
+        return numbool((nocall >= 0 ? SGNTO0(nocall) + (a == w) : ((B(*)())jtmatchsub)(jt, a, w, 0 MATCHSUBDEFAULTS)) ^
+                       eqis0);  // SGNTO0 to prevent misbranch
     }
     // Otherwise we are doing match with rank.  Set up for the repetition in matchsub
     // Create m: #cells in shorter (i. e. common) frame  n: # times cell of shorter frame is repeated

--- a/jsrc/verbs/v2.c
+++ b/jsrc/verbs/v2.c
@@ -629,7 +629,7 @@ jtqco2(J jt, A a, A w) {
     I c, j, k, m, *qv, wn, wr, *yv, *zv;
     wn = AN(w);
     wr = AR(w);
-    b  = all1(lt(a, zeroionei(0)));
+    b  = all1(lt(a, num(0)));
     xt = 1 && AT(w) & XNUM + RAT;
     if (AR(a) || wr && (b || xt)) return jtrank2ex0(jt, a, w, UNUSED_VALUE, jtqco2);
     if (!b && xt) {
@@ -641,8 +641,8 @@ jtqco2(J jt, A a, A w) {
     if (b) RZ(a = jtnegate(jt, a));
     bb = jtequ(jt, a, ainf);
     if (b & bb) { /* __ q: w */
-        RZ(y = ne(q, jtcurtail(jt, jtover(jt, zeroionei(0), q))));
-        return jtlamin2(jt, jtrepeat(jt, y, q), df1(z, y, jtcut(jt, ds(CPOUND), zeroionei(1))));
+        RZ(y = ne(q, jtcurtail(jt, jtover(jt, num(0), q))));
+        return jtlamin2(jt, jtrepeat(jt, y, q), df1(z, y, jtcut(jt, ds(CPOUND), num(1))));
     }
     RZ(y = jtvi(jt, jtplt(jt, q)));
     yv = AV(y);

--- a/jsrc/verbs/v2.c
+++ b/jsrc/verbs/v2.c
@@ -380,7 +380,7 @@ jtprimetest(J jt, A w) {
     A x;
     I t;
     t = AT(w);
-    if ((UI)SGNIF(t, B01X) >= (UI)AN(w)) return jtreshape(jt, shape(jt, w), num(0));  // AN is 0, or t is boolean
+    if ((UI)SGNIF(t, B01X) >= (UI)AN(w)) return jtreshape(jt, shape(jt, w), jfalse);  // AN is 0, or t is boolean
     switch (CTTZ(t)) {
         default: ASSERT(0, EVDOMAIN);
         case INTX: return jtiprimetest(jt, w);

--- a/jsrc/verbs/va2.c
+++ b/jsrc/verbs/va2.c
@@ -2146,14 +2146,14 @@ jtresidue(J jt, A a, A w, A self) {
 
 // We use the right type of singleton so that we engage AVX loops
 #define SETCONPTR(n)                            \
-    A conptr  = num(n);                         \
+    A conptr  = numbool(n);                     \
     A conptr2 = zeroionei(n);                   \
     A conptr3 = numvr(n);                       \
     conptr    = AT(w) & INT ? conptr2 : conptr; \
     conptr    = AT(w) & FL ? conptr3 : conptr;  // for 0 or 1 only
-#define SETCONPTR2(n)     \
-    A conptr  = num(n);   \
-    A conptr3 = numvr(n); \
+#define SETCONPTR2(n)       \
+    A conptr  = numbool(n); \
+    A conptr3 = numvr(n);   \
     conptr    = AT(w) & FL ? conptr3 : conptr;  // used for 2, when the only options are INT/FL
 
 A

--- a/jsrc/verbs/va2.c
+++ b/jsrc/verbs/va2.c
@@ -2147,7 +2147,7 @@ jtresidue(J jt, A a, A w, A self) {
 // We use the right type of singleton so that we engage AVX loops
 #define SETCONPTR(n)                            \
     A conptr  = numbool(n);                     \
-    A conptr2 = zeroionei(n);                   \
+    A conptr2 = num(n);                         \
     A conptr3 = numvr(n);                       \
     conptr    = AT(w) & INT ? conptr2 : conptr; \
     conptr    = AT(w) & FL ? conptr3 : conptr;  // for 0 or 1 only

--- a/jsrc/verbs/va2.c
+++ b/jsrc/verbs/va2.c
@@ -2158,7 +2158,7 @@ jtresidue(J jt, A a, A w, A self) {
 
 A
 jtnot(J jt, A w) {
-    SETCONPTR(1) return AT(w) & B01 + SB01 ? eq(num(0), w) : minus(conptr, w);
+    SETCONPTR(1) return AT(w) & B01 + SB01 ? eq(jfalse, w) : minus(conptr, w);
 }
 A
 jtnegate(J jt, A w) {

--- a/jsrc/verbs/va2s.c
+++ b/jsrc/verbs/va2s.c
@@ -238,8 +238,8 @@ jtvaspeq(J jt, A a, A w, C id, VF ado, I cv, I t, I zt, I f, I r) {
     I rc = EVOK;
     RZ(jtvaspeqprep(jt, a, w, t, f, r, &ae, &ay, &ax, &we, &wy, &wx, &za));
     if (id == CSTAR || id == CSTARDOT) {
-        ab = !jtequ(jt, ae, num(0));
-        wb = !jtequ(jt, we, num(0));
+        ab = !jtequ(jt, ae, jfalse);
+        wb = !jtequ(jt, we, jfalse);
     }
     v   = AS(ay);
     m   = v[0];

--- a/jsrc/verbs/va2ss.c
+++ b/jsrc/verbs/va2ss.c
@@ -741,7 +741,7 @@ compareresult:
     ziv &= 1;  // Since we are writing into num[], invest 1 instruction to make sure we don't have an invalid boolean
     // If we did not inplace a result block, return num[ziv].  To avoid a misbranch, we store the value and type into
     // num[], which is OK since they never change what's there already
-    aiv = (I)(num(ziv));
+    aiv = (I)(ziv ? jtrue : jfalse);
     z   = z ? z : (A)aiv;
     SSSTORE((B)ziv, z, B01, B) return z;
 

--- a/jsrc/verbs/vb.c
+++ b/jsrc/verbs/vb.c
@@ -365,7 +365,7 @@ jtanyebar(J jt, A a, A w) {
         case -4: return jtaslash(jt, CPLUSDOT, jtebarvec(jt, a, w));
     }
     if ((-m & -n) >= 0) {
-        return num(SGNTO0(-n));
+        return numbool(SGNTO0(-n));
     }  // empty argument.  If m, it matches everywhere, so use n; if n, it's 0, use it - 0/1 only
     GATV0(y, INT, d, 1);
     yv = AV(y);

--- a/jsrc/verbs/vb.c
+++ b/jsrc/verbs/vb.c
@@ -222,7 +222,7 @@ jtebar(J jt, A a, A w) {
     n  = AN(w);
     p  = n - m;
     switch (d) {
-        case -1: return jtreshape(jt, shape(jt, w), num(0));
+        case -1: return jtreshape(jt, shape(jt, w), jfalse);
         case -2: return jtebarmat(jt, a, w);
         case -3: return df2(z, shape(jt, a), w, jtcut(jt, jtamp(jt, a, ds(CMATCH)), num(3)));
         case -4: return jtebarvec(jt, a, w);
@@ -273,7 +273,7 @@ jti1ebar(J jt, A a, A w) {
     p  = n - m;
     switch (d) {
         case -1: return jtsc(jt, n);
-        case -4: return jtindexof(jt, jtebarvec(jt, a, w), num(1));
+        case -4: return jtindexof(jt, jtebarvec(jt, a, w), jtrue);
     }
     GATV0(y, INT, d, 1);
     yv = AV(y);
@@ -315,7 +315,7 @@ jtsumebar(J jt, A a, A w) {
     n  = AN(w);
     p  = n - m;
     switch (d) {
-        case -1: return num(0);
+        case -1: return jfalse;
         case -4: return jtaslash(jt, CPLUS, jtebarvec(jt, a, w));
     }
     if ((-m & -n) >= 0) {
@@ -361,7 +361,7 @@ jtanyebar(J jt, A a, A w) {
     n  = AN(w);
     p  = n - m;
     switch (d) {
-        case -1: return num(0);
+        case -1: return jfalse;
         case -4: return jtaslash(jt, CPLUSDOT, jtebarvec(jt, a, w));
     }
     if ((-m & -n) >= 0) {
@@ -373,26 +373,26 @@ jtanyebar(J jt, A a, A w) {
     switch (CTTZ(AT(w))) {
         case INTX:
             if (c)
-                EBLOOP(I, u[i] - c, v[k + m] - c, if (i == m) return num(1))
+                EBLOOP(I, u[i] - c, v[k + m] - c, if (i == m) return jtrue)
             else
-                EBLOOP(I, u[i], v[k + m], if (i == m) return num(1));
+                EBLOOP(I, u[i], v[k + m], if (i == m) return jtrue);
             break;
         case SBTX:
             if (c)
-                EBLOOP(SB, u[i] - c, v[k + m] - c, if (i == m) return num(1))
+                EBLOOP(SB, u[i] - c, v[k + m] - c, if (i == m) return jtrue)
             else
-                EBLOOP(SB, u[i], v[k + m], if (i == m) return num(1));
+                EBLOOP(SB, u[i], v[k + m], if (i == m) return jtrue);
             break;
-        case C2TX: EBLOOP(US, u[i], v[k + m], if (i == m) return num(1)); break;
+        case C2TX: EBLOOP(US, u[i], v[k + m], if (i == m) return jtrue); break;
         case C4TX:
             if (c)
-                EBLOOP(C4, u[i] - c, v[k + m] - c, if (i == m) return num(1))
+                EBLOOP(C4, u[i] - c, v[k + m] - c, if (i == m) return jtrue)
             else
-                EBLOOP(C4, u[i], v[k + m], if (i == m) return num(1));
+                EBLOOP(C4, u[i], v[k + m], if (i == m) return jtrue);
             break;
-        default: EBLOOP(UC, u[i], v[k + m], if (i == m) return num(1));
+        default: EBLOOP(UC, u[i], v[k + m], if (i == m) return jtrue);
     }
-    return num(0);
+    return jfalse;
 } /* a ([: +./ E.) w where a and w are atoms or lists */
 
 #define IFB1                         \

--- a/jsrc/verbs/vcant.c
+++ b/jsrc/verbs/vcant.c
@@ -34,7 +34,7 @@ jtcants(J jt, A a, A w, A z) {
     SPB(
       zp,
       x,
-      jtfrom(jt, q, jtcanta(jt, jtover(jt, zeroionei(0), jtincrem(jt, jtgrade1(jt, jtless(jt, a, a1)))), SPA(wp, x))));
+      jtfrom(jt, q, jtcanta(jt, jtover(jt, num(0), jtincrem(jt, jtgrade1(jt, jtless(jt, a, a1)))), SPA(wp, x))));
     return z;
 } /* w is sparse */
 

--- a/jsrc/verbs/vcompsc.c
+++ b/jsrc/verbs/vcompsc.c
@@ -209,7 +209,7 @@
         n  = 1;                                                        \
         n  = AR(a) ? an : n;                                           \
         n  = AR(w) ? wn : n;                                           \
-        if ((q = (n - 1) >> LGSZI) < 0) return zeroionei(0);           \
+        if ((q = (n - 1) >> LGSZI) < 0) return num(0);                 \
         r   = ((n - 1) & (SZI - 1)); /* # first bytes to do minus 1 */ \
         I i = q;                                                       \
         if (!AR(a)) {                                                  \

--- a/jsrc/verbs/vd.c
+++ b/jsrc/verbs/vd.c
@@ -106,9 +106,9 @@ jtqrr(J jt, A w) {
     m     = (m + tom < n) ? m + tom : m;  // Minimize number of wasted multiply slots, processing in batches of 4
     if (1 >= n) {                         // just 1 col
         t = jtnorm(jt, jtravel(jt, w));   // norm of col
-        ASSERT(!AN(w) || !jtequ(jt, t, num(0)), EVDOMAIN);  // norm must not be 0 unless column is empty
+        ASSERT(!AN(w) || !jtequ(jt, t, jfalse), EVDOMAIN);  // norm must not be 0 unless column is empty
         RZ(q = tymes(w, jtrecip(jt, t)));
-        return link(2 > AR(q) ? jttable(jt, q) : q, jtreshape(jt, jtv2(jt, n, n), p ? t : num(1)));
+        return link(2 > AR(q) ? jttable(jt, q) : q, jtreshape(jt, jtv2(jt, n, n), p ? t : jtrue));
     }
     // construe w as w0 w1 w0t w1t
     RZ(t0 = jtqrr(jt, jttake(jt, jtv2(jt, p, m), w)));  // find QR of w0 pxm   w0t
@@ -156,7 +156,7 @@ jtltqip(J jt, A w) {
             AN(q0)    = cl;  // kludge use sumattymesprod to create a table result directly
             A t;
             RZ(t = jtnorm(jt, q0));                   // norm of row
-            ASSERT(!jtequ(jt, t, num(0)), EVDOMAIN);  // norm must not be 0
+            ASSERT(!jtequ(jt, t, jfalse), EVDOMAIN);  // norm must not be 0
             A z;
             RZ(z = tymesA(w, jtrecip(jt, t)));
             verifyinplace(w, z);

--- a/jsrc/verbs/ve.c
+++ b/jsrc/verbs/ve.c
@@ -570,7 +570,7 @@ static A
 jtweight(J jt, A a, A w) {
     A z;
     return df1(
-      z, jtbehead(jt, jtover(jt, AR(w) ? w : jtreshape(jt, a, w), num(1))), jtbsdot(jt, jtslash(jt, ds(CSTAR))));
+      z, jtbehead(jt, jtover(jt, AR(w) ? w : jtreshape(jt, a, w), jtrue)), jtbsdot(jt, jtslash(jt, ds(CSTAR))));
 }  // */\. }. (({:$a)$w),1
 
 A

--- a/jsrc/verbs/ve.c
+++ b/jsrc/verbs/ve.c
@@ -638,11 +638,11 @@ jtabase1(J jt, A w) {
     ASSERT(t & DENSE, EVNONCE);
     // Result has rank one more than the input.  If there are no atoms,
     // return (($w),0)($,)w; if Boolean, return (($w),1)($,)w
-    if ((-n & SGNIFNOT(t, B01X)) >= 0) return jtreshape(jt, apip(shape(jt, w), zeroionei(n != 0)), w);
+    if ((-n & SGNIFNOT(t, B01X)) >= 0) return jtreshape(jt, apip(shape(jt, w), num(n != 0)), w);
     if (!(t & INT)) {
         // Not integer.  Calculate # digits-1 as d = 2 <.@^. >./ | , w
         df2(
-          d, num(2), maximum(zeroionei(1), jtaslash(jt, CMAX, mag(jtravel(jt, w)))), jtatop(jt, ds(CFLOOR), ds(CLOG)));
+          d, num(2), maximum(num(1), jtaslash(jt, CMAX, mag(jtravel(jt, w)))), jtatop(jt, ds(CFLOOR), ds(CLOG)));
         // Calculate z = ((1+d)$2) #: w
         RZ(z = jtabase2(jt, jtreshape(jt, jtincrem(jt, d), num(2)), w));
         // If not float, result is exact or complex; either way, keep it
@@ -651,7 +651,7 @@ jtabase1(J jt, A w) {
         // calculate that as (0 = >./ ({."1 z)).  If so, return }."1 z ,  otherwise z
         // But we can't delete a digit if any of the values were negative - all are significant then
         // We also can't delete a digit if there is only 1 digit in the numbers
-        if (AS(z)[AR(z) - 1] <= 1 || jti0(jt, jtaslash(jt, CPLUSDOT, jtravel(jt, lt(w, zeroionei(0)))))) return z;
+        if (AS(z)[AR(z) - 1] <= 1 || jti0(jt, jtaslash(jt, CPLUSDOT, jtravel(jt, lt(w, num(0)))))) return z;
         if (0 == jti0(jt, jtaslash(jt, CMAX, jtravel(jt, IRS1(z, 0L, 1L, jthead, d)))))
             return IRS1(z, 0L, 1L, jtbehead, d);
         return z;

--- a/jsrc/verbs/vg.c
+++ b/jsrc/verbs/vg.c
@@ -1364,7 +1364,7 @@ jtordstat(J jt, A a, A w) {
         ASSERT((UI)j < (UI)n, EVINDEX);
     }
     // deal a bunch of random floats to provide pivots.  We reuse them if needed
-    RZ(df2(q, jtsc(jt, NRANDS), num(0), jtatop(jt, ds(CQUERY), ds(CDOLLAR))));
+    RZ(df2(q, jtsc(jt, NRANDS), jfalse, jtatop(jt, ds(CQUERY), ds(CDOLLAR))));
     qv = DAV(q);
     if (wt & FL) OSLOOP(D, jtscf) else OSLOOP(I, jtsc);
 } /* a{/:~w */

--- a/jsrc/verbs/vgauss.c
+++ b/jsrc/verbs/vgauss.c
@@ -78,7 +78,7 @@ jtdetr(J jt, A w) {
               e = i + j;
               break;
           } u += c;); /* find pivot row */
-        if (0 > e) return jtcvt(jt, RAT, num(0));
+        if (0 > e) return jtcvt(jt, RAT, jfalse);
         x = v + c * j;
         if (j != e) {
             u = v + c * e;

--- a/jsrc/verbs/vgranking.c
+++ b/jsrc/verbs/vgranking.c
@@ -132,7 +132,7 @@ jtranking(J jt, A w) {
     else {
         RE(m = jtprod(jt, wf, ws));
         return m ? jtreitem(jt, jtvec(jt, INT, wf, ws), jtiota(jt, jtv2(jt, 1L, n)))
-                 : jtreshape(jt, jtvec(jt, INT, 1 + wf, ws), num(0));
+                 : jtreshape(jt, jtvec(jt, INT, 1 + wf, ws), jfalse);
     }
     PROD(icn, wcr - 1, ws + wf + 1);
     k = icn << bplg(

--- a/jsrc/verbs/vgsp.c
+++ b/jsrc/verbs/vgsp.c
@@ -329,7 +329,7 @@ jtgrd1spdd(J jt, A w, I wf, I wcr) {
     n  = wcr ? ws[wf] : 1;
     x  = SPA(wp, x);
     if (AN(x)) {
-        RZ(z = jtfrom(jt, num(0), x));
+        RZ(z = jtfrom(jt, jfalse, x));
         return IRS1(z, 0L, wcr, jtgr1, x);
     } else {
         return jtreshape(jt, jtvec(jt, INT, 1 + wf, ws), IX(n));

--- a/jsrc/verbs/vi.c
+++ b/jsrc/verbs/vi.c
@@ -2094,7 +2094,7 @@ jtindexofsub(J jt, I mode, A a, A w) {
                 case IIFBEPS: return mtv;
                 case IANYEPS:
                 case IALLEPS:
-                case II0EPS: return num(0);
+                case II0EPS: return jfalse;
                 case ISUMEPS: return jtsc(jt, 0L);
                 case II1EPS:
                 case IJ1EPS: return jtsc(jt, witems);
@@ -2246,7 +2246,7 @@ jtindexofsub(J jt, I mode, A a, A w) {
                 return z;
             }  // all 0 but the first has the total count
             case IICO: return jtreshape(jt, shape(jt, z), jtsc(jt, n ? m : m - 1));
-            case INUBSV: return jtreshape(jt, shape(jt, z), jttake(jt, jtsc(jt, m), num(1)));
+            case INUBSV: return jtreshape(jt, shape(jt, z), jttake(jt, jtsc(jt, m), jtrue));
             case INUB:
                 AN(z)  = 0;
                 *AS(z) = m ? 1 : 0;
@@ -2257,7 +2257,7 @@ jtindexofsub(J jt, I mode, A a, A w) {
                 else
                     memcpy(AV(z), AV(w), k1 * AN(w));
                 return z;
-            case IEPS: return jtreshape(jt, shape(jt, z), num(m && (!n || th)));
+            case IEPS: return jtreshape(jt, shape(jt, z), (m && (!n || th)) ? jtrue : jfalse);
             case INUBI: return m ? iv0 : mtv;
             // th<0 means that the result of e. would have rank>1 and would never compare against either 0 or 1
             case II0EPS: return jtsc(jt, n && zn ? 0L : witems);
@@ -2265,8 +2265,8 @@ jtindexofsub(J jt, I mode, A a, A w) {
             case IJ0EPS: return jtsc(jt, n && zn ? MAX(0, witems - 1) : witems);
             case IJ1EPS: return jtsc(jt, n && zn ? witems : MAX(0, witems - 1));
             case ISUMEPS: return jtsc(jt, n ? 0L : c);  // must include shape of w
-            case IANYEPS: return num(!n);
-            case IALLEPS: return num(!(c && n));
+            case IANYEPS: return n ? jfalse : jtrue;
+            case IALLEPS: return (c && n) ? jfalse : jtrue;
             case IIFBEPS: return n ? mtv : IX(c);
         }
     }
@@ -2817,7 +2817,7 @@ jtsclass(J jt, A w) {
     I c, j, m, n, *v;
     P* p;
     // If w is scalar, return 1 1$1
-    if (!AR(w)) return jtreshape(jt, jtv2(jt, 1L, 1L), num(1));
+    if (!AR(w)) return jtreshape(jt, jtv2(jt, 1L, 1L), jtrue);
     SETIC(w, n);                  // n=#items of y
     RZ(x = jtindexof(jt, w, w));  // x = i.~ y
     // if w is dense, return ((x = i.n) # x) =/ x
@@ -2845,9 +2845,9 @@ jtsclass(J jt, A w) {
     v[1] = n;
     p    = PAV(z);
     SPB(p, a, jtv2(jt, 0L, 1L));
-    SPB(p, e, num(0));
+    SPB(p, e, jfalse);
     SPB(p, i, xy);
-    SPB(p, x, jtreshape(jt, jtsc(jt, c), num(1)));
+    SPB(p, x, jtreshape(jt, jtsc(jt, c), jtrue));
     return z;
 }
 

--- a/jsrc/verbs/visp.c
+++ b/jsrc/verbs/visp.c
@@ -171,7 +171,7 @@ jtioe(J jt, I mode, A w) {
         AR(b)        = 2;
     }
     if (1 < AR(b)) RZ(b = jtaslash1(jt, CSTARDOT, b)); /* b=. *./@,"_1 (3$.w)=5$.w */
-    RZ(y = jtirs2(jt, num(0), y, 0L, 0L, 1L, jtfrom));
+    RZ(y = jtirs2(jt, jfalse, y, 0L, 0L, 1L, jtfrom));
     RZ(df2(p, y, b, jtsldot(jt, jtslash(jt, ds(CSTARDOT)))));
     RZ(j = jtrepeat(jt, jtnot(jt, p), jtrepeat(jt, ne(y, jtcurtail(jt, jtover(jt, num(-1), y))), y)));
     jn = AN(j);
@@ -275,7 +275,7 @@ jtiopart(J jt, A w, I r, I mm, I* zc, A* zi, A* zj, A* zx) {
            v += n;)
     }
     if (m) {
-        RZ(f = jtcut(jt, ds(CCOMMA), num(1)));
+        RZ(f = jtcut(jt, ds(CCOMMA), jtrue));
         RZ(df2(y, b, jtdropr(jt, d, wy), f));
         RZ(df2(x, b, wx, f));
     } else {
@@ -398,8 +398,8 @@ jtnubsievesp(J jt, A w) {
     GASPARSE(z, SB01, 1, 1, &n);
     p = PAV(z);
     SPB(p, a, iv0);
-    SPB(p, e, num(0));
+    SPB(p, e, jfalse);
     SPB(p, i, y);
-    SPB(p, x, jtreshape(jt, jtsc(jt, m), num(1)));
+    SPB(p, x, jtreshape(jt, jtsc(jt, m), jtrue));
     return z;
 }

--- a/jsrc/verbs/vm.c
+++ b/jsrc/verbs/vm.c
@@ -221,5 +221,5 @@ jtrect(J jt, A w) {
         SPB(zp, x, jtrect(jt, SPA(wp, x)));
         return z;
     } else
-        return df2(z, w, jfalse, jtqq(jt, ds(CCOMMA), zeroionei(0)));
+        return df2(z, w, jfalse, jtqq(jt, ds(CCOMMA), num(0)));
 }

--- a/jsrc/verbs/vm.c
+++ b/jsrc/verbs/vm.c
@@ -221,5 +221,5 @@ jtrect(J jt, A w) {
         SPB(zp, x, jtrect(jt, SPA(wp, x)));
         return z;
     } else
-        return df2(z, w, num(0), jtqq(jt, ds(CCOMMA), zeroionei(0)));
+        return df2(z, w, jfalse, jtqq(jt, ds(CCOMMA), zeroionei(0)));
 }

--- a/jsrc/verbs/vo.c
+++ b/jsrc/verbs/vo.c
@@ -607,7 +607,7 @@ jtopes1(J jt, B **zb, A *za, A *ze, I *zm, A cs, A w) {
     A bvec = jtifb(jt, wcr, b);
     makewritable(bvec) RZ(*za = bvec); /* union of sparse axes           */  // avoid readonly
     *zb = b;                                                                 /* mask corresp. to sparse axes   */
-    *ze = e ? e : num(0);                                                    /* sparse element                 */
+    *ze = e ? e : jfalse;                                                    /* sparse element                 */
     *zm = m;                                                                 /* estimate # of non-sparse cells */
     return 1;
 }

--- a/jsrc/verbs/vrand.c
+++ b/jsrc/verbs/vrand.c
@@ -488,7 +488,7 @@ jtrngstateq(J jt, A w) {
         case SMI:
             GAT0(z, BOX, 9, 1);
             zv = AAV(z);
-            RZ(*zv++ = num(0));
+            RZ(*zv++ = jfalse);
             RZ(*zv++ = jtincorp(jt, jtsc(jt, jt->rngI0[GBI])));
             RZ(*zv++ = jtincorp(jt, jtvec(jt, INT, GBN, jt->rngV0[GBI])));
             RZ(*zv++ = jtincorp(jt, jtsc(jt, jt->rngI0[MTI])));

--- a/jsrc/verbs/vrep.c
+++ b/jsrc/verbs/vrep.c
@@ -34,7 +34,7 @@ jtrepzsx(J jt, A a, A w, I wf, I wcr) {
     yv = AV(y);
     RZ(x = jtcvt(jt, INT, jtvec(jt, FL, 2 * m, AV(x))));
     xv = AV(x);
-    if (jtequ(jt, num(0), SPA(ap, e))) {
+    if (jtequ(jt, jfalse, SPA(ap, e))) {
         k = c = *(wf + AS(w));
         if (!wf && SPARSE & AT(w)) {
             A a, y;
@@ -356,7 +356,7 @@ jtrep1sa(J jt, A a, I *c, I *d) {
     b = 1 && AT(a) & CMPX;
     if (b) RZ(x = jtrect(jt, a)) else x = a;
     if (AR(a)) {
-        ASSERT(jtequ(jt, num(1), jtaslash(jt, CSTARDOT, le(zeroionei(0), jtravel(jt, x)))), EVDOMAIN);
+        ASSERT(jtequ(jt, jtrue, jtaslash(jt, CSTARDOT, le(zeroionei(0), jtravel(jt, x)))), EVDOMAIN);
         RZ(x = jtaslash(jt, CPLUS, x));
     }
     if (!(INT & AT(x))) RZ(x = jtcvt(jt, INT, x));

--- a/jsrc/verbs/vrep.c
+++ b/jsrc/verbs/vrep.c
@@ -356,7 +356,7 @@ jtrep1sa(J jt, A a, I *c, I *d) {
     b = 1 && AT(a) & CMPX;
     if (b) RZ(x = jtrect(jt, a)) else x = a;
     if (AR(a)) {
-        ASSERT(jtequ(jt, jtrue, jtaslash(jt, CSTARDOT, le(zeroionei(0), jtravel(jt, x)))), EVDOMAIN);
+        ASSERT(jtequ(jt, jtrue, jtaslash(jt, CSTARDOT, le(num(0), jtravel(jt, x)))), EVDOMAIN);
         RZ(x = jtaslash(jt, CPLUS, x));
     }
     if (!(INT & AT(x))) RZ(x = jtcvt(jt, INT, x));

--- a/jsrc/verbs/vs.c
+++ b/jsrc/verbs/vs.c
@@ -37,7 +37,7 @@ jtscheck(J jt, A w) {
     ASSERTSYS(SETIC(y, k1) == SETIC(x, k2), "scheck i/x tally");
     ASSERTSYS(*(1 + AS(y)) == SETIC(a, k1), "scheck i/a length");
     ASSERTSYS(jtequ(jt, y, jtnub(jt, y)), "scheck i unique");
-    ASSERTSYS(all1(le(num(0), y)), "scheck i negative");
+    ASSERTSYS(all1(le(jfalse, y)), "scheck i negative");
     ASSERTSYS(all1(ATOMIC2(jt, y, jtfrom(jt, a, shape(jt, w)), rkblk, 1L, 1L, CLT)), "scheck i index");
     ASSERTSYS(jtequ(jt, jtgrade1(jt, y), IX(*AS(y))), "scheck i sorted");
     ASSERTSYS(AR(x) == 1 + r - AN(a), "scheck x rank");
@@ -47,7 +47,7 @@ jtscheck(J jt, A w) {
 
 static A
 jtselm(J jt, I t) {
-    return t & NUMERIC ? jtcvt(jt, t, num(0)) : t & BOX ? ds(CACE) : chrspace;
+    return t & NUMERIC ? jtcvt(jt, t, jfalse) : t & BOX ? ds(CACE) : chrspace;
 }
 
 A
@@ -245,7 +245,7 @@ jtsparseit(J jt, A w, A a, A e) {
     v     = AS(x);
     *v    = m;
     if (r > n) ICPY(1 + v, n + s, r - n);
-    b = b && SB01 & AT(z) && jtequ(jt, e, num(0));
+    b = b && SB01 & AT(z) && jtequ(jt, e, jfalse);
     c = w;
     if (!b) RZ(c = jtnot(jt, jtirs2(jt, jtreshape(jt, jtvec(jt, INT, r - n, n + s), SPA(p, e)), x, VFLAGNONE, RMAX, -1L, jtmatch)));
     cn = AN(c);
@@ -298,7 +298,7 @@ jtsparseit(J jt, A w, A a, A e) {
         }
     }
     SPB(p, i, y);
-    SPB(p, x, b ? jtreshape(jt, jtsc(jt, cm), num(1)) : jtrepeat(jt, c, x));
+    SPB(p, x, b ? jtreshape(jt, jtsc(jt, cm), jtrue) : jtrepeat(jt, c, x));
     EPILOG(z);
 }
 

--- a/jsrc/verbs/vsb.c
+++ b/jsrc/verbs/vsb.c
@@ -938,7 +938,7 @@ jtsbcheck1(J jt, A una, A sna, A u, A s, A h, A roota, A ff, A gp) {
         ASSERTD(BETWEENO(j, 0, c) && 1 >= ++upv[j] && (!j || ord < (j + uv)->order), "u successor");
     }
     ASSERTD(jtequ(jt, jtgrade1(jt, x), jtgrade1(jt, y)), "u order");
-    EPILOG(num(1));
+    EPILOG(jtrue);
 }
 
 static A
@@ -984,7 +984,7 @@ jtsbsetdata(J jt, A w) {
     fa(u);
     fa(s);
     fa(h);
-    return num(1);
+    return jtrue;
 }
 
 static A
@@ -1024,9 +1024,9 @@ jtsb2(J jt, A a, A w) {
                 case 5: return jtsc(jt, ROOT);
                 case 6: return jtsc(jt, FILLFACTOR);
                 case 7: return jtsc(jt, GAP);
-                case 10: return jtsbgetdata(jt, num(0));
-                case 11: return jtsbcheck(jt, num(0));
-                case 12: return jtsbhashstat(jt, num(0));
+                case 10: return jtsbgetdata(jt, jfalse);
+                case 11: return jtsbcheck(jt, jfalse);
+                case 12: return jtsbhashstat(jt, jfalse);
             }
         case 1: return jtsbstr(jt, 1L, w);
         case -1: return jtsbunstr(jt, -1L, w);

--- a/jsrc/words/wn.c
+++ b/jsrc/words/wn.c
@@ -338,12 +338,12 @@ jtconnum(J jt, I n, C *s) {
     I d = 0, e, k, m, t, *yv;
     if (1 == n) {
         if (k = s[0] - '0', (UI)k <= (UI)9)
-            return num(k);
+            return numbool(k);
         else
             return ainf;
     }  // single digit - a number or _
     else if (2 == n && CSIGN == *s) {
-        if (k = s[1] - '0', (UI)k <= (UI)9) return num(-k);
+        if (k = s[1] - '0', (UI)k <= (UI)9) return numbool(-k);
     }
     RZ(y = jtmkwris(jt, jtstr(jt, 1 + n, s)));
     s = v = CAV(y);

--- a/jsrc/xenos/x15.c
+++ b/jsrc/xenos/x15.c
@@ -3063,7 +3063,7 @@ jtmemf(J jt, A w) {
     I k;
     RE(k = jti0(jt, w));
     free((void *)k);
-    return num(0);
+    return jfalse;
 }
 /* 15!:4  memory free */
 
@@ -3160,7 +3160,7 @@ jtfh15(J jt, A w) {
     I k;
     RE(k = jti0(jt, w));
     jtfh(jt, (A)k);
-    return num(0);
+    return jfalse;
 }
 /* 15!:9  free header */
 

--- a/jsrc/xenos/xb.c
+++ b/jsrc/xenos/xb.c
@@ -1051,8 +1051,8 @@ jtiso8601toe(J jt, A a, A w) {
         w    = a;
         prec = 9;  // monad: switch argument, set defaults
     }
-    ASSERT(AT(w) & LIT, EVDOMAIN);                                             // must be LIT
-    ASSERT(AR(w), EVRANK);                                                     // must not be an atom
-    if (!AN(w)) { return df1(z, w, jtqq(jt, jtsc(jt, IMIN), zeroionei(1))); }  // return _"1 w on empty w - equivalent
+    ASSERT(AT(w) & LIT, EVDOMAIN);                                       // must be LIT
+    ASSERT(AR(w), EVRANK);                                               // must not be an atom
+    if (!AN(w)) { return df1(z, w, jtqq(jt, jtsc(jt, IMIN), num(1))); }  // return _"1 w on empty w - equivalent
     return efs(jt, w, prec);
 }

--- a/jsrc/xenos/xcrc.c
+++ b/jsrc/xenos/xcrc.c
@@ -110,9 +110,9 @@ jtqhash12(J jt, A a, A w) {
                   UCAV(w));  // sign-extend result if needed to make 64-bit and 32-bit the same numeric value
     } else {                 // not DIRECT, calculate CRC of component CRCs
         crc    = -1;         // where we accumulate CRC
-        I lpct = AN(w) << ((AT(w) >> RATX) & 1);                                    // number of component values
-        A *av  = AAV(w);                                                            // pointer to subvalues
-        DQ(lpct, crc = CRC32L(crc, jti0(jt, jtqhash12(jt, zeroionei(0), *av++)));)  // recur
+        I lpct = AN(w) << ((AT(w) >> RATX) & 1);                              // number of component values
+        A *av  = AAV(w);                                                      // pointer to subvalues
+        DQ(lpct, crc = CRC32L(crc, jti0(jt, jtqhash12(jt, num(0), *av++)));)  // recur
     }
     if (hsiz) crc = (crc * (UI)hsiz) >> 32;  // convert hash to user's range
     return jtsc(jt, (I)(I4)crc);             // make the result a valid integer.  Could reuse the a arg inplace

--- a/jsrc/xenos/xf.c
+++ b/jsrc/xenos/xf.c
@@ -275,7 +275,7 @@ jtjmkdir(J jt, A w) {
     F1RANK(0, jtjmkdir, UNUSED_VALUE);
     ASSERT(AT(w) & BOX, EVDOMAIN);
     RZ(y = jtstr0(jt, jtvslit(jt, AAV(w)[0])));
-    return mkdir(CAV(y), 0775) ? jtjerrno(jt) : num(1);
+    return mkdir(CAV(y), 0775) ? jtjerrno(jt) : jtrue;
 }
 
 A
@@ -291,7 +291,7 @@ jtjferase(J jt, A w) {
         ASSERT(y = jtvslit(jt, AAV(w)[0]), EVFNUM);
     if (h) RZ(jtjclose(jt, jtsc(jt, h)));
     A y0 = jtstr0(jt, y);
-    return !unlink(CAV(y0)) || !rmdir(CAV(y0)) ? num(1) : jtjerrno(jt);
+    return !unlink(CAV(y0)) || !rmdir(CAV(y0)) ? jtrue : jtjerrno(jt);
 
 } /* erase file or directory */
 
@@ -320,9 +320,9 @@ jtjgetenv(J jt, A w) {
     ASSERT((LIT + C2T + C4T) & AT(w), EVDOMAIN);
     {
         C *s;
-        return (s = getenv(CAV(jttoutf8x(jt, w)))) ? jtcstr(jt, s) : num(0);  // toutf8x has trailing nul
+        return (s = getenv(CAV(jttoutf8x(jt, w)))) ? jtcstr(jt, s) : jfalse;  // toutf8x has trailing nul
     }
-    return num(0);
+    return jfalse;
 }
 
 A

--- a/jsrc/xenos/xfmt.c
+++ b/jsrc/xenos/xfmt.c
@@ -935,7 +935,7 @@ jtfmtxi(J jt, A a, A w, I mode, I *omode) {
     *omode = 0;
     if ((SPARSE & AT(w)) != 0) RZ(w = jtdenseit(jt, w));
     if (!AN(w)) RZ(w = jtreshape(jt, shape(jt, w), chrspace));
-    if (JCHAR & AT(w)) return df1(a, w, jtqq(jt, jtatop(jt, ds(CBOX), ds(CCOMMA)), num(1)));
+    if (JCHAR & AT(w)) return df1(a, w, jtqq(jt, jtatop(jt, ds(CBOX), ds(CCOMMA)), jtrue));
     ASSERT(1 >= AR(a), EVRANK);
     ASSERT(!AN(a) || JCHAR + BOX & AT(a), EVDOMAIN);
     if (JCHAR & AT(a) || !AN(a)) RZ(a = jtfmtbfc(jt, a));
@@ -952,7 +952,7 @@ jtfmtxi(J jt, A a, A w, I mode, I *omode) {
               ASSERT(!(AR(x) && AT(x) & NUMERIC), EVRANK);
           });
         A z;
-        return df2(z, jtreitem(jt, shape(jt, w), a), w, jtamp(jt, jtforeign(jt, num(8), num(0)), ds(COPE)));
+        return df2(z, jtreitem(jt, shape(jt, w), a), w, jtamp(jt, jtforeign(jt, num(8), jfalse), ds(COPE)));
     } else {
         if (XNUM + RAT + CMPX & AT(w)) RZ(w = jtcvt(jt, FL, w));
         *omode = mode;
@@ -980,7 +980,7 @@ jtfmt12(J jt, A a, A w) {
     A t;
     df1(t,
         jtcant1(jt, 2 == r ? z : jtreshape(jt, jtv2(jt, 1L, SETIC(z, j)), z)),
-        jtqq(jt, jtatco(jt, ds(CBOX), ds(COPE)), num(1)));
+        jtqq(jt, jtatco(jt, ds(CBOX), ds(COPE)), jtrue));
     return jtravel(jt, t);
 } /* 8!:1 dyad */
 
@@ -995,7 +995,7 @@ jtfmt22(J jt, A a, A w) {
     A t;
     df1(t,
         jtcant1(jt, 2 == r ? z : jtreshape(jt, jtv2(jt, 1L, SETIC(z, j)), z)),
-        jtqq(jt, jtatco(jt, ds(CBOX), ds(COPE)), num(1)));
+        jtqq(jt, jtatco(jt, ds(CBOX), ds(COPE)), jtrue));
     RZ(z = jtravel(jt, t));
     return AS(z)[0] ? jtrazeh(jt, z) : jtlamin1(jt, z);
 } /* 8!:2 dyad */

--- a/jsrc/xenos/xl.c
+++ b/jsrc/xenos/xl.c
@@ -64,10 +64,10 @@ jtjlock(J jt, A w) {
         AM(jt->flkd) = ct;
     }
     RE(b = jtdolock(jt, 1, (F)v[0], v[1], v[2]));
-    if (!b) return num(0);
+    if (!b) return jfalse;
     ICPY(AV(jt->flkd) + LKC * AM(jt->flkd), v, LKC);
     ++AM(jt->flkd);
-    return num(1);
+    return jtrue;
 } /* w is (number,index,length); lock the specified region */
 
 static A
@@ -79,13 +79,13 @@ jtunlj(J jt, I j) {
     u = AV(jt->flkd);
     v = u + j * LKC;
     RE(b = jtdolock(jt, 0, (F)v[0], v[1], v[2]));
-    if (!b) return num(0);
+    if (!b) return jfalse;
     --AM(jt->flkd);
     if (j < AM(jt->flkd))
         ICPY(v, u + AM(jt->flkd) * LKC, LKC);
     else
         *v = 0;
-    return num(1);
+    return jtrue;
 } /* unlock the j-th entry in jt->flkd */
 
 A

--- a/jsrc/xenos/xo.c
+++ b/jsrc/xenos/xo.c
@@ -160,7 +160,7 @@ jtjclose(J jt, A w) {
         av[j] = av[AM(jt->fopf)];
         iv[j] = iv[AM(jt->fopf)];
     }
-    return num(1);
+    return jtrue;
 } /* close file# w */
 
 F

--- a/jsrc/xenos/xs.c
+++ b/jsrc/xenos/xs.c
@@ -51,7 +51,7 @@ jtline(J jt, A w, I si, C ce, B tso) {
     A x  = mtv, z;
     B xt = jt->tostdout;
     DC d, xd = jt->dcs;
-    if (jtequ(jt, w, num(1))) return mtm;
+    if (jtequ(jt, w, jtrue)) return mtm;
     RZ(w = jtvs(jt, w));
     // Handle locking.  Global glock has lock status for higher levels.  We see if this text is locked; if so, we mark
     // lock status for this level We do not inherit the lock from higher levels, per the original design
@@ -100,7 +100,7 @@ jtline(J jt, A w, I si, C ce, B tso) {
     FDEPDEC(1);                          // ASSERT OK now
     jt->uflags.us.cx.cx_c.glock = oldk;  // pop lock status
     if (3 == ce) {
-        z = num(jt->jerr == 0);
+        z = jt->jerr == 0 ? jtrue : jfalse;
         RESETERR;
         return z;
     } else

--- a/jsrc/xenos/xt.c
+++ b/jsrc/xenos/xt.c
@@ -210,7 +210,7 @@ jttsit2(J jt, A a, A w) {
 
 A
 jttsit1(J jt, A w) {
-    return jttsit2(jt, num(1), w);
+    return jttsit2(jt, jtrue, w);
 }
 
 #define sleepms(i) usleep(i * 1000)
@@ -275,7 +275,7 @@ jtpmfree(J jt, A w) {
            ++v;);
         fa(w);
     }
-    return num(1);
+    return jtrue;
 } /* free old data area */
 
 A

--- a/learning/REFACTORINGS.md
+++ b/learning/REFACTORINGS.md
@@ -27,7 +27,6 @@
 |         `AV`          |                 `pointer_to_values`                 |
 |         `IAV`         |                 `pointer_to_values`                 |
 |    `IAV(w)[i] = k`    |               `set_value_at(w, i, k)`               |
-|       `k & ~1`        |                  `!zero_or_one(k)`                  |
 | `GAT0(z, TYPE, x, y)` |   `z = make_array<TYPE, copy_shape_0>(jt, x, y)`    |
 |       `GA(...)`       |                    `make_array`                     |
 |         `sc`          |                `make_scalar_integer`                |

--- a/learning/REFACTORINGS.md
+++ b/learning/REFACTORINGS.md
@@ -23,7 +23,6 @@
 | :-------------------: | :-------------------------------------------------: |
 |          `A`          |                       `array`                       |
 |       `SETIC` 1       |                   `item_count()`                    |
-|       `REPSGN`        |                 `replicate_sign` 2                  |
 |         `AV`          |                 `pointer_to_values`                 |
 |         `IAV`         |                 `pointer_to_values`                 |
 |    `IAV(w)[i] = k`    |               `set_value_at(w, i, k)`               |
@@ -33,4 +32,3 @@
 |      `DO(m, s)`       | `for (int i = 0; i < m; ++i) m` OR `std::algorithm` |
 
 1. There could be exceptions where this doesn't work
-2. Will probably be renamed


### PR DESCRIPTION
This should fix (or at least kickstart) #85, #86 and #87. The technical write up is in #87, the refactoring schedule has been updated a bit. This changes a lot of the internals (in the C code as well), I wouldn't mind having more than one review on it. I would advise to review each commit separately, instead of looking at the full diff.

 The changes include:
* Add a `numbool` macro that preserves the old behaviour of `num`. This is used in locations where we actually return a number or a boolean, or if we aren't sure of the input value. The perfect case would be to remove this macro eventually, but we might have to stick with it. The macro has some documentation
* Add `jtrue` and `jfalse` macros, replace the old `num(0)` and `num(1)` entries with these. The names have been inspired by the suggestion for `jarray`, and we needed some prefix to distinguish them from `true` and `false`.
* Create a separate lookup table for the boolean, use those every time we try to return a boolean instead of `Bnum`. The booleans in `Bnum` are now unused.
* Replace the (unused) booleans in `Bnum` with integers 0 and 1, and replace `zeroionei` with `num`
* Remove the duplicated integers in `Bnum` and update all lookup indices.
* Cleanup `refactorme_num` a little bit, add some documentation (mostly copied from `numbool`), rename it to `num` and undefine the C macro. The C++ code that includes `header.hpp` will now use the new implementation.