### PR TITLE
Remove few macros

### DIFF
--- a/jsrc/adverbs/ar.c
+++ b/jsrc/adverbs/ar.c
@@ -278,7 +278,7 @@ jtredg(J jt, A w, A self) {
         // if w happens to be the same virtual block that we passed in as x, we have to clone it before we change the
         // pointer
         if (a == wfaux) {
-            RZ(wfaux = virtual(wfaux, 0, AR(a)));
+            RZ(wfaux = jtvirtual(jt, wfaux, 0, AR(a)));
             AN(wfaux) = AN(a);
             MCISH(AS(wfaux), AS(a), AR(a));
         }
@@ -884,7 +884,7 @@ jtredcatcell(J jt, A w, I r) {
         z     = w;
         AR(z) = (RANKT)(r + 1);  // inplace it, install new rank
     } else {
-        RZ(z = virtual(w, 0, r + 1));
+        RZ(z = jtvirtual(jt, w, 0, r + 1));
         AN(z) = AN(w);  // create virtual block
     }
     I m;

--- a/jsrc/adverbs/as.c
+++ b/jsrc/adverbs/as.c
@@ -356,7 +356,7 @@ jtssg(J jt, A w, A self) {
         // if result happens to be the same virtual block that we passed in, we have to clone it before we change the
         // pointer
         else if (a == z) {
-            RZ(z = virtual(z, 0, AR(a)));
+            RZ(z = jtvirtual(jt, z, 0, AR(a)));
             AN(z) = AN(a);
             MCISH(AS(z), AS(a), r - 1);
         }

--- a/jsrc/conjunctions/cr.c
+++ b/jsrc/conjunctions/cr.c
@@ -750,13 +750,13 @@ jtrank2ex0(J jt, AD *RESTRICT a, AD *RESTRICT w, A fs, AF f2) {
             if (!AN(a)) {
                 RZ(virta = jtfiller(jt, a));
             } else {
-                virta     = virtual(a, 0, 0);
+                virta     = jtvirtual(jt, a, 0, 0);
                 AN(virta) = 1;
             }  // if there are cells, use first atom; else fill atom
             if (!AN(w)) {
                 RZ(virtw = jtfiller(jt, w));
             } else {
-                virtw     = virtual(w, 0, 0);
+                virtw     = jtvirtual(jt, w, 0, 0);
                 AN(virtw) = 1;
             }
             WITHDEBUGOFF(z = CALL2(f2, virta, virtw, fs);)  // normal execution on fill-cell

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -629,7 +629,7 @@
 // Install new value z into xv[k], where xv is AAV(x).  If x has recursive usecount, we must increment the usecount of
 // z. This also guarantees that z has recursive usecount whenever x does, and that z is realized
 #define INSTALLBOX(x, xv, k, z) \
-    rifv(z);                    \
+    realizeifvirtual(z);        \
     if ((UCISRECUR(x)) != 0) {  \
         A zzZ = xv[k];          \
         ra(z);                  \
@@ -637,11 +637,11 @@
     }                           \
     xv[k] = z
 #define INSTALLBOXNF(x, xv, k, z)       \
-    rifv(z);                            \
+    realizeifvirtual(z);                \
     if ((UCISRECUR(x)) != 0) { ra(z); } \
     xv[k] = z  // Don't do the free - if we are installing into known 0 or known nonrecursive
 #define INSTALLBOXRECUR(xv, k, z) \
-    rifv(z);                      \
+    realizeifvirtual(z);          \
     {                             \
         I zzK = (k);              \
         {                         \

--- a/jsrc/ja.h
+++ b/jsrc/ja.h
@@ -180,7 +180,7 @@
             z             = (A)(v);                                                                       \
             AC(z)         = (c);                                                                          \
         } else {                                                                                          \
-            RZ(z = virtual((w), 0, (r)));                                                                 \
+            RZ(z = jtvirtual(jt, (w), 0, (r)));                                                                 \
             AFLAG(z) |= AFUNINCORPABLE;                                                                   \
             if ((c) != ACUC1) AC(z) = (c);                                                                \
         }                                                                                                 \
@@ -591,8 +591,6 @@
     jtvaspeqprep(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9), (x10), (x11))
 #define vec(x, y, z) jtvec(jt, (x), (y), (z))
 #define vecb01(x, y, z) jtvecb01(jt, (x), (y), (z))
-#define virtual(x, y, z) jtvirtual(jt, (x), (y), (z))
-#define virtualip(x, y, z) jtvirtual(jtinplace, (x), (y), (z))
 #define wa(x, y, z) jtwa(jt, (x), (y), (z))
 #define widthdp(x, y, z) jtwidthdp(jt, (x), (y), (z))
 #define words(x) jtwords(jt, (x), ds(CWORDS))

--- a/jsrc/ja.h
+++ b/jsrc/ja.h
@@ -433,7 +433,6 @@
     {                                                                \
         if ((AFLAG(x) & AFVIRTUAL) != 0) RZ((x) = jtrealize(jt, x)); \
     }
-#define rifv(x) realizeifvirtual(x)
 // We have used rifvs liberally through the code to guarantee that all functions can deal with virtual blocks returned.
 // In some cases, the call is to an internal routine that we know will not return a virtual block normally, and is in an
 // important performance path.  We use rifvsdebug for these places.  rifvs is called only during debugging.  Review them
@@ -519,7 +518,7 @@
 // usecount We can have an inplaceable but recursible block, if it was gc'd.  We never push a PERMANENT block, so that
 // we won't try to free it NOTE that PERMANENT blocks are always marked traversible if they are of traversible type, so
 // we will not recur on them internally
-#define tpushcommon(x, suffix)                                                                 \
+#define tpush(x)                                                                               \
     {                                                                                          \
         if (!ACISPERM(AC(x))) {                                                                \
             I tt     = AT(x);                                                                  \
@@ -528,10 +527,8 @@
             if (!((I)pushp & (NTSTACKBLOCK - 1))) { RZ(pushp = jttg(jt, pushp)); }             \
             if (((tt ^ AFLAG(x)) & TRAVERSIBLE) != 0) RZ(pushp = jttpush(jt, (x), tt, pushp)); \
             jt->tnextpushp = pushp;                                                            \
-            suffix                                                                             \
         }                                                                                      \
     }
-#define tpush(x) tpushcommon(x, )
 // Internal version, used when the local name pushp is known to hold jt->tnextpushp
 #define tpushi(x)                                                                              \
     {                                                                                          \

--- a/jsrc/ja.h
+++ b/jsrc/ja.h
@@ -320,7 +320,6 @@
 #define minusA(x, y) jtatomic2((J)((I)jt | JTINPLACEA), (x), (y), ds(CMINUS))
 #define mmharvest(x0, x1, x2, x3, x4, x5, x6) jtmmharvest(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6))
 #define mmprep(x0, x1, x2, x3, x4, x5) jtmmprep(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define move(x, y, z) jtmove(jt, (x), (y), (z))
 #define movandor(x0, x1, x2, x3) jtmovandor(jt, (x0), (x1), (x2), (x3))
 #define movbwneeq(x0, x1, x2, x3) jtmovbwneeq(jt, (x0), (x1), (x2), (x3))
 #define movfslash(x, y, z) jtmovfslash(jt, (x), (y), (z))

--- a/jsrc/m.c
+++ b/jsrc/m.c
@@ -1307,7 +1307,7 @@ jtcar(J jt, A w) {
 A
 jtclonevirtual(J jt, A w) {
     A z;
-    RZ(z = virtual(w, 0, AR(w)));  // allocate a new virtual block
+    RZ(z = jtvirtual(jt, w, 0, AR(w)));  // allocate a new virtual block
     AN(z) = AN(w);
     MCISH(AS(z), AS(w), (I)AR(w));  // copy AN and shape; leave AC alone
     return z;

--- a/jsrc/verbs/dyadic/take_drop.cpp
+++ b/jsrc/verbs/dyadic/take_drop.cpp
@@ -266,7 +266,7 @@ jttake(J jt, A a, A w) {
             PROD(wcellsize, wr - 1, ws + 1);  // size of a cell in atoms of w
             I offset = woffset * wcellsize;   // offset in atoms of the virtual data
             // allocate virtual block, passing in the in-place status from w
-            RZ(s = virtualip(w, offset, wr));  // allocate block
+            RZ(s = jtvirtual(jtinplace, w, offset, wr));  // allocate block
             // fill in shape.  Note that s and w may be the same block, so ws is destroyed
             I* RESTRICT ss = AS(s);
             ss[0]          = tkabs;
@@ -343,7 +343,7 @@ jtdrop(J jt, A a, A w) {
         PROD(wcellsize, wr - 1, ws + 1);  // size of a cell in atoms of w
         I offset = woffset * wcellsize;   // offset in bytes of the virtual data
         // allocate virtual block.  May use inplace w
-        RZ(s = virtualip(w, offset, wr));  // allocate block
+        RZ(s = jtvirtual(jtinplace, w, offset, wr));  // allocate block
         // fill in shape.  s and w may be the same block, so ws is destroyed
         I* RESTRICT ss = AS(s);
         ss[0]          = remlen;
@@ -413,7 +413,7 @@ jthead(J jt, A w) {
             wcr--;
             wcr = (wcr < 0) ? wr : wcr;  // wn=#atoms of w, wcr=rank of cell being created
             A z;
-            RZ(z = virtualip(w, 0, wcr));  // allocate the cell.  Now fill in shape & #atoms
+            RZ(z = jtvirtual(jtinplace, w, 0, wcr));  // allocate the cell.  Now fill in shape & #atoms
                                            // if w is empty we have to worry about overflow when calculating #atoms
             I zn;
             PROD(zn, wcr, AS(w) + 1)

--- a/jsrc/verbs/v.c
+++ b/jsrc/verbs/v.c
@@ -57,7 +57,7 @@ jtravel(J jt, A w) {
         // Not self-virtual.  Create a (noninplace) virtual copy, but not if NJA memory  NJAwhy
         // If rank 0 were the only thing stopping us from inplacing, we could inherit pristinity
         if (!(AFLAG(w) & (AFNJA))) {
-            RZ(z = virtual(w, 0, 1 + f));
+            RZ(z = jtvirtual(jt, w, 0, 1 + f));
             AN(z)                           = AN(w);
             MCISH(AS(z), AS(w), f) AS(z)[f] = m;
             return z;

--- a/jsrc/verbs/vcat.c
+++ b/jsrc/verbs/vcat.c
@@ -738,7 +738,7 @@ jtapip(J jt, A a, A w) {
                             // virtual extension.  Allocate a virtual block, which will extend past the original block.
                             // Fill in AN and AS for the block
                             A oa = a;
-                            RZ(a = virtual(a, 0, ar));
+                            RZ(a = jtvirtual(jt, a, 0, ar));
                             AN(a)    = AN(oa) + wn;
                             AS(a)[0] = AS(oa)[0] + wm;
                             MCISH(&AS(a)[1], &AS(oa)[1], AR(oa) - 1);

--- a/jsrc/verbs/vf.c
+++ b/jsrc/verbs/vf.c
@@ -556,7 +556,7 @@ jtreshape(J jt, A a, A w) {
             // correct   if(!(AFLAG(w)&(AFNJA))){RZ(z=virtual(w,0,r+wf)); AN(z)=m; I *zs=AS(z); DO(wf, *zs++=ws[i];);
             // DO(r, zs[i]=u[i];) return z;}
             if ((SGNIF(AFLAG(w), AFNJAX) | ((t & (DIRECT | RECURSIBLE)) - 1)) >= 0) {
-                RZ(z = virtual(w, 0, r + wf));
+                RZ(z = jtvirtual(jt, w, 0, r + wf));
                 AN(z)          = m;
                 I *RESTRICT zs = AS(z);
                 MCISH(zs, ws, wf) MCISH(zs + wf, u, r) return z;

--- a/jsrc/verbs/vfrom.c
+++ b/jsrc/verbs/vfrom.c
@@ -143,7 +143,7 @@ jtifrom(J jt, A a, A w) {
             if ((index0 | (p - indexn - 1)) >= 0) {  // index0>0 and indexn<=p-1
                 // indexes are consecutive and in range.  Make the result virtual.  Rank of w cell must be > 0, since we
                 // have >=2 consecutive result atoms
-                RZ(z = virtualip(w, index0 * k, ar + wr - 1));
+                RZ(z = jtvirtual(jtinplace, w, index0 * k, ar + wr - 1));
                 // fill in shape and number of atoms.  ar can be anything.
                 I *as = AS(a);
                 AN(z) = zn;
@@ -309,7 +309,7 @@ jtfrombu(J jt, A a, A w, I wf) {
     } else {
         //  reshape w to combine the first h axes of each cell.  Be careful with the copying, because w and q may be the
         //  same block.  Some axes may be closed up by the copy
-        RZ(q = virtualip(w, 0, r));
+        RZ(q = jtvirtual(jtinplace, w, 0, r));
         AN(q) = AN(w);
         v     = AS(q);
         MCISH(v, ws, wf);
@@ -513,7 +513,7 @@ jtafrom(J jt, A a, A w) {
     }
     if (i) {
         I *ys;
-        RZ(y = virtual(w, m, pr + wcr - i));
+        RZ(y = jtvirtual(jt, w, m, pr + wcr - i));
         ys = AS(y);
         DO(pr, *ys++ = 1;);
         MCISH(ys, s + i, wcr - i);
@@ -594,7 +594,7 @@ jtfrom(J jt, A a, A w) {
                 PROD(m, wr1, ws + 1);  // number of atoms in a cell
                 I j;
                 SETNDX(j, av, ws[0]);              // j=positive index
-                RZ(z = virtualip(w, j * m, wr1));  // if w is rank 2, could reuse inplaceable a for this virtual block
+                RZ(z = jtvirtual(jtinplace, w, j * m, wr1));  // if w is rank 2, could reuse inplaceable a for this virtual block
                 // fill in shape and number of atoms.  ar can be anything.
                 AN(z) = m;
                 MCISH(AS(z), ws + 1, wr1)

--- a/jsrc/verbs/vi.c
+++ b/jsrc/verbs/vi.c
@@ -2760,7 +2760,7 @@ jtless(J jt, A a, A w) {
     // if w's rank is larger than that of a cell of a, reheader w to look like a list of such cells.  The number of
     // atoms stays the same
     if (wr && r != wr) {
-        RZ(x = virtual(w, 0, r));
+        RZ(x = jtvirtual(jt, w, 0, r));
         AN(x) = AN(w);
         s     = AS(x);
         ws    = AS(w);

--- a/jsrc/verbs/vs.c
+++ b/jsrc/verbs/vs.c
@@ -240,7 +240,7 @@ jtsparseit(J jt, A w, A a, A e) {
     DO(r, s[i] = v[u[i]];);
     RE(m = jtprod(jt, n, s));
     b = jtequ(jt, a, IX(r));
-    RZ(x = virtual(b ? w : jtcant2(jt, ax, w), 0, 1 + r - n));
+    RZ(x = jtvirtual(jt, b ? w : jtcant2(jt, ax, w), 0, 1 + r - n));
     AN(x) = AN(w);
     v     = AS(x);
     *v    = m;

--- a/jsrc/words/w.c
+++ b/jsrc/words/w.c
@@ -449,7 +449,7 @@ jtenqueue(J jt, A a, A w, I env) {
             }  // bad first character or inflection
         }
         // Since the word is being incorporated into a list, we must realize it
-        rifv(*x);
+        realizeifvirtual(*x);
         // Mark the word as not-inplaceable.  Since all allocations start life marked in-placeable, we get into trouble
         // if words in a explicit definition are left that way, because the sentences may get reexecuted and any
         // constant marked inplaceable could be modified by each use.  The trouble happens only if the definition is not


### PR DESCRIPTION
resolves #184 

- replaced `virtual` & `virtualip` with direct calls
- removed unused `move` macro (`jtmove()` doesn't even exist anymore)
- removed couple unnecessary pointless indirection macros