### PR TITLE
Remove FHS from C source

### DIFF
--- a/jsrc/jeload.cpp
+++ b/jsrc/jeload.cpp
@@ -32,8 +32,6 @@ static JGetAType jgeta;
 static JSetAType jseta;
 std::string path;
 std::string pathdll;
-static char jdllver[20];  // Not sure why this is being added, but keeping it for now.
-static int FHS = 0;       // Not sure what this is
 
 auto
 jedo(char const* sentence) -> int {
@@ -178,15 +176,9 @@ auto
 jefirst(int type, char* arg) -> int {
     std::string input;
 
-    if (type == 0) {
-        if (!FHS)
-            input.append("(3 : '0!:0 y')<BINPATH,'");
-        else {
-            input.append("(3 : '0!:0 y')<'/etc/j/");
-            input.append(jdllver);
-        }
-        input.append("/profile.ijs'");
-    } else if (type == 1)
+    if (type == 0)
+        input.append("(3 : '0!:0 y')<BINPATH,'/profile.ijs'");
+    else if (type == 1)
         input.append("(3 : '0!:0 y')2{ARGV");
     else if (type == 2)
         input.append("");


### PR DESCRIPTION
The meaning of it is described at
https://www.jsoftware.com/help/user/lib_sysenv.htm#FHS. I guess this has
once been a compile option, but is now set runtime in stdlib.ijs.
This also resulted in jdllver no longer being referenced, and a
possiblity to combine two string append statements.