### PR TITLE
Macro removal

### DIFF
--- a/jsrc/adverbs/a.c
+++ b/jsrc/adverbs/a.c
@@ -65,7 +65,7 @@ jtbdot2(J jt, A a, A w, A self) {
 
 static A
 jtbdot1(J jt, A w, A self) {
-    return bdot2(num(0), w, self);
+    return jtbdot2(jt, num(0), w, self);
 }
 
 static A
@@ -258,7 +258,7 @@ jtmemo1(J jt, A w, A self) {
     x = IMIN;
     y = jtint0(jt, w);
     if (y == IMIN) return CALL1(f1, w, fs);
-    return (z = memoget(x, y, self)) ? z : memoput(x, y, self, CALL1(f1, w, fs));
+    return (z = jtmemoget(jt, x, y, self)) ? z : jtmemoput(jt, x, y, self, CALL1(f1, w, fs));
 }
 
 static A
@@ -269,9 +269,9 @@ jtmemo2(J jt, A a, A w, A self) {
     x = jtint0(jt, a);
     y = jtint0(jt, w);
     if (MIN(x, y) == IMIN) return CALL2(f2, a, w, fs);  // IMIN is unmemoable, run fn
-    return (z = memoget(x, y, self))
+    return (z = jtmemoget(jt, x, y, self))
              ? z
-             : memoput(x,
+             : jtmemoput(jt, x,
                        y,
                        self,
                        CALL2(f2, a, w, fs));  // if memo lookup returns empty, run the function and remember the result

--- a/jsrc/adverbs/a.c
+++ b/jsrc/adverbs/a.c
@@ -40,7 +40,7 @@ jtswap(J jt, A w) {
         I flag = FAV(w)->flag & (VIRS2 | VJTFLGOK2);
         flag   = (FAV(w)->flag & VASGSAFE) + flag +
                (flag >> 1);  // set ASGSAFE, both inplace/irs bits from dyad; ISATOMIC immaterial, since always dyad
-        return fdef(0, CTILDE, VERB, (AF)(swap1), (AF)(swap2), w, 0L, 0L, flag, (I)(RMAX), (I)(rr(w)), (I)(lr(w)));
+        return jtfdef(jt, 0, CTILDE, VERB, (AF)(swap1), (AF)(swap2), w, 0L, 0L, flag, (I)(RMAX), (I)(rr(w)), (I)(lr(w)));
     } else {
         // evoke.  Ii must be LIT and convertible to ASCII.
         if ((C2T + C4T) & AT(w)) RZ(w = jtcvt(jt, LIT, w)) else ASSERT(LIT & AT(w), EVDOMAIN);
@@ -116,15 +116,15 @@ jtbdot(J jt, A w) {
         memcpy(AV(b), booltab, 64L);
         RZ(h = jtrifvs(jt, jtcant2(jt, IX(AR(w)), jtfrom(jt, w, b))));  // h is an array representing b.  One cell for
                                                                         // each atom of b; cell is 4 values
-        return fdef(0, CBDOT, VERB, jtbdot1, jtbdot2, 0L, w, h, VFLAGNONE, RMAX, 0L, 0L);
+        return jtfdef(jt, 0, CBDOT, VERB, jtbdot1, jtbdot2, 0L, w, h, VFLAGNONE, RMAX, 0L, 0L);
     } else
         switch (j) {
             case 32:
-                return fdef(0, CBDOT, VERB, jtbitwise1, jtbitwiserotate, 0L, w, 0L, VASGSAFE | VJTFLGOK2, 0L, 0L, 0L);
+                return jtfdef(jt, 0, CBDOT, VERB, jtbitwise1, jtbitwiserotate, 0L, w, 0L, VASGSAFE | VJTFLGOK2, 0L, 0L, 0L);
             case 33:
-                return fdef(0, CBDOT, VERB, jtbitwise1, jtbitwiseshift, 0L, w, 0L, VASGSAFE | VJTFLGOK2, 0L, 0L, 0L);
+                return jtfdef(jt, 0, CBDOT, VERB, jtbitwise1, jtbitwiseshift, 0L, w, 0L, VASGSAFE | VJTFLGOK2, 0L, 0L, 0L);
             case 34:
-                return fdef(0, CBDOT, VERB, jtbitwise1, jtbitwiseshifta, 0L, w, 0L, VASGSAFE | VJTFLGOK2, 0L, 0L, 0L);
+                return jtfdef(jt, 0, CBDOT, VERB, jtbitwise1, jtbitwiseshifta, 0L, w, 0L, VASGSAFE | VJTFLGOK2, 0L, 0L, 0L);
             // The code uses a VERB with id CBDOT to stand for the derived verb of m b. .  This is used for spellout and
             // for inverses, so we retain it. We copy the other information from the verb that executes the function.
             // This contains pointers to the routines, and to the function table
@@ -300,7 +300,7 @@ jtmemo(J jt, A w) {
     RZ(hv[1] = jtmkwris(jt, q));
     GATV0(q, BOX, m, 1);
     hv[2] = q;
-    EPILOG(fdef(0, CMCAP, VERB, jtmemo1, jtmemo2, w, 0L, h, 0L, v->mr, lrv(v), rrv(v)));
+    EPILOG(jtfdef(jt, 0, CMCAP, VERB, jtmemo1, jtmemo2, w, 0L, h, 0L, v->mr, lrv(v), rrv(v)));
     // Now we have converted the verb result to recursive usecount, and gotten rid of the pending tpops for the
     // components of h
 }

--- a/jsrc/adverbs/a.h
+++ b/jsrc/adverbs/a.h
@@ -98,9 +98,9 @@
     }
 
 #define ADERIV(id, f1, f2, flag, m, l, r) \
-    fdef(0, id, VERB, (AF)(f1), (AF)(f2), w, 0L, 0L, (flag), (I)(m), (I)(l), (I)(r))
+    jtfdef(jt, 0, id, VERB, (AF)(f1), (AF)(f2), w, 0L, 0L, (flag), (I)(m), (I)(l), (I)(r))
 #define CDERIV(id, f1, f2, flag, m, l, r) \
-    fdef(0, id, VERB, (AF)(f1), (AF)(f2), a, w, 0L, (flag), (I)(m), (I)(l), (I)(r))
+    jtfdef(jt, 0, id, VERB, (AF)(f1), (AF)(f2), a, w, 0L, (flag), (I)(m), (I)(l), (I)(r))
 
 #define ASSERTVV(a, w) ASSERT(VERB& AT(a) & AT(w), EVDOMAIN)
 #define ASSERTVVn(a, w) ASSERT(VERB& AT(a), EVDOMAIN)

--- a/jsrc/adverbs/af.c
+++ b/jsrc/adverbs/af.c
@@ -147,7 +147,7 @@ jtfixa(J jt, A a, A w) {
                 }
                 f = REFIXA(0, f);
                 h = REFIXA(0, h);
-                return xop2(f, h, g);
+                return jtxop2(jt, f, h, g);
             } else {
                 f = REFIXA(1, f);
                 g = REFIXA(2, g);
@@ -165,11 +165,11 @@ jtfixa(J jt, A a, A w) {
             f = REFIXA(na, f);
             g = REFIXA(ID(f) == CCAP ? 1 : 2, g);
             h = REFIXA(na, h);
-            return folk(f, g, h);  // f first in case it's [:
+            return jtfolk(jt, f, g, h);  // f first in case it's [:
         case CATDOT:
         case CGRCO:
             IAV0(aa)[0] = (aif | na);
-            RZ(f = jtevery(jt, every2(aa, h, (A)&arofixaself), (A)&arofixaself));  // full A block required for call
+            RZ(f = jtevery(jt, jtevery2(jt, aa, h, (A)&arofixaself), (A)&arofixaself));  // full A block required for call
             RZ(g = REFIXA(na, g));
             return df2(z, f, g, wf);
         case CIBEAM:

--- a/jsrc/adverbs/ai.c
+++ b/jsrc/adverbs/ai.c
@@ -262,11 +262,11 @@ jtinvamp(J jt, A w) {
         case CFIT:
             ASSERT(nf && (CPOUND == ID(FAV(g)->fgh[0])), EVDOMAIN);
             ASSERT(1 == AR(x), EVRANK);
-            return fdef(0, CPOWOP, VERB, jtexpandg, 0L, w, num(-1), 0L, VFLAGNONE, RMAX, 0L, 0L);
+            return jtfdef(jt, 0, CPOWOP, VERB, jtexpandg, 0L, w, num(-1), 0L, VFLAGNONE, RMAX, 0L, 0L);
         case CPOUND:
             ASSERT(nf != 0, EVDOMAIN);
             ASSERT(1 == AR(x), EVRANK);
-            return fdef(0, CPOWOP, VERB, jtexpandf, 0L, w, num(-1), 0L, VFLAGNONE, RMAX, 0L, 0L);
+            return jtfdef(jt, 0, CPOWOP, VERB, jtexpandf, 0L, w, num(-1), 0L, VFLAGNONE, RMAX, 0L, 0L);
             break;
         case CPOWOP:
             if (VGERL & u->flag) {
@@ -409,8 +409,8 @@ jtinv(J jt, A w, I recur) {
         case CBANG:
             return jteval(jt, "3 : '(-(y -~ !)%0.001&* (0.001%~[:-/[:! 0.001 0 +/ ]) ])^:_<.&170^:(-:+)^.y' :. !");
         case CXCO: return jtamp(jt, num(-1), w);
-        case CSPARSE: return fdef(0, CPOWOP, VERB, jtdenseit, 0L, w, num(-1), 0L, VFLAGNONE, RMAX, RMAX, RMAX);
-        case CPCO: return fdef(0, CPOWOP, VERB, jtplt, 0L, w, num(-1), 0L, 0L, 0L, 0L, 0L);
+        case CSPARSE: return jtfdef(jt, 0, CPOWOP, VERB, jtdenseit, 0L, w, num(-1), 0L, VFLAGNONE, RMAX, RMAX, RMAX);
+        case CPCO: return jtfdef(jt, 0, CPOWOP, VERB, jtplt, 0L, w, num(-1), 0L, 0L, 0L, 0L, 0L);
         case CQCO: return jteval(jt, "*/");
         case CUCO: return jtamp(jt, num(3), w);
         case CUNDER: return jtunder(jt, invrecur(f), g);
@@ -472,7 +472,7 @@ jtinv(J jt, A w, I recur) {
             break;
         case CCUT:
             if (CBOX == ID(f) && ng && (p = jti0(jt, g), 1 == p || 2 == p))
-                return fdef(0, CPOWOP, VERB, jtbminv, 0L, w, num(-1), 0L, VFLAGNONE, RMAX, RMAX, RMAX);
+                return jtfdef(jt, 0, CPOWOP, VERB, jtbminv, 0L, w, num(-1), 0L, VFLAGNONE, RMAX, RMAX, RMAX);
             break;
         case CIBEAM:
             p = jti0(jt, f);

--- a/jsrc/adverbs/ai.c
+++ b/jsrc/adverbs/ai.c
@@ -35,8 +35,8 @@ jtfong(J jt, A a, A w) {
     c = v->id;
     f = v->fgh[0];
     return c == CRIGHT                                     ? w
-           : c == CFORK && (NOUN & AT(f) || CCAP == ID(f)) ? folk(f, v->fgh[1], jtfong(jt, v->fgh[2], w))
-                                                           : folk(ds(CCAP), a, w);
+           : c == CFORK && (NOUN & AT(f) || CCAP == ID(f)) ? jtfolk(jt, f, v->fgh[1], jtfong(jt, v->fgh[2], w))
+                                                           : jtfolk(jt, ds(CCAP), a, w);
 }  // [: f g  with simplifications: [: ] w -> w;  [: (N/[: x y) w -> N/[: x [: y w   and y omittrd if ]
 
 static A
@@ -58,9 +58,9 @@ jtinvfork(J jt, A w) {
     if (CAMP == ID(gi)) {
         v = FAV(gi);
         if (NOUN & AT(v->fgh[0]))
-            RZ(gi = folk(v->fgh[0], v->fgh[1], ds(CRIGHT)))
+            RZ(gi = jtfolk(jt, v->fgh[0], v->fgh[1], ds(CRIGHT)))
         else if (NOUN & AT(v->fgh[1]))
-            RZ(gi = folk(v->fgh[1], jtswap(jt, v->fgh[0]), ds(CRIGHT)));
+            RZ(gi = jtfolk(jt, v->fgh[1], jtswap(jt, v->fgh[0]), ds(CRIGHT)));
     }
     return jtfong(jt, fi, gi);
 }
@@ -280,7 +280,7 @@ jtinvamp(J jt, A w) {
         case CBASE:
             if (!nf) break;
             return AR(x) ? jtamp(jt, x, ds(CABASE))
-                         : jtobverse(jt, evc(x, mag(x), "$&u@>:@(v&(<.@^.))@(1&>.)@(>./)@:|@, #: ]"), w);
+                         : jtobverse(jt, jtevc(jt, x, mag(x), "$&u@>:@(v&(<.@^.))@(1&>.)@(>./)@:|@, #: ]"), w);
         case CATOMIC:
             if (ng) {
                 ASSERT(jtequ(jt, x, jtnub(jt, x)), EVDOMAIN);
@@ -440,7 +440,7 @@ jtinv(J jt, A w, I recur) {
         case CPOWOP:
             if (vf && ng) {
                 RE(p = jti0(jt, g));
-                return -1 == p ? f : 1 == p ? invrecur(f) : powop(0 > p ? f : invrecur(f), jtsc(jt, ABS(p)), 0);
+                return -1 == p ? f : 1 == p ? invrecur(f) : jtpowop(jt, 0 > p ? f : invrecur(f), jtsc(jt, ABS(p)), 0);
             }
             if (VGERL & v->flag) return *(1 + AAV(v->fgh[2]));
             break;
@@ -604,7 +604,7 @@ jtiden(J jt, A w) {
             break;
     }
     ASSERT(x != 0, EVDOMAIN);
-    return folk(x, jtswap(jt, ds(CDOLLAR)), jtatop(jt, ds(CBEHEAD), ds(CDOLLAR)));
+    return jtfolk(jt, x, jtswap(jt, ds(CDOLLAR)), jtatop(jt, ds(CBEHEAD), ds(CDOLLAR)));
 }
 
 A
@@ -628,5 +628,5 @@ jtidensb(J jt, A w) {
             break;
     }
     ASSERT(x != 0, EVDOMAIN);
-    return folk(x, jtswap(jt, ds(CDOLLAR)), jtatop(jt, ds(CBEHEAD), ds(CDOLLAR)));
+    return jtfolk(jt, x, jtswap(jt, ds(CDOLLAR)), jtatop(jt, ds(CBEHEAD), ds(CDOLLAR)));
 }

--- a/jsrc/adverbs/am.c
+++ b/jsrc/adverbs/am.c
@@ -167,7 +167,7 @@ jtcasev(J jt, A w) {
     // have to make sure abc is locally defined
     if (p = q && 0 <= c && ACUC1 >= AC(u[c])) {  // passes quick check
         p = (AN(jt->locsyms) == 1) || CAV(AAV(v[m + 2])[1])[0] != CASGN ||
-            probe(
+            jtprobe(jt, 
               NAV(AAV(v[m + 2])[0])->m,
               NAV(AAV(v[m + 2])[0])->s,
               NAV(AAV(v[m + 2])[0])->hash,
@@ -436,7 +436,7 @@ jtjstd(J jt, A w, A ind, I *cellframelen) {
         return x;
     }                                // if w is an atom, the best you can get is indexes of 0.  No axes are used
     if ((b & -AR(ind)) < 0) {        // array of boxed indexes
-        RE(aindex(ind, w, 0L, &j));  // see if the boxes are homogeneous
+        RE(jtaindex(jt, ind, w, 0L, &j));  // see if the boxes are homogeneous
         if (!j) {                    // if not...
             RZ(x = MODIFIABLE(jtfrom(jt, ind, jtincrem(jt, jtiota(jt, shape(jt, w))))));
             u = AV(x);  // go back to the original indexes, select from table of all possible incremented indexes; since
@@ -507,7 +507,7 @@ jtamendn2(J jt, A a, A w, A self) {
     AD *RESTRICT ind = VAV(self)->fgh[0];
     if (!((AT(w) | AT(ind)) & SPARSE)) {
         I cellframelen;
-        ind = jstd(w, ind, &cellframelen);  // convert indexes to cell indexes; remember how many were converted
+        ind = jtjstd(jt, w, ind, &cellframelen);  // convert indexes to cell indexes; remember how many were converted
         z   = jtmerge2(
           jtinplace, AT(a) & SPARSE ? jtdenseit(jt, a) : a, w, ind, cellframelen);  //  dense a if needed; dense amend
         // We modified w which is now not pristine.
@@ -552,7 +552,7 @@ jtamendn2(J jt, A a, A w, A self) {
              : AT(a) & SPARSE ? jtam1sp
                               : jtam1a)(jt, a, z, AT(ind) & NUMERIC ? jtbox(jt, ind) : jtope(jt, ind), ip);
     else {
-        RE(aindex(ind, z, 0L, (A *)&ind));
+        RE(jtaindex(jt, ind, z, 0L, (A *)&ind));
         ASSERT(ind != 0, EVNONCE);
         z = (b ? jtamne : AT(a) & SPARSE ? jtamnsp : jtamna)(jt, a, z, ind, ip);
     }               // A* for the #$&^% type-checking

--- a/jsrc/adverbs/am1.c
+++ b/jsrc/adverbs/am1.c
@@ -119,7 +119,7 @@ jtipart(J jt, A z, A ind, A *i1, A *i2) {
     n  = AN(ind);
     iv = AAV(ind);
     zp = PAV(z);
-    RZ(b = bfi(AR(z), SPA(zp, a), 1));
+    RZ(b = jtbfi(jt, AR(z), SPA(zp, a), 1));
     c = 0;
     DO(n, if (b[i])++ c;);
     d = n - c;
@@ -190,7 +190,7 @@ jtscubb(J jt, A z, A i1) {
     A a, q, x, y;
     I c, d, h, j, *s, *v, *xv;
     P *zp;
-    RZ(q = scuba(z, i1, 1));
+    RZ(q = jtscuba(jt, z, i1, 1));
     if (!*AS(q)) return mtm;
     s  = AS(z);
     zp = PAV(z);
@@ -206,7 +206,7 @@ jtscubb(J jt, A z, A i1) {
     xv = AV(x);
     j  = c;
     DO(h, xv[i] = s[v[j++]];);
-    RZ(x = odom(2L, h, xv));
+    RZ(x = jtodom(jt, 2L, h, xv));
     c = *AS(q);
     d = *AS(x);
     return jtstitch(jt, jtrepeat(jt, jtsc(jt, d), q), jtreitem(jt, jtsc(jt, c * d), x));
@@ -247,7 +247,7 @@ jtscubc(J jt, A z, A i1, A p) {
     RZ(y1 = jtrepeat(jt, q, y1));
     c = *AS(y1);
     if (!c) return mtm;
-    return jtless(jt, jtstitch(jt, jtrepeat(jt, jtsc(jt, d), y1), jtreitem(jt, jtsc(jt, c * d), odom(2L, h, sv))), y);
+    return jtless(jt, jtstitch(jt, jtrepeat(jt, jtsc(jt, d), y1), jtreitem(jt, jtsc(jt, c * d), jtodom(jt, 2L, h, sv))), y);
 } /* new rows for the index matrix of z for existing cells */
 
 static A
@@ -257,7 +257,7 @@ jtscube(J jt, A z, A i1, A p) {
     zp = PAV(z);
     a  = SPA(zp, a);
     y  = SPA(zp, i);
-    return !AN(a) && !*AS(y) ? jttake(jt, num(1), mtm) : jtover(jt, jtscubb(jt, z, i1), scubc(z, i1, p));
+    return !AN(a) && !*AS(y) ? jttake(jt, num(1), mtm) : jtover(jt, jtscubb(jt, z, i1), jtscubc(jt, z, i1, p));
 } /* new rows for the index matrix of z */
 
 static A
@@ -268,10 +268,10 @@ jtiindx(J jt, A z, A i1) {
     c  = AN(i1);
     zp = PAV(z);
     y  = SPA(zp, i);
-    if (c == *(1 + AS(y))) return jtindexof(jt, y, scuba(z, i1, 0));
+    if (c == *(1 + AS(y))) return jtindexof(jt, y, jtscuba(jt, z, i1, 0));
     /* when y has excess columns, do progressive indexing */
     RZ(y = jttaker(jt, c, y));
-    RZ(j = jtindexof(jt, y, scuba(z, i1, 0))); /* j: group indices           */
+    RZ(j = jtindexof(jt, y, jtscuba(jt, z, i1, 0))); /* j: group indices           */
     n  = AN(j);
     jv = AV(j);
     m  = *AS(y);
@@ -347,7 +347,7 @@ jtam1e(J jt, A a, A z, A ind, B ip) {
     e  = SPA(zp, e);
     RZ(p = jtssel(jt, z, ind));
     pv = BAV(p);
-    RZ(ipart(z, ind, &i1, &i2));
+    RZ(jtipart(jt, z, ind, &i1, &i2));
     m  = AN(p);
     n  = AN(i2);
     u  = CAV(e);
@@ -375,10 +375,10 @@ jtam1a(J jt, A a, A z, A ind, B ip) {
     I ar, c, *iv, *jv, k, m, n, r, *s, uk, vk, xk;
     P *zp;
     RZ(a && (ind = jtistd1(jt, z, ind)));
-    RZ(a = astd1(a, z, ind));
+    RZ(a = jtastd1(jt, a, z, ind));
     if (mtind(ind)) return z;
-    RZ(ipart(z, ind, &i1, &i2));
-    RZ(z = zpad1(z, scube(z, i1, jtssel(jt, z, ind)), ip));
+    RZ(jtipart(jt, z, ind, &i1, &i2));
+    RZ(z = jtzpad1(jt, z, jtscube(jt, z, i1, jtssel(jt, z, ind)), ip));
     zp = PAV(z);
     x  = SPA(zp, x);
     y  = SPA(zp, i);
@@ -398,7 +398,7 @@ jtam1a(J jt, A a, A z, A ind, B ip) {
     m  = AN(t);
     if (!n && !m) {
         a1 = SPA(zp, a);
-        return ar ? sparseit(a0, a1, e) : sparseit(jtreshape(jt, shape(jt, z), a), a1, a);
+        return ar ? jtsparseit(jt, a0, a1, e) : jtsparseit(jt, jtreshape(jt, shape(jt, z), a), a1, a);
     }
     if (n) {
         RZ(t = jtdcube(jt, z, i2));
@@ -417,6 +417,6 @@ jtam1a(J jt, A a, A z, A ind, B ip) {
 
 A
 jtam1sp(J jt, A a, A z, A ind, B ip) {
-    return amnsp(a, z, jtope(jt, jtcatalog(jt, jtistd1(jt, z, ind))), ip);
+    return jtamnsp(jt, a, z, jtope(jt, jtcatalog(jt, jtistd1(jt, z, ind))), ip);
 }
 /* a (<ind)}z; sparse z; ind is index list; arbitrary sparse array a replacement */

--- a/jsrc/adverbs/amn.c
+++ b/jsrc/adverbs/amn.c
@@ -17,7 +17,7 @@ jtcsize(J jt, A z, A ind) {
     r  = AR(z);
     s  = AS(z);
     zp = PAV(z);
-    RZ(b = bfi(r, SPA(zp, a), 0));
+    RZ(b = jtbfi(jt, r, SPA(zp, a), 0));
     m = 1;
     j = h = *(AR(ind) + AS(ind) - 1);
     DQ(r - h, if (b[j]) m *= s[j]; ++j;);
@@ -48,7 +48,7 @@ jtiaddr(J jt, A z, A ind, A* i1, A* i2) {
     e = 0;
     d = 1;
     DO(n, if (h > u[i]) v[e++] = s[i]; else d *= s[i];);
-    RZ(*i2 = jj = tymes(jtsc(jt, d), jtbase2(jt, vec(INT, e, v), jtrepeatr(jt, jteps(jt, ai, as), ind))));
+    RZ(*i2 = jj = tymes(jtsc(jt, d), jtbase2(jt, jtvec(jt, INT, e, v), jtrepeatr(jt, jteps(jt, ai, as), ind))));
     c = *(1 + AS(y));
     if (!c) {
         n = AN(jj);
@@ -106,7 +106,7 @@ jtzpadn(J jt, A z, A ind, B ip) {
     RZ(p = jtnub(jt, jtless(jt, i1, y1)));
     if (c = AN(a) - d) {
         RZ(t = jtfrom(jt, jtless(jt, a, ai), shape(jt, z)));
-        RZ(p1 = odom(2L, c, AV(t)));
+        RZ(p1 = jtodom(jt, 2L, c, AV(t)));
         n = *AS(p1);
         if (m = *AS(p)) RZ(p = jtstitch(jt, jtrepeat(jt, jtsc(jt, n), p), jtreshape(jt, jtv2(jt, n * m, c), p1)));
         RZ(t = jtnub(jt, jtrepeat(jt, jteps(jt, y1, i1), y1)));
@@ -171,7 +171,7 @@ jtastdn(J jt, A a, A z, A ind) {
     v    = AV(r);
     *v++ = ar - (zr - n);
     DQ(zr - n, *v++ = 1;);
-    RZ(q = jtdgrade1(jt, jtrepeat(jt, r, vec(B01, zr - n1, b + n1))));
+    RZ(q = jtdgrade1(jt, jtrepeat(jt, r, jtvec(jt, B01, zr - n1, b + n1))));
     return jtequ(jt, q, IX(ar)) ? a : jtcant2(jt, q, a);
 } /* convert replacement array a into standard form relative to index array ind */
 
@@ -182,7 +182,7 @@ jtamne(J jt, A a, A z, A ind, B ip) {
     I *iv, *jv, k, m, n, vk, xk;
     P* zp;
     RZ(a && z && ind);
-    RZ(iaddr(z, ind, &i1, &i2));
+    RZ(jtiaddr(jt, z, ind, &i1, &i2));
     zp = PAV(z);
     x  = SPA(zp, x);
     y  = SPA(zp, i);
@@ -206,9 +206,9 @@ jtamna(J jt, A a, A z, A ind, B ip) {
     I *iv, *jv, k, n, vk, xk;
     P* zp;
     RZ(a && z && ind);
-    RZ(z = zpadn(z, ind, ip));
-    RZ(a = astdn(a, z, ind));
-    RZ(iaddr(z, ind, &i1, &i2));
+    RZ(z = jtzpadn(jt, z, ind, ip));
+    RZ(a = jtastdn(jt, a, z, ind));
+    RZ(jtiaddr(jt, z, ind, &i1, &i2));
     zp = PAV(z);
     x  = SPA(zp, x);
     n  = AN(i1);
@@ -237,11 +237,11 @@ jtamnsp(J jt, A a, A z, A ind, B ip) {
     ap = PAV(a);
     t  = SPA(ap, a);
     if (r > AN(t)) RZ(a = jtreaxis(jt, IX(r), a));
-    RZ(a = astdn(a, z, ind));
+    RZ(a = jtastdn(jt, a, z, ind));
     ap = PAV(a);
-    RZ(z = zpadn(z, ind, ip));
+    RZ(z = jtzpadn(jt, z, ind, ip));
     zp = PAV(z);
-    RZ(iaddr(z, ind, &i1, &i2));
+    RZ(jtiaddr(jt, z, ind, &i1, &i2));
     s  = AS(a);
     n  = AN(i1);
     c  = jtcsize(jt, z, ind);

--- a/jsrc/adverbs/ao.c
+++ b/jsrc/adverbs/ao.c
@@ -1452,5 +1452,5 @@ jtsldot(J jt, A w) {
             // otherwise (including keymean) fall through to...
         default: f2 = jtkey; flag |= (FAV(w)->flag & VASGSAFE);  // pass through ASGSAFE.
     }
-    return fdef(0, CSLDOT, VERB, f1, f2, w, 0L, h, flag, RMAX, RMAX, RMAX);
+    return jtfdef(jt, 0, CSLDOT, VERB, f1, f2, w, 0L, h, flag, RMAX, RMAX, RMAX);
 }

--- a/jsrc/adverbs/ao.c
+++ b/jsrc/adverbs/ao.c
@@ -213,7 +213,7 @@ jtpolymult(J jt, A a, A w, A self) {
                 VA2 adocv;
                 VARPS adocvsum;
                 b     = 1;
-                adocv = var(ds(CSTAR), at, wt);
+                adocv = jtvar(jt, ds(CSTAR), at, wt);
                 varps(adocvsum, FAV(f)->fgh[0], wt, 0);  // get sum routine from f/, which is +/
                 GATV0(a1, INT, m, 1);
                 aa = AV(a1);
@@ -272,7 +272,7 @@ jtkeysp(J jt, A a, A w, A self) {
     DO(AN(x), if (k <= u[i]) break; if (u[i] == v[i])++ j;);
     RZ(b = ne(e, x));
     RZ(by = jtrepeat(jt, b, y));
-    RZ(x = key(jtrepeat(jt, b, x), jtfrom(jt, jtravel(jt, by), w), self));
+    RZ(x = jtkey(jt, jtrepeat(jt, b, x), jtfrom(jt, jtravel(jt, by), w), self));
     GASPARSE(q, SB01, 1, 1, (I *)0);
     *AS(q) = n; /* q=: 0 by}1$.n;0;1 */
     p      = PAV(q);
@@ -292,12 +292,12 @@ jtkey(J jt, A a, A w, A self) {
     PROLOG(0009);
     A ai, z = 0;
     I nitems;
-    if ((SPARSE & AT(a)) != 0) return keysp(a, w, self);  // if sparse, go handle it
+    if ((SPARSE & AT(a)) != 0) return jtkeysp(jt, a, w, self);  // if sparse, go handle it
     {
         I t2;
         ASSERT(SETIC(a, nitems) == SETIC(w, t2), EVLENGTH);
     }                                    // verify agreement.  nitems is # items of a
-    RZ(ai = indexofsub(IFORKEY, a, a));  // self-classify the input using ct set before this verb
+    RZ(ai = jtindexofsub(jt, IFORKEY, a, a));  // self-classify the input using ct set before this verb
     // indexofsub has 2 returns: most of the time, it returns a normal i.-family result, but with each slot holding the
     // index PLUS the number of values mapped to that index.  If processing determines that small-range lookup would be
     // best, indexofsub doesn't do it, but instead returns a block giving the size, min value, and range. We then
@@ -346,7 +346,7 @@ jtkey(J jt, A a, A w, A self) {
                                             // which differ in type of freq result
                 A accfn = FAV(FAV(self)->fgh[0])->fgh[0];
                 accfn   = keyslashfn == 3 ? ds(CPLUS) : accfn;
-                adocv   = var(
+                adocv   = jtvar(jt, 
                   accfn, AT(w), zt);  // get dyadic action routine for f out of f//. or (+/%#)/. for the given arguments
             }
 
@@ -904,7 +904,7 @@ jtkeybox(J jt, A a, A w, A self) {
     }
 
     // Note: self is invalid from here on
-    RZ(ai = indexofsub(IFORKEY, a, a));  // self-classify the input using ct set before this verb
+    RZ(ai = jtindexofsub(jt, IFORKEY, a, a));  // self-classify the input using ct set before this verb
     // indexofsub has 2 returns: most of the time, it returns a normal i.-family result, but with each slot holding the
     // index PLUS the number of values mapped to that index.  If processing determines that small-range lookup would be
     // best, indexofsub doesn't do it, but instead returns a block giving the size, min value, and range. We then
@@ -1085,7 +1085,7 @@ jtkeytallysp(J jt, A w) {
     DO(c, if (k <= u[i]) break; if (u[i] == v[i])++ j;);
     RZ(b = ne(e, x));
     RZ(x = jtrepeat(jt, b, x));
-    RZ(x = keytally(x, x, mark));
+    RZ(x = jtkeytally(jt, x, x, mark));
     u = AV(x);
     d = AN(x);
     GATV0(z, INT, 1 + d, 1);
@@ -1106,7 +1106,7 @@ jtkeytally(J jt, A a, A w, A self) {
     at = AT(a);
     ASSERT(n == SETIC(w, k), EVLENGTH);
     if (!AN(a))
-        return vec(INT, !!n, &AS(a)[0]);  // handle case of empties - a must have rank, so use AS[0] as  proxy for n
+        return jtvec(jt, INT, !!n, &AS(a)[0]);  // handle case of empties - a must have rank, so use AS[0] as  proxy for n
     if ((at & SPARSE) != 0) return jtkeytallysp(jt, a);
     if ((-n & SGNIF(at, B01X) & (AR(a) - 2)) < 0) {
         B *b = BAV(a);
@@ -1114,7 +1114,7 @@ jtkeytally(J jt, A a, A w, A self) {
         return BETWEENO(k, 1, n) ? jtv2(jt, *b ? k : n - k, *b ? n - k : k) : jtvci(jt, n);
     }                                    // nonempty rank<2 boolean a, just add the 1s
     A ai;                                // result from classifying a
-    RZ(ai = indexofsub(IFORKEY, a, a));  // self-classify the input using ct set before this verb
+    RZ(ai = jtindexofsub(jt, IFORKEY, a, a));  // self-classify the input using ct set before this verb
     // indexofsub has 2 returns: most of the time, it returns a normal i.-family result, but with each slot holding the
     // index PLUS the number of values mapped to that index.  If processing determines that small-range lookup would be
     // best, indexofsub doesn't do it, but instead returns a block giving the size, min value, and range. We then
@@ -1199,7 +1199,7 @@ jtkeyheadtally(J jt, A a, A w, A self) {
     ASSERT((-n & ((wt & NUMERIC + VERB) - 1)) >= 0, EVDOMAIN);  // OK if n=0 or numeric/i.@# w
     if ((((SPARSE & AT(a)) - 1) & ((I)AR(w) - 2) & (-n) & (-AN(a))) >= 0)
         return wt & VERB ? jthook1cell(jt, a, w)
-                         : key(a, w, self);  // if sparse or w has rank>1 or a has no cells or no atoms, revert, to
+                         : jtkey(jt, a, w, self);  // if sparse or w has rank>1 or a has no cells or no atoms, revert, to
                                              // monad/dyad.  w=self for monad
     av = AV(a);
     f  = FAV(f)->fgh[0];
@@ -1236,7 +1236,7 @@ jtkeyheadtally(J jt, A a, A w, A self) {
     // for other types of a, we handle it quickly only if w is B01/INT/FL or i.@# which has type of VERB
     if (wt & B01 + INT + FL + VERB) {
         A ai;                                // result from classifying a
-        RZ(ai = indexofsub(IFORKEY, a, a));  // self-classify the input using ct set before this verb
+        RZ(ai = jtindexofsub(jt, IFORKEY, a, a));  // self-classify the input using ct set before this verb
         // indexofsub has 2 returns: most of the time, it returns a normal i.-family result, but with each slot holding
         // the index PLUS the number of values mapped to that index.  If processing determines that small-range lookup
         // would be best, indexofsub doesn't do it, but instead returns a block giving the size, min value, and range.
@@ -1396,7 +1396,7 @@ jtkeyheadtally(J jt, A a, A w, A self) {
     } else {  // no special processing
         RZ(q = jtindexof(jt, a, a));
         x = jtrepeat(jt, eq(q, IX(n)), w);
-        y = keytally(q, q, 0L);
+        y = jtkeytally(jt, q, q, 0L);
         z = jtstitch(jt, b ? x : y, b ? y : x);  // (((i.~a) = i. # a) # w) ,. (#/.~ i.~ a)   for ({. , #)
     }
     EPILOG(z);

--- a/jsrc/adverbs/ap.c
+++ b/jsrc/adverbs/ap.c
@@ -274,12 +274,12 @@ jtpscanlt(J jt, I m, I d, I n, B* z, B* x, B p) {
 
 I
 ltpfxB(I d, I n, I m, B* RESTRICTI x, B* RESTRICTI z, J jt) {
-    pscanlt(m, d, n, z, x, C1);
+    jtpscanlt(jt, m, d, n, z, x, C1);
     return EVOK;
 }
 I
 lepfxB(I d, I n, I m, B* RESTRICTI x, B* RESTRICTI z, J jt) {
-    pscanlt(m, d, n, z, x, C0);
+    jtpscanlt(jt, m, d, n, z, x, C0);
     return EVOK;
 }
 
@@ -377,22 +377,22 @@ jtpscangt(J jt, I m, I d, I n, B* z, B* x, I apas) {
 
 I
 gtpfxB(I d, I n, I m, B* RESTRICTI x, B* RESTRICTI z, J jt) {
-    pscangt(m, d, n, z, x, 0x2);
+    jtpscangt(jt, m, d, n, z, x, 0x2);
     return EVOK;
 }
 I
 gepfxB(I d, I n, I m, B* RESTRICTI x, B* RESTRICTI z, J jt) {
-    pscangt(m, d, n, z, x, 0xd);
+    jtpscangt(jt, m, d, n, z, x, 0xd);
     return EVOK;
 }
 I
 norpfxB(I d, I n, I m, B* RESTRICTI x, B* RESTRICTI z, J jt) {
-    pscangt(m, d, n, z, x, 0x5);
+    jtpscangt(jt, m, d, n, z, x, 0x5);
     return EVOK;
 }
 I
 nandpfxB(I d, I n, I m, B* RESTRICTI x, B* RESTRICTI z, J jt) {
-    pscangt(m, d, n, z, x, 0xa);
+    jtpscangt(jt, m, d, n, z, x, 0xa);
     return EVOK;
 }
 
@@ -508,8 +508,8 @@ jtprefix(J jt, A w, A self) {
     I r;
     r = (RANKT)jt->ranks;
     RESETRANK;
-    if (r < AR(w)) { return rank1ex(w, self, r, jtprefix); }
-    return eachl(apv(SETIC(w, r), 1L, 1L), w, jtatop(jt, fs, ds(CTAKE)));
+    if (r < AR(w)) { return jtrank1ex(jt, w, self, r, jtprefix); }
+    return jteachl(jt, jtapv(jt, SETIC(w, r), 1L, 1L), w, jtatop(jt, fs, ds(CTAKE)));
 } /* f\"r w for general f */
 
 static A
@@ -519,7 +519,7 @@ jtgprefix(J jt, A w, A self) {
     ASSERT(DENSE & AT(w), EVNONCE);
     r = (RANKT)jt->ranks;
     RESETRANK;
-    if (r < AR(w)) { return rank1ex(w, self, r, jtgprefix); }
+    if (r < AR(w)) { return jtrank1ex(jt, w, self, r, jtgprefix); }
     SETIC(w, n);
     h  = VAV(self)->fgh[2];
     hv = AAV(h);
@@ -605,7 +605,7 @@ jtinfix(J jt, A a, A w, A self) {
     RZ(x = jtifxi(jt, m, w));
     // If there are infixes, apply fs@:jtseg (ac2 creates an A verb for jtseg)
     if (AS(x)[0])
-        z = eachl(x, w, jtatop(jt, fs, jtac2(jt, jtseg)));
+        z = jteachl(jt, x, w, jtatop(jt, fs, jtac2(jt, jtseg)));
     else {
         A s;
         I r, rr;
@@ -896,7 +896,7 @@ jtpscan(J jt, A w, A self) {
     I f, n, r, t, wn, wr, *ws, wt;
     FPREFIP;
     wt = AT(w);                                               // get type of w
-    if ((SPARSE & wt) != 0) return scansp(w, self, jtpscan);  // if sparse, go do it separately
+    if ((SPARSE & wt) != 0) return jtscansp(jt, w, self, jtpscan);  // if sparse, go do it separately
     // wn = #atoms in w, wr=rank of w, r=effective rank, f=length of frame, ws->shape of w
     wn = AN(w);
     wr = AR(w);
@@ -974,7 +974,7 @@ jtinfixd(J jt, A a, A w, A self) {
             DQ(d, memcpy(x, y, q); x += q; y += k;);
         } else {
             memcpy(x, y, n * k);
-            if (q = d * p - n) fillv(wt, q * c, x + n * k);
+            if (q = d * p - n) jtfillv(jt, wt, q * c, x + n * k);
         }
     }
     return z;
@@ -1056,7 +1056,7 @@ jtmovsumavg1(J jt, I m, A w, A fs, B avg) {
 static A
 jtmovsumavg(J jt, I m, A w, A fs, B avg) {
     A z;
-    z = movsumavg1(m, w, fs, avg);
+    z = jtmovsumavg1(jt, m, w, fs, avg);
     if (jt->jerr == EVNAN) RESETERR else return z;
     return jtinfixprefix2(jt, jtsc(jt, m), w, fs);
 }
@@ -1067,7 +1067,7 @@ jtmovavg(J jt, A a, A w, A self) {
     PREF2(jtmovavg);
     RE(m = jti0(jt, jtvib(jt, a)));
     SETIC(w, j);
-    if (0 < m && m <= j && AT(w) & B01 + FL + INT) return movsumavg(m, w, self, 1);  // j may be 0
+    if (0 < m && m <= j && AT(w) & B01 + FL + INT) return jtmovsumavg(jt, m, w, self, 1);  // j may be 0
     return jtinfixprefix2(jt, a, w, self);
 } /* a (+/ % #)\w */
 
@@ -1362,31 +1362,31 @@ jtmovfslash(J jt, A a, A w, A self) {
     if (id == CBDOT && (x = VAV(x)->fgh[1], INT & AT(x) && !AR(x))) id = (C)AV(x)[0];
     switch (AR(w) && BETWEENC(m0, 0, AS(w)[0]) ? id : 0) {
         case CPLUS:
-            if (wt & B01 + INT + FL) return movsumavg(m, w, self, 0);
+            if (wt & B01 + INT + FL) return jtmovsumavg(jt, m, w, self, 0);
             break;
         case CMIN:
-            if (wt & SBT + INT + FL) return movminmax(m, w, self, 0);
+            if (wt & SBT + INT + FL) return jtmovminmax(jt, m, w, self, 0);
             break;
         case CMAX:
-            if (wt & SBT + INT + FL) return movminmax(m, w, self, 1);
+            if (wt & SBT + INT + FL) return jtmovminmax(jt, m, w, self, 1);
             break;
         case CSTARDOT:
-            if (wt & B01) return movandor(m, w, self, 0);
+            if (wt & B01) return jtmovandor(jt, m, w, self, 0);
             break;
         case CPLUSDOT:
-            if (wt & B01) return movandor(m, w, self, 1);
+            if (wt & B01) return jtmovandor(jt, m, w, self, 1);
             break;
         case CNE:
-            if (wt & B01) return movneeq(m, w, self, 0);
+            if (wt & B01) return jtmovneeq(jt, m, w, self, 0);
             break;
         case CEQ:
-            if (wt & B01) return movneeq(m, w, self, 1);
+            if (wt & B01) return jtmovneeq(jt, m, w, self, 1);
             break;
         case CBW1001:
-            if (wt & INT) return movbwneeq(m, w, self, 1);
+            if (wt & INT) return jtmovbwneeq(jt, m, w, self, 1);
             break;
         case CBW0110:
-            if (wt & INT) return movbwneeq(m, w, self, 0);
+            if (wt & INT) return jtmovbwneeq(jt, m, w, self, 0);
             break;
     }
     VARPS adocv;
@@ -1427,7 +1427,7 @@ jtmovfslash(J jt, A a, A w, A self) {
         jtjsignal(jt, rc);
         if (rc >= EWOV) {
             RESETERR;
-            return movfslash(a, jtcvt(jt, FL, w), self);
+            return jtmovfslash(jt, a, jtcvt(jt, FL, w), self);
         }
         return 0;
     } else
@@ -1437,7 +1437,7 @@ jtmovfslash(J jt, A a, A w, A self) {
 static A
 jtiota1(J jt, A w, A self) {
     I j;
-    return apv(SETIC(w, j), 1L, 1L);
+    return jtapv(jt, SETIC(w, j), 1L, 1L);
 }
 
 A

--- a/jsrc/adverbs/ap.c
+++ b/jsrc/adverbs/ap.c
@@ -1449,7 +1449,7 @@ jtbslash(J jt, A w) {
     ;
     if (!w) return 0;
     if (NOUN & AT(w))
-        return fdef(
+        return jtfdef(jt, 
           0, CBSLASH, VERB, jtinfixprefix1, jtinfixprefix2, w, 0L, jtfxeachv(jt, 1L, w), VGERL | flag, RMAX, 0L, RMAX);
     v = FAV(w);  // v is the u in u\ y
     switch (v->id) {

--- a/jsrc/adverbs/ar.c
+++ b/jsrc/adverbs/ar.c
@@ -1091,7 +1091,7 @@ jtslash(J jt, A w) {
             break;  // monad is inplaceable if the dyad for u is
     }
     RZ(h = jtqq(jt, w, jtv2(jt, lr(w), RMAX)));  // create the rank compound to use if dyad
-    RZ(h = fdef(0, CSLASH, VERB, f1, jtoprod, w, 0L, h, flag | FAV(ds(CSLASH))->flag, RMAX, RMAX, RMAX));
+    RZ(h = jtfdef(jt, 0, CSLASH, VERB, f1, jtoprod, w, 0L, h, flag | FAV(ds(CSLASH))->flag, RMAX, RMAX, RMAX));
     // set lvp[1] to point to the VARPSA block for w if w is atomic dyad; otherwise to the null VARPSA block
     FAV(h)->localuse.lvp[1] = v->flag & VISATOMIC2 ? ((VA*)v->localuse.lvp[0])->rps : &rpsnull;
     return h;

--- a/jsrc/adverbs/ar.c
+++ b/jsrc/adverbs/ar.c
@@ -208,7 +208,7 @@ jtred0(J jt, A w, A self) {
     } else {
         GASPARSE(x, AT(w), 1, r, f + s);
     }
-    return jtreitem(jt, vec(INT, f, s), jtlamin1(jt, df1(z, x, (AT(w) & SBT) ? jtidensb(jt, fs) : jtiden(jt, fs))));
+    return jtreitem(jt, jtvec(jt, INT, f, s), jtlamin1(jt, df1(z, x, (AT(w) & SBT) ? jtidensb(jt, fs) : jtiden(jt, fs))));
 } /* f/"r w identity case */
 
 // general reduce.  We inplace the results into the next iteration.  This routine cannot inplace its inputs.
@@ -225,7 +225,7 @@ jtredg(J jt, A w, A self) {
     r  = (RANKT)jt->ranks;
     r  = wr < r ? wr : r;
     RESETRANK;
-    if (r < wr) return rank1ex(w, self, r, jtredg);
+    if (r < wr) return jtrank1ex(jt, w, self, r, jtredg);
     // From here on we are doing a single reduction
     n = AS(w)[0];  // n=#cells
     // Allocate virtual block for the running x argument.
@@ -349,7 +349,7 @@ jtredsp1(J jt, A w, A self, C id, VARPSF ado, I cv, I f, I r, I zt) {
         RE(0);
         if (m == n) return z;
     }
-    return redsp1a(id, z, e, n, AR(w), AS(w));
+    return jtredsp1a(jt, id, z, e, n, AR(w), AS(w));
 } /* f/"r w for sparse vector w */
 
 A
@@ -375,7 +375,7 @@ jtredravel(J jt, A w, A self) {
         if (rc) jtjsignal(jt, rc);
         if (rc < EWOV) {
             if (rc) return 0;
-            return redsp1a(FAV(FAV(f)->fgh[0])->id, z, SPA(wp, e), n, AR(w), AS(w));
+            return jtredsp1a(jt, FAV(FAV(f)->fgh[0])->id, z, SPA(wp, e), n, AR(w), AS(w));
         }  // since f has an insert fn, its id must be OK
     }
 } /* f/@, w */
@@ -644,7 +644,7 @@ jtredsps(J jt, A w, A self, C id, VARPSF ado, I cv, I f, I r, I zt) {
             yv += n * yc;
         }
     }
-    if (sn) RZ(redspse(id, wm, xt, e, zx, sn, &e, &zx));
+    if (sn) RZ(jtredspse(jt, id, wm, xt, e, zx, sn, &e, &zx));
     RZ(a1 = jtca(jt, a));
     v = AV(a1);
     n = 0;
@@ -652,7 +652,7 @@ jtredsps(J jt, A w, A self, C id, VARPSF ado, I cv, I f, I r, I zt) {
     GASPARSE(z, STYPE(AT(zx)), 1, wr - 1, ws);
     if (1 < r) MCISH(f + AS(z), f + 1 + ws, r - 1);
     zp = PAV(z);
-    SPB(zp, a, vec(INT, n, v));
+    SPB(zp, a, jtvec(jt, INT, n, v));
     SPB(zp, e, jtcvt(jt, AT(zx), e));
     SPB(zp, x, zx);
     SPB(zp, i, zy);
@@ -698,7 +698,7 @@ jtreducesp(J jt, A w, A self) {
     zt = rtype(adocv.cv);
     RESETRANK;
     if (1 == wr)
-        z = redsp1(w, self, id, adocv.f, adocv.cv, f, r, zt);
+        z = jtredsp1(jt, w, self, id, adocv.f, adocv.cv, f, r, zt);
     else {
         wp = PAV(w);
         a  = SPA(wp, a);
@@ -709,7 +709,7 @@ jtreducesp(J jt, A w, A self) {
               b = 1;
               break;
           });
-        z = b ? redsps(w, self, id, adocv.f, adocv.cv, f, r, zt) : redspd(w, self, id, adocv.f, adocv.cv, f, r, zt);
+        z = b ? jtredsps(jt, w, self, id, adocv.f, adocv.cv, f, r, zt) : jtredspd(jt, w, self, id, adocv.f, adocv.cv, f, r, zt);
     }
     return jt->jerr >= EWOV ? IRS1(w, self, r, jtreducesp, z) : z;
 } /* f/"r for sparse w */
@@ -801,7 +801,7 @@ jtredcatsp(J jt, A w, A z, I r) {
     n  = AN(a);
     n1 = n - 1;
     xr = AR(x);
-    RZ(b = bfi(wr, a, 1));
+    RZ(b = jtbfi(jt, wr, a, 1));
     c = b[f];
     d = b[1 + f];
     if (c && d) b[f] = 0;
@@ -850,7 +850,7 @@ jtredcatsp(J jt, A w, A z, I r) {
         u  = AS(x);
         *v = u[0] * u[1];
         MCISH(1 + v, 2 + u, xr - 1);
-        RZ(x = jtreshape(jt, vec(INT, xr - 1, v), x));
+        RZ(x = jtreshape(jt, jtvec(jt, INT, xr - 1, v), x));
         e = ws[f + c];
         RZ(y = jtrepeat(jt, jtsc(jt, e), y));
         RZ(y = jtmkwris(jt, y));
@@ -927,7 +927,7 @@ jtredcat(J jt, A w, A self) {
             DPMULDE(s[f], s[1 + f], *v);
             MCISH(1 + v, 2 + f + s, r - 2);
         }
-        return redcatsp(w, z, r);
+        return jtredcatsp(jt, w, z, r);
     }
 } /* ,/"r w */
 
@@ -974,7 +974,7 @@ jtredstitch(J jt, A w, A self) {
         return IRS2(z1, z2, 0L, 1L, 0L, jtover, z3);
     }
     if (2 == r) return IRS1(w, 0L, 2L, jtcant1, y);
-    RZ(c = apvwr(wr, 0L, 1L));
+    RZ(c = jtapvwr(jt, wr, 0L, 1L));
     v        = AV(c);
     v[f]     = f + 1;
     v[f + 1] = f;
@@ -1142,7 +1142,7 @@ jtfoldx(J jt, A a, A w, A self) {
     // get the rest of the flags from the original ID byte, which was moved to lc
     foldflag |= FAV(self)->lc - CFDOT;  // this sets mult fwd rev
     // define the flags as the special global
-    RZ(symbis(jtnfs(jt, 11, "Foldtype_j_"), jtsc(jt, foldflag), jt->locsyms));
+    RZ(jtsymbis(jt, jtnfs(jt, 11, "Foldtype_j_"), jtsc(jt, foldflag), jt->locsyms));
     // execute the Fold.  While it is running, set the flag to allow Z:
     B foldrunning   = jt->foldrunning;
     jt->foldrunning = 1;
@@ -1178,7 +1178,7 @@ found:;
 
     // Apply Fold_j_ to the input arguments, creating a derived verb to do the work
     A derivvb;
-    RZ(derivvb = unquote(a, w, foldconj));
+    RZ(derivvb = jtunquote(jt, a, w, foldconj));
     // Modify the derived verb to go to our preparatory stub.  Save the dyadic entry point for the derived verb so the
     // stub can call it
     FAV(derivvb)->localuse.lfns[1] = FAV(derivvb)->valencefns[1];
@@ -1197,7 +1197,7 @@ jtfoldZ(J jt, A a, A w, A self) {
     RZ(foldvb = jtnameref(jt, jtnfs(jt, 8, "FoldZ_j_"), jt->locsyms));
     ASSERT((AT(foldvb) & VERB), EVNONCE);  // error if undefined or not verb
     // Apply FoldZ_j_ to the input arguments, creating a derived verb to do the work
-    A z = unquote(a, w, foldvb);
+    A z = jtunquote(jt, a, w, foldvb);
     // if there was an error, save the error code and recreate the error at this level, to cover up details inside the
     // script
     if (jt->jerr) {

--- a/jsrc/adverbs/as.c
+++ b/jsrc/adverbs/as.c
@@ -218,8 +218,8 @@ jtsuffix(J jt, A w, A self) {
     I r;
     r = (RANKT)jt->ranks;
     RESETRANK;
-    if (r < AR(w)) return rank1ex(w, self, r, jtsuffix);
-    return eachl(IX(SETIC(w, r)), w, jtatop(jt, fs, ds(CDROP)));
+    if (r < AR(w)) return jtrank1ex(jt, w, self, r, jtsuffix);
+    return jteachl(jt, IX(SETIC(w, r)), w, jtatop(jt, fs, ds(CDROP)));
 } /* f\."r w for general f */
 
 static A
@@ -228,7 +228,7 @@ jtgsuffix(J jt, A w, A self) {
     I m, n, r;
     r = (RANKT)jt->ranks;
     RESETRANK;
-    if (r < AR(w)) return rank1ex(w, self, r, jtgsuffix);
+    if (r < AR(w)) return jtrank1ex(jt, w, self, r, jtgsuffix);
     SETIC(w, n);
     h  = VAV(self)->fgh[2];
     hv = AAV(h);
@@ -252,7 +252,7 @@ jtssg(J jt, A w, A self) {
     r  = (RANKT)jt->ranks;
     r  = wr < r ? wr : r;
     RESETRANK;
-    if (r < wr) return rank1ex(w, self, r, jtssg);
+    if (r < wr) return jtrank1ex(jt, w, self, r, jtssg);
 
     // From here on we are doing a single scan
     n = AS(w)[0];  // n=#cells
@@ -389,7 +389,7 @@ jtscansp(J jt, A w, A self, AF sf) {
         RZ(x = jtdenseit(jt, w));
         return IRS1(x, self, r, sf, z);
     } else {
-        RZ(b = bfi(wr, SPA(wp, a), 1));
+        RZ(b = jtbfi(jt, wr, SPA(wp, a), 1));
         if (r && b[f]) {
             b[f] = 0;
             RZ(w = jtreaxis(jt, jtifb(jt, wr, b), w));
@@ -422,7 +422,7 @@ jtsscan(J jt, A w, A self) {
     FPREFIP;
     if (!w) return 0;
     wt = AT(w);
-    if ((SPARSE & wt) != 0) return scansp(w, self, jtsscan);
+    if ((SPARSE & wt) != 0) return jtscansp(jt, w, self, jtsscan);
     wn = AN(w);
     wr = AR(w);
     r  = (RANKT)jt->ranks;
@@ -492,7 +492,7 @@ jtgoutfix(J jt, A a, A w, A self) {
     return jtope(jt, z);
 }
 
-static AS2(jtoutfix, eachl(jtomask(jt, a, w), w, jtatop(jt, fs, ds(CPOUND))), 0117)
+static AS2(jtoutfix, jteachl(jt, jtomask(jt, a, w), w, jtatop(jt, fs, ds(CPOUND))), 0117)
 
   static A jtofxinv(J jt, A a, A w, A self) {
     A f, fs, z;
@@ -506,12 +506,12 @@ static AS2(jtoutfix, eachl(jtomask(jt, a, w), w, jtatop(jt, fs, ds(CPOUND))), 01
     c  = v->id;
     t  = AT(w);  // self = f/\. fs = f/  f = f  v = verb info for f
     if (!(c == CPLUS || c == CBDOT && t & INT || ((c & -2) == CEQ) && t & B01))
-        return outfix(a, w, self);  // if not +/\. or m b./\. or =/\. or ~:/\.
+        return jtoutfix(jt, a, w, self);  // if not +/\. or m b./\. or =/\. or ~:/\.
     A z0, z1;
-    z = irs2(df1(z0, w, fs), df2(z1, a, w, jtbslash(jt, fs)), c == CPLUS ? ds(CMINUS) : f, RMAX, -1L, jtatomic2);
+    z = jtirs2(jt, df1(z0, w, fs), df2(z1, a, w, jtbslash(jt, fs)), c == CPLUS ? ds(CMINUS) : f, RMAX, -1L, jtatomic2);
     if (jt->jerr == EVNAN) {
         RESETERR;
-        return outfix(a, w, self);
+        return jtoutfix(jt, a, w, self);
     } else
         return z;
 } /* a f/\. w where f has an "undo" */
@@ -532,15 +532,15 @@ jtofxassoc(J jt, A a, A w, A self) {
     v  = FAV(x);
     id = CBDOT == v->id ? (C)AV(v->fgh[1])[0] : v->id;  // self = f/\. f = f/  x = f  v = verb info for f
     if (k == IMIN || m <= c || id == CSTARDOT && !(B01 & AT(w)))
-        return outfix(a, w, self);  // if there is not >1 outfix, do general code which handles empties
+        return jtoutfix(jt, a, w, self);  // if there is not >1 outfix, do general code which handles empties
     if (-1 <= k) {
         d = m - c;
         RZ(i = IX(d));
-        RZ(j = apv(d, c, 1L));
+        RZ(j = jtapv(jt, d, c, 1L));
     } else {
         d = (m - 1) / c;
-        RZ(i = apv(d, c - 1, c));
-        RZ(j = apv(d, c, c));
+        RZ(i = jtapv(jt, d, c - 1, c));
+        RZ(j = jtapv(jt, d, c, c));
     }
     // d is (number of result cells)-1; i is indexes of last item of the excluded infix for cells AFTER the first
     // j is indexes of first item AFTER the excluded infix for cells BEFORE the last
@@ -562,7 +562,7 @@ jtofxassoc(J jt, A a, A w, A self) {
         PROD(c, AR(p) - 1, AS(p) + 1) t = AT(p);
         klg                             = bplg(t);
         kc                              = c << klg;
-        adocv                           = var(x, t, t);  // analyze the u operand
+        adocv                           = jtvar(jt, x, t, t);  // analyze the u operand
         ASSERTSYS(adocv.f, "ofxassoc");                  // scaf
         GA(z, t, c * (1 + d), r, AS(p));
         AS(z)[0] = 1 + d;
@@ -575,7 +575,7 @@ jtofxassoc(J jt, A a, A w, A self) {
         // We also have to redo if the types of p and s were different (for example, if one overflowed to float and the
         // other didn't)
     }
-    if ((rc & 255) >= EWOV) { return ofxassoc(a, jtcvt(jt, FL, w), self); }
+    if ((rc & 255) >= EWOV) { return jtofxassoc(jt, a, jtcvt(jt, FL, w), self); }
     if (rc) jtjsignal(jt, rc);  // if there was an error, signal it
     return z;
 } /* a f/\. w where f is an atomic associative fn */
@@ -584,7 +584,7 @@ static A
 jtiota1rev(J jt, A w, A self) {
     I j;
     SETIC(w, j);
-    return apv(j, j, -1L);
+    return jtapv(jt, j, j, -1L);
 }
 
 A

--- a/jsrc/adverbs/as.c
+++ b/jsrc/adverbs/as.c
@@ -595,7 +595,7 @@ jtbsdot(J jt, A w) {
     C id;
     V* v;  // init flag is IRS1
     if (NOUN & AT(w))
-        return fdef(0,
+        return jtfdef(jt, 0,
                     CBSLASH,
                     VERB,
                     jtgsuffix,

--- a/jsrc/adverbs/au.c
+++ b/jsrc/adverbs/au.c
@@ -47,7 +47,7 @@ jtself2(J jt, A a, A w) {
 
 A
 jtac2(J jt, AF f) {
-    return fdef(0, 0, VERB, 0L, f, 0L, 0L, 0L, VFLAGNONE, RMAX, RMAX, RMAX);
+    return jtfdef(jt, 0, 0, VERB, 0L, f, 0L, 0L, 0L, VFLAGNONE, RMAX, RMAX, RMAX);
 }
 
 A

--- a/jsrc/array.hpp
+++ b/jsrc/array.hpp
@@ -98,7 +98,7 @@ make_array(J jt, int64_t atoms, rank_t rank) {
 template <typename Type>
 [[nodiscard]] inline auto
 make_array(J jt, int64_t n, rank_t r, shape_t s) -> array {
-    return ga(to_c_type<Type>(), n, r, s);
+    return jtga(jt, to_c_type<Type>(), n, r, s);
 }
 
 // this is for "creating an integer atom with value k"

--- a/jsrc/conjunctions/ca.c
+++ b/jsrc/conjunctions/ca.c
@@ -80,7 +80,7 @@ jtmodpow2(J jt, A a, A w, A self) {
 static A
 jtmodpow1(J jt, A w, A self) {
     A g = FAV(self)->fgh[1];
-    return rank2ex0(FAV(g)->fgh[0], w, self, jtmodpow2);
+    return jtrank2ex0(jt, FAV(g)->fgh[0], w, self, jtmodpow2);
 }  // m must be an atom; I think n can have shape.  But we treat w as atomic
    /* m&|@(n&^) w ; m guaranteed to be INT or XNUM */
 
@@ -196,7 +196,7 @@ static A
 atcomp(J jt, A a, A w, A self) {
     AF f;
     A z;
-    f = atcompf(a, w, self);
+    f = jtatcompf(jt, a, w, self);
     if (f) {
         I postflags = jt->workareas.compsc.postflags;
         z           = f(jt, a, w, self);
@@ -204,7 +204,7 @@ atcomp(J jt, A a, A w, A self) {
             if (postflags & 2) { z = num((IAV(z)[0] != AN(AR(a) >= AR(w) ? a : w)) ^ (postflags & 1)); }
         }
     } else
-        z = upon2(a, w, self);
+        z = jtupon2(jt, a, w, self);
     return z;
 }
 
@@ -212,7 +212,7 @@ static A
 atcomp0(J jt, A a, A w, A self) {
     A z;
     AF f;
-    f = atcompf(a, w, self);
+    f = jtatcompf(jt, a, w, self);
     PUSHCCT(1.0)
     if (f) {
         I postflags = jt->workareas.compsc.postflags;
@@ -221,7 +221,7 @@ atcomp0(J jt, A a, A w, A self) {
             if (postflags & 2) { z = num((IAV(z)[0] != AN(AR(a) >= AR(w) ? a : w)) ^ (postflags & 1)); }
         }
     } else
-        z = upon2(a, w, self);
+        z = jtupon2(jt, a, w, self);
     return z;
 }
 
@@ -727,13 +727,13 @@ withr(J jt, A w, A self) {
 static A
 ixfixedleft(J jt, A w, A self) {
     V *v = FAV(self);
-    return indexofprehashed(v->fgh[0], w, v->fgh[2]);
+    return jtindexofprehashed(jt, v->fgh[0], w, v->fgh[2]);
 }
 // Here for compounds like (i.&0@:e.)&n or -.&n that compute a prehashed table from w
 static A
 ixfixedright(J jt, A w, A self) {
     V *v = FAV(self);
-    return indexofprehashed(v->fgh[1], w, v->fgh[2]);
+    return jtindexofprehashed(jt, v->fgh[1], w, v->fgh[2]);
 }
 
 // Here if ct was 0 when the compound was created - we must keep it 0
@@ -741,7 +741,7 @@ static A
 ixfixedleft0(J jt, A w, A self) {
     A z;
     V *v           = FAV(self);
-    PUSHCCT(1.0) z = indexofprehashed(v->fgh[0], w, v->fgh[2]);
+    PUSHCCT(1.0) z = jtindexofprehashed(jt, v->fgh[0], w, v->fgh[2]);
     POPCCT
     return z;
 }
@@ -750,7 +750,7 @@ static A
 ixfixedright0(J jt, A w, A self) {
     A z;
     V *v           = FAV(self);
-    PUSHCCT(1.0) z = indexofprehashed(v->fgh[1], w, v->fgh[2]);
+    PUSHCCT(1.0) z = jtindexofprehashed(jt, v->fgh[1], w, v->fgh[2]);
     POPCCT
     return z;
 }
@@ -758,7 +758,7 @@ ixfixedright0(J jt, A w, A self) {
 static A
 with2(J jt, A a, A w, A self) {
     A z;
-    return df1(z, w, powop(self, a, 0));
+    return df1(z, w, jtpowop(jt, self, a, 0));
 }
 
 // u&v
@@ -800,11 +800,11 @@ jtamp(J jt, A a, A w) {
             }
             if (0 <= mode) {
                 if (b) {
-                    PUSHCCT(1.0) h = indexofsub(mode, a, mark);
+                    PUSHCCT(1.0) h = jtindexofsub(jt, mode, a, mark);
                     POPCCT f1      = ixfixedleft0;
                     flag &= ~VJTFLGOK1;
                 } else {
-                    h  = indexofsub(mode, a, mark);
+                    h  = jtindexofsub(jt, mode, a, mark);
                     f1 = ixfixedleft;
                     flag &= ~VJTFLGOK1;
                 }
@@ -853,11 +853,11 @@ jtamp(J jt, A a, A w) {
             }
             if (0 <= mode) {
                 if (b) {
-                    PUSHCCT(1.0) h = indexofsub(mode, w, mark);
+                    PUSHCCT(1.0) h = jtindexofsub(jt, mode, w, mark);
                     POPCCT f1      = ixfixedright0;
                     flag &= ~VJTFLGOK1;
                 } else {
-                    h  = indexofsub(mode, w, mark);
+                    h  = jtindexofsub(jt, mode, w, mark);
                     f1 = ixfixedright;
                     flag &= ~VJTFLGOK1;
                 }

--- a/jsrc/conjunctions/ca.c
+++ b/jsrc/conjunctions/ca.c
@@ -271,14 +271,14 @@ jtatop(J jt, A a, A w) {
                 AT(w) |= LIT;
             }
         }
-        return fdef(0, CAT, VERB, onconst1, onconst2, a, w, h, VFLAGNONE, RMAX, RMAX, RMAX);
+        return jtfdef(jt, 0, CAT, VERB, onconst1, onconst2, a, w, h, VFLAGNONE, RMAX, RMAX, RMAX);
     }
     wv = FAV(w);
     d  = wv->id;
     if ((d & ~1) == CLEFT) {
         // the very common case u@] and u@[.  Take ASGSAFE and inplaceability from u.  No IRS.  Vector the monad
         // straight to u; vector the dyad to our routine that shuffles args and inplace bits
-        return fdef(0,
+        return jtfdef(jt, 0,
                     CAT,
                     VERB,
                     onright1,
@@ -471,7 +471,7 @@ jtatop(J jt, A a, A w) {
         }
     }
 
-    return fdef(flag2, CAT, VERB, f1, f2, a, w, h, flag, (I)wv->mr, (I)lrv(wv), rrv(wv));
+    return jtfdef(jt, flag2, CAT, VERB, f1, f2, a, w, h, flag, (I)wv->mr, (I)lrv(wv), rrv(wv));
 }
 
 // u@:v
@@ -493,7 +493,7 @@ jtatco(J jt, A a, A w) {
     if ((d & ~1) == CLEFT) {
         // the very common case u@:] and u@:[.  Take ASGSAFE and inplaceability from u.  No IRS.  Vector the monad
         // straight to u; vector the dyad to our routine that shuffles args and inplace bits
-        return fdef(0,
+        return jtfdef(jt, 0,
                     CATCO,
                     VERB,
                     onright1,
@@ -638,7 +638,7 @@ jtatco(J jt, A a, A w) {
     flag2 |= wv->flag2 & (VF2WILLOPEN1 | VF2WILLOPEN2W | VF2WILLOPEN2A | VF2USESITEMCOUNT1 | VF2USESITEMCOUNT2W |
                           VF2USESITEMCOUNT2A);
 
-    return fdef(flag2, CATCO, VERB, f1, f2, a, w, 0L, flag, RMAX, RMAX, RMAX);
+    return jtfdef(jt, flag2, CATCO, VERB, f1, f2, a, w, 0L, flag, RMAX, RMAX, RMAX);
 }
 
 // u&:v
@@ -693,7 +693,7 @@ jtampco(J jt, A a, A w) {
     flag2 |= (f1 == on1cell) << VF2RANKATOP1X;
     flag2 |= VF2RANKATOP2;
     A z;
-    RZ(z = fdef(flag2, CAMPCO, VERB, f1, f2, a, w, 0L, flag, RMAX, RMAX, RMAX));
+    RZ(z = jtfdef(jt, flag2, CAMPCO, VERB, f1, f2, a, w, 0L, flag, RMAX, RMAX, RMAX));
     FAV(z)->localuse.lclr[0] = linktype;
     return z;
 }
@@ -822,7 +822,7 @@ jtamp(J jt, A a, A w) {
                             flag &= ~VJTFLGOK1;
                         }
                 }
-            return fdef(0, CAMP, VERB, f1, with2, a, w, h, flag, RMAX, RMAX, RMAX);
+            return jtfdef(jt, 0, CAMP, VERB, f1, with2, a, w, h, flag, RMAX, RMAX, RMAX);
         case VN:
             f1 = withr;
             v  = FAV(a);
@@ -862,7 +862,7 @@ jtamp(J jt, A a, A w) {
                     flag &= ~VJTFLGOK1;
                 }
             }
-            return fdef(0, CAMP, VERB, f1, with2, a, w, h, flag, RMAX, RMAX, RMAX);
+            return jtfdef(jt, 0, CAMP, VERB, f1, with2, a, w, h, flag, RMAX, RMAX, RMAX);
         case VV:
             // u&v
             f1 = on1;
@@ -963,7 +963,7 @@ jtamp(J jt, A a, A w) {
                 }
             }
             A z;
-            RZ(z = fdef(flag2, CAMP, VERB, f1, f2, a, w, 0L, flag, r, r, r));
+            RZ(z = jtfdef(jt, flag2, CAMP, VERB, f1, f2, a, w, 0L, flag, r, r, r));
             FAV(z)->localuse.lclr[0] = linktype;
             return z;
     }

--- a/jsrc/conjunctions/cc.c
+++ b/jsrc/conjunctions/cc.c
@@ -153,7 +153,7 @@ jtcut02(J jt, A a, A w, A self) {
                         RZ(
                           qv[i] = jtincorp(
                             jt,
-                            apv(k, j, 2 * e + 1)));  // create ascending or descending vector.  The increment is 1 or -1
+                            jtapv(jt, k, j, 2 * e + 1)));  // create ascending or descending vector.  The increment is 1 or -1
                     }
                     break;  // this is the loop exit
                 } else {    // we have not allocated the input to {; do so now
@@ -417,7 +417,7 @@ jtcut2bx(J jt, A a, A w, A self) {
     } else {
         RZ(t = jtiota(jt, apip(shape(jt, x), jtv2(jt, 2L, 0L))));
     }
-    return cut02(t, w, self);
+    return jtcut02(jt, t, w, self);
 } /* a f;.n w for boxed a, with special code for matrix w */
 
 #define CUTSWITCH(EACHC)                                                                                             \
@@ -435,7 +435,7 @@ jtcut2bx(J jt, A a, A w, A self) {
             zi = AV(z);                                                                                              \
             EACHC(*zi++ = d;);                                                                                       \
             A zz, zw;                                                                                                \
-            RZ(zw = vec(INT, MAX(0, r - 1), 1 + s));                                                                 \
+            RZ(zw = jtvec(jt, INT, MAX(0, r - 1), 1 + s));                                                                 \
             IRS2(z, zw, 0L, 0L, 1L, jtover, zz);                                                                     \
             return zz;                                                                                               \
         case CHEAD:                                                                                                  \
@@ -457,7 +457,7 @@ jtcut2bx(J jt, A a, A w, A self) {
             DPMULDE(m *c, e, d);                                                                                     \
             GA(z, t, d, id == CCOMMA ? 2 : 1 + r, s - 1);                                                            \
             zc = CAV(z);                                                                                             \
-            fillv(t, d, zc);                                                                                         \
+            jtfillv(jt, t, d, zc);                                                                                         \
             zs    = AS(z);                                                                                           \
             zs[0] = m;                                                                                               \
             zs[1] = id == CCOMMA ? e * c : e;                                                                        \
@@ -581,7 +581,7 @@ jtcut2sx(J jt, A a, A w, A self) {
     RZ(a = a == mark ? jteps(jt, w, jttake(jt, num(pfx ? 1 : -1), w)) : DENSE & AT(a) ? jtsparse1(jt, a) : a);
     ASSERT(n == AS(a)[0], EVLENGTH);
     ap = PAV(a);
-    if (!(jtequ(jt, num(0), SPA(ap, e)) && AN(SPA(ap, a)))) return cut2(jtcvt(jt, B01, a), w, self);
+    if (!(jtequ(jt, num(0), SPA(ap, e)) && AN(SPA(ap, a)))) return jtcut2(jt, jtcvt(jt, B01, a), w, self);
     vf = VAV(fs);
     if (VGERL & sv->flag) {
         h  = sv->fgh[2];
@@ -692,8 +692,8 @@ jtcut2sx(J jt, A a, A w, A self) {
                               break;
                           });
                     *AS(ww) = (yu[i] - yu[i - 1]) - neg;
-                    SPB(wwp, i, sely(y, qn, p, 1 + yu[i - 1]));
-                    SPB(wwp, x, selx(x, qn, p));
+                    SPB(wwp, i, jtsely(jt, y, qn, p, 1 + yu[i - 1]));
+                    SPB(wwp, x, jtselx(jt, x, qn, p));
                     RZ(zz = h ? df1(z0, ww, hv[(i - 1) % hn]) : CALL1(f1, ww, fs));
                     // reallocate ww if it was used, which we detect by seeing the usecount incremented.  This requires
                     // that everything that touches a buffer either copy it or jtrat(jt,).  So that ] doesn't have to
@@ -731,8 +731,8 @@ jtcut2sx(J jt, A a, A w, A self) {
                           });
                     }
                     *AS(ww) = (yu[i - 1] - yu[i]) - neg;
-                    SPB(wwp, i, sely(y, qn, p + q - qn, yu[i] + neg));
-                    SPB(wwp, x, selx(x, qn, p + q - qn));
+                    SPB(wwp, i, jtsely(jt, y, qn, p + q - qn, yu[i] + neg));
+                    SPB(wwp, x, jtselx(jt, x, qn, p + q - qn));
                     RZ(zz = h ? df1(z0, ww, hv[(m - i) % hn]) : CALL1(f1, ww, fs));
                     p += q;
                     if (WASINCORP1(zz, ww)) {
@@ -746,7 +746,7 @@ jtcut2sx(J jt, A a, A w, A self) {
                 for (i = 1; i <= m; ++i) {
                     q       = yu[i] - yu[i - 1];
                     *AS(ww) = q - neg;
-                    SPB(wwp, x, irs2(apv(q - neg, p, 1L), x, 0L, 1L, -1L, jtfrom));
+                    SPB(wwp, x, jtirs2(jt, jtapv(jt, q - neg, p, 1L), x, 0L, 1L, -1L, jtfrom));
                     RZ(zz = h ? df1(z0, ww, hv[(i - 1) % hn]) : CALL1(f1, ww, fs));
                     p += q;
                     if (WASINCORP1(zz, ww)) {
@@ -760,7 +760,7 @@ jtcut2sx(J jt, A a, A w, A self) {
                 for (i = m; i >= 1; --i) {
                     q       = yu[i - 1] - yu[i];
                     *AS(ww) = q - neg;
-                    SPB(wwp, x, irs2(apv(q - neg, p + neg, 1L), x, 0L, 1L, -1L, jtfrom));
+                    SPB(wwp, x, jtirs2(jt, jtapv(jt, q - neg, p + neg, 1L), x, 0L, 1L, -1L, jtfrom));
                     RZ(zz = h ? df1(z0, ww, hv[(i - 1) % hn]) : CALL1(f1, ww, fs));
                     p += q;
                     if (WASINCORP1(zz, ww)) {
@@ -784,7 +784,7 @@ jtidenv0(J jt, A a, A w, V *sv, I zt, A *zz) {
     fs  = sv->fgh[0];
     RE(df1(y, num(0), jtiden(jt, VAV(fs)->fgh[0])));
     if (TYPESLT(zt, AT(y))) {
-        *zz = df1(z, cut2(a, w, jtcut(jt, ds(CBOX), sv->fgh[1])), jtamp(jt, fs, ds(COPE)));
+        *zz = df1(z, jtcut2(jt, a, w, jtcut(jt, ds(CBOX), sv->fgh[1])), jtamp(jt, fs, ds(COPE)));
         return 0;
     }  // fgh still has the original A, OK to use
     if (TYPESGT(zt, AT(y))) RE(y = jtcvt(jt, zt, y));
@@ -938,7 +938,7 @@ jtcut2(J jt, A a, A w, A self) {
     UC *pd, *pdend;  // Don't make d1 too big - it fill lots of stack space
     PREF2(jtcut2);
     // a may have come from /., in which case it is incompletely filled in.  We look at the type, but nothing else
-    if ((SGNIF(AT(a), SB01X) | -(AT(w) & SPARSE)) < 0) return cut2sx(a, w, self);
+    if ((SGNIF(AT(a), SB01X) | -(AT(w) & SPARSE)) < 0) return jtcut2sx(jt, a, w, self);
 #define ZZFLAGWORD state
     I state = ZZFLAGINITSTATE;  // init flags, including zz flags
 
@@ -979,7 +979,7 @@ jtcut2(J jt, A a, A w, A self) {
                 return CALL1(f1, w, fs);
             }
             if (((-AN(a)) & (SGNIF(AT(a), BOXX))) < 0)
-                return cut2bx(a, w, self);                      // handle boxed a separately if a not empty
+                return jtcut2bx(jt, a, w, self);                      // handle boxed a separately if a not empty
             if (!(B01 & AT(a))) RZ(a = jtcvt(jt, B01, a));      // convert other a to binary, error if impossible
             if (!AR(a)) RZ(a = jtreshape(jt, jtsc(jt, n), a));  // extend scalar x to length of y
             ak = 1;
@@ -1291,7 +1291,7 @@ jtcut2(J jt, A a, A w, A self) {
             GATV0(zz, INT, m, 1);
             zi = AV(zz);
             EACHCUT(*zi++ = d;);
-            A zw = vec(INT, MAX(0, r - 1), AS(w) + 1);  // could use virt block
+            A zw = jtvec(jt, INT, MAX(0, r - 1), AS(w) + 1);  // could use virt block
             return IRS2(zz, zw, 0L, 0L, 1L, jtover, z);
         case CTAIL:
         case CHEAD:;
@@ -1300,7 +1300,7 @@ jtcut2(J jt, A a, A w, A self) {
             GA(zz, wt, m * wcn, r, AS(w));
             zc        = CAV(zz);
             AS(zz)[0] = m;
-            EACHCUT(if (d) memcpy(zc, id == CHEAD ? v1 : v1 + k * (d - 1), k); else fillv(wt, wcn, zc); zc += k;);
+            EACHCUT(if (d) memcpy(zc, id == CHEAD ? v1 : v1 + k * (d - 1), k); else jtfillv(jt, wt, wcn, zc); zc += k;);
             break;
         case CSLASH:;
             // no need to turn off pristinity in w, because we handle only DIRECT types here
@@ -1328,7 +1328,7 @@ jtcut2(J jt, A a, A w, A self) {
                       rc    = lrc < rc ? lrc : rc;
                   } else if (d == 1) { copyTT(zc, v1, wcn, zt, wt); } else {
                       if (!z0) {
-                          z0 = idenv0(a, w, FAV(self), zt, &z);  // compared to normal reduces, c means d and d means n
+                          z0 = jtidenv0(jt, a, w, FAV(self), zt, &z);  // compared to normal reduces, c means d and d means n
                           if (!z0) {
                               if (z)
                                   return z;
@@ -1345,7 +1345,7 @@ jtcut2(J jt, A a, A w, A self) {
                     if (FAV(self)->id != CCUT)
                         CUTFRETCOUNT(a) = m;  // if we are going to retry, we have to reset the # frets indicator which
                                               // has been destroyed
-                    return rc >= EWOV ? cut2(a, w, self) : 0;
+                    return rc >= EWOV ? jtcut2(jt, a, w, self) : 0;
                 } else
                     return adocv.cv & VRI + VRD ? jtcvz(jt, adocv.cv, zz) : zz;
                 break;
@@ -1426,7 +1426,7 @@ jtcut2(J jt, A a, A w, A self) {
 
 static A
 jtcut1(J jt, A w, A self) {
-    return cut2(mark, w, self);
+    return jtcut2(jt, mark, w, self);
 }
 
 // ;@((<@(f/\));._2 _1 1 2) when  f is atomic   also @: but only when no rank
@@ -1517,7 +1517,7 @@ jtrazecut2(J jt, A a, A w, A self) {
                   d, n, (I)1, wv + k * (b + wi - p), zv, jt);  // do the prefix, but not if items empty
             if (rc & 255) {
                 jtjsignal(jt, rc);
-                return rc >= EWOV ? razecut2(a, w, self) : 0;
+                return rc >= EWOV ? jtrazecut2(jt, a, w, self) : 0;
             }  // if overflow, restart the whole thing with conversion to float
             m += n;
             zv += n * zk;
@@ -1532,7 +1532,7 @@ jtrazecut2(J jt, A a, A w, A self) {
 
 A
 jtrazecut1(J jt, A w, A self) {
-    return razecut2(mark, w, self);
+    return jtrazecut2(jt, mark, w, self);
 }
 
 // if pv given, it is the place to put the shapes of the top 2 result axes.  If omitted, do them all and return an A
@@ -1619,7 +1619,7 @@ jttess2(J jt, A a, A w, A self) {
     I wt  = AT(w);                                // rank of w, type of w
     I *as = AS(a), *av = IAV(a), axisct = as[1];  // a-> shape of a, axisct=# axes in a, av->mv/size area
     // get shape of final result
-    tesos(a, w, n, rs);  // vert/horiz shape of 1st 2 axes of result, from argument sizes and cut type
+    jttesos(jt, a, w, n, rs);  // vert/horiz shape of 1st 2 axes of result, from argument sizes and cut type
     I nregcells;
     PROD(nregcells,
          axisct,
@@ -1629,11 +1629,11 @@ jttess2(J jt, A a, A w, A self) {
         // w is sparse, atomic, or empty, or the region has no axes or is empty, or the result is empty.  Go the slow
         // way: create a selector block for each cell, and then apply u;.0 to each cell trailing axes taken in full will
         // be omitted from the shape of the result
-        RZ(p = tesos(a, w, n, 0));  // recalculate all the result shapes
+        RZ(p = jttesos(jt, a, w, n, 0));  // recalculate all the result shapes
         A za, zw;
         RZ(za = jtcant1(jt, tymesW(jthead(jt, a), jtcant1(jt, jtabase2(jt, p, jtiota(jt, p))))));
         RZ(zw = jttail(jt, a));
-        return cut02(IRS2(za, zw, 0L, 1L, 1L, jtlamin2, z), w, self);  // ((|: ({.a) * |: (#: i.)p) ,:"1 ({:a)) u;.0 w
+        return jtcut02(jt, IRS2(za, zw, 0L, 1L, 1L, jtlamin2, z), w, self);  // ((|: ({.a) * |: (#: i.)p) ,:"1 ({:a)) u;.0 w
     }
     DECLF;                      // get the function pointers
     fauxblockINT(xfaux, 5, 1);  // declare xpose arg where it has scope
@@ -1912,7 +1912,7 @@ jttess2(J jt, A a, A w, A self) {
     // and we are deferring the transpose until the top level because n is negative
     if (!(((axisproc << 9) | (inrecursion & n)) & 512)) {
         A xposeaxes;  // axisproc=1, or bit 9 of n mismatches bit 8 (with n>0), is enough to turn off transpose
-        RZ(xposeaxes = apvwr(AR(zz), 0L, 1L));
+        RZ(xposeaxes = jtapvwr(jt, AR(zz), 0L, 1L));
         IAV(xposeaxes)[0] = 1;
         IAV(xposeaxes)[1] = 0;  // xpose arg, 1 0 2 3 4...
         RZ(zz = jtcant2(jt, xposeaxes, zz));
@@ -1932,7 +1932,7 @@ jttess1(J jt, A w, A self) {
     m = IMAX;
     DO(r, if (m > v[i]) m = v[i];);
     DO(r, v[i] = m;);  // Get length of long axis; set all axes to that length in a arg to cut
-    return tess2(s, w, self);
+    return jttess2(jt, s, w, self);
 }
 
 A

--- a/jsrc/conjunctions/cc.c
+++ b/jsrc/conjunctions/cc.c
@@ -1951,24 +1951,24 @@ jtcut(J jt, A a, A w) {
     switch (k) {
         case 0:
             if (FAV(a)->id == CBOX) {  // <;.0
-                RZ(z = fdef(0, CCUT, VERB, jtcut01, jtboxcut0, a, w, h, flag | VJTFLGOK2, RMAX, 2L, RMAX));
+                RZ(z = jtfdef(jt, 0, CCUT, VERB, jtcut01, jtboxcut0, a, w, h, flag | VJTFLGOK2, RMAX, 2L, RMAX));
                 FAV(z)->localuse.lpf.parm = ~0;
                 FAV(z)->localuse.lpf.func = jtcut02;  // store parms to specify start/len format
                 return z;
             }
-            z = fdef(0, CCUT, VERB, jtcut01, jtcut02, a, w, h, flag | VJTFLGOK2, RMAX, 2L, RMAX);
+            z = jtfdef(jt, 0, CCUT, VERB, jtcut01, jtcut02, a, w, h, flag | VJTFLGOK2, RMAX, 2L, RMAX);
             break;
         case 1:
         case -1:
         case 2:
         case -2:
             if (!(NOUN & AT(a))) flag = VJTFLGOK2 + VJTFLGOK1;
-            z = fdef(0, CCUT, VERB, jtcut1, jtcut2, a, w, h, flag, RMAX, 1L, RMAX);
+            z = jtfdef(jt, 0, CCUT, VERB, jtcut1, jtcut2, a, w, h, flag, RMAX, 1L, RMAX);
             break;
         case 3:
         case -3:
         case 259:
-        case -259: z = fdef(0, CCUT, VERB, jttess1, jttess2, a, w, h, flag, RMAX, 2L, RMAX); break;
+        case -259: z = jtfdef(jt, 0, CCUT, VERB, jttess1, jttess2, a, w, h, flag, RMAX, 2L, RMAX); break;
         default: ASSERT(0, EVDOMAIN);
     }
     RZ(z);

--- a/jsrc/conjunctions/cf.c
+++ b/jsrc/conjunctions/cf.c
@@ -304,7 +304,7 @@ jtfolk(J jt, A f, A g, A h) {
                 flag &= ~(VJTFLGOK1);
             }  // (N {~ N i, ])
         }
-        return fdef(0, CFORK, VERB, f1, jtnvv2, f, g, h, flag, RMAX, RMAX, RMAX);
+        return jtfdef(jt, 0, CFORK, VERB, f1, jtnvv2, f, g, h, flag, RMAX, RMAX, RMAX);
     }
     fv = FAV(f);
     fi = jtcap(jt, f) ? CCAP : fv->id;  // if f is a name defined as [:, detect that now & treat it as if capped fork
@@ -451,7 +451,7 @@ jtfolk(J jt, A f, A g, A h) {
     // If this fork is not a special form, set the flags to indicate whether the f verb does not use an
     // argument.  In that case h can inplace the unused argument.
     if (f1 == jtfolk1 && f2 == jtfolk2) flag |= atoplr(f);
-    return fdef(flag2, CFORK, VERB, f1, f2, f, g, h, flag, RMAX, RMAX, RMAX);
+    return jtfdef(jt, flag2, CFORK, VERB, f1, f2, f, g, h, flag, RMAX, RMAX, RMAX);
 }
 
 // Handlers for to  handle w (aa), w (vc), w (cv)
@@ -725,7 +725,7 @@ jthook(J jt, A a, A w) {
                 }
             // Return the derived verb
             A z;
-            RZ(z = fdef(0, CHOOK, VERB, f1, f2, a, w, 0L, flag, RMAX, RMAX, RMAX));
+            RZ(z = jtfdef(jt, 0, CHOOK, VERB, f1, f2, a, w, 0L, flag, RMAX, RMAX, RMAX));
             FAV(z)->localuse.lclr[0] = linktype;
             return z;  // if it's a form of ;, install the form
         // All other cases produce an adverb
@@ -742,5 +742,5 @@ jthook(J jt, A a, A w) {
             id = ID(a);
             if (BOX & AT(w) && (id == CGRAVE || id == CPOWOP && 1 < AN(w)) && jtgerexact(jt, w)) flag += VGERR;
     }
-    return fdef(0, CADVF, ADV, f1, 0L, a, w, 0L, flag, 0L, 0L, 0L);
+    return jtfdef(jt, 0, CADVF, ADV, f1, 0L, a, w, 0L, flag, 0L, 0L, 0L);
 }

--- a/jsrc/conjunctions/cf.c
+++ b/jsrc/conjunctions/cf.c
@@ -227,7 +227,7 @@ jtfolkcomp(J jt, A a, A w, A self) {
     PROLOG(0034);
     A z;
     AF f;
-    f = atcompf(a, w, self);
+    f = jtatcompf(jt, a, w, self);
     if (f) {
         I postflags = jt->workareas.compsc.postflags;
         z           = f(jt, a, w, self);
@@ -247,7 +247,7 @@ jtfolkcomp0(J jt, A a, A w, A self) {
     A z;
     AF f;
     PUSHCCT(1.0)
-    f = atcompf(a, w, self);
+    f = jtatcompf(jt, a, w, self);
     if (f) {
         I postflags = jt->workareas.compsc.postflags;
         z           = f(jt, a, w, self);
@@ -263,12 +263,12 @@ jtfolkcomp0(J jt, A a, A w, A self) {
 static A
 jtcharmapa(J jt, A w, A self) {
     V *v = FAV(self);
-    return charmap(w, FAV(v->fgh[2])->fgh[0], v->fgh[0]);
+    return jtcharmap(jt, w, FAV(v->fgh[2])->fgh[0], v->fgh[0]);
 }
 static A
 jtcharmapb(J jt, A w, A self) {
     V *v = FAV(self);
-    return charmap(w, FAV(v->fgh[0])->fgh[0], FAV(v->fgh[2])->fgh[0]);
+    return jtcharmap(jt, w, FAV(v->fgh[0])->fgh[0], FAV(v->fgh[2])->fgh[0]);
 }
 
 // Create the derived verb for a fork.  Insert in-placeable flags based on routine, and asgsafe based on fgh
@@ -551,7 +551,7 @@ jthkodom(J jt, A w, A self) {
         n = AN(w);
         v = AV(w);
         DO(n, if (b = 0 > v[i]) break;);
-        if (!b) return odom(2L, n, v);
+        if (!b) return jtodom(jt, 2L, n, v);
     }
     return CALL2(f2, w, CALL1(g1, w, gs), fs);
 } /* special code for (#: i.@(* /)) */

--- a/jsrc/conjunctions/cg.c
+++ b/jsrc/conjunctions/cg.c
@@ -199,10 +199,10 @@ jtevger(J jt, A a, A w) {
     if (k == GTRAIN) return jtexg(jt, a);
     RZ(hs = jtfxeachv(jt, RMAX, a));
     switch (k) {
-        case GAPPEND: return fdef(0, CGRCO, VERB, jtcon1, jtcon2, a, w, hs, VGERL, RMAX, RMAX, RMAX);
+        case GAPPEND: return jtfdef(jt, 0, CGRCO, VERB, jtcon1, jtcon2, a, w, hs, VGERL, RMAX, RMAX, RMAX);
         case GINSERT:
             ASSERT(1 >= AR(a), EVRANK);
-            return fdef(0, CGRCO, VERB, jtinsert, 0L, a, w, hs, VGERL, RMAX, 0L, 0L);
+            return jtfdef(jt, 0, CGRCO, VERB, jtinsert, 0L, a, w, hs, VGERL, RMAX, 0L, 0L);
         default: ASSERT(0, EVDOMAIN);
     }
 }
@@ -477,7 +477,7 @@ jtagendai(J jt, A a, A w) {
     flag    = VASGSAFE & FAV(w)->flag;
     A *avbv = AAV(avb);
     DQ(AN(avb), flag &= FAV(*avbv)->flag; ++avbv;);  // Don't increment inside FAV!
-    return fdef(0,
+    return jtfdef(jt, 0,
                 CATDOT,
                 VERB,
                 jtcasei12,
@@ -565,7 +565,7 @@ jtgconj(J jt, A a, A w, C id) {
     ASSERT((n & -2) == 2, EVLENGTH);  // length is 2 or 3
     ASSERT(BOX & AT(y), EVDOMAIN);
     RZ(hs = jtfxeach(jt, 3 == n ? y : link(jtscc(jt, CLBKTC), y), (A)&jtfxself[0]));
-    return fdef(
+    return jtfdef(jt, 
       0, id, VERB, na ? jtgcl1 : jtgcr1, na ? jtgcl2 : jtgcr2, a, w, hs, na ? VGERL : VGERR, RMAX, RMAX, RMAX);
 }
 
@@ -657,5 +657,5 @@ jtgadv(J jt, A w, C id) {
     ASSERT(AT(AAV(hs)[0]) & AT(AAV(hs)[1]) & AT(AAV(hs)[2]) & VERB, EVDOMAIN);
     I flag = (FAV(AAV(hs)[0])->flag & FAV(AAV(hs)[1])->flag & FAV(AAV(hs)[2])->flag & VASGSAFE) + (VGERL | VJTFLGOK2) +
              atoplr(AAV(hs)[0]);
-    return fdef(0, id, VERB, jtgav1, jtgav2, w, 0L, hs, flag, RMAX, RMAX, RMAX);  // create the derived verb
+    return jtfdef(jt, 0, id, VERB, jtgav1, jtgav2, w, 0L, hs, flag, RMAX, RMAX, RMAX);  // create the derived verb
 }

--- a/jsrc/conjunctions/cg.c
+++ b/jsrc/conjunctions/cg.c
@@ -416,7 +416,7 @@ jtcasei12(J jt, A a, A w, A self) {
                 // inhomogeneous types or shapes.  Instantiate the entire result and then shuffle it into place
                 // first, install the actual number of boxes of result, which might differ from the calculated maximum
                 AN(zz) = AS(zz)[0] = nblkscreated;                                    // # valid boxes
-                zz                 = ev2(gradepm, zz, "(/:~   >@:;@:((<\"_1)&.>))");  // (> ; <"_1&.> zz) /: gradepm
+                zz                 = jtev2(jt, gradepm, zz, "(/:~   >@:;@:((<\"_1)&.>))");  // (> ; <"_1&.> zz) /: gradepm
             }
             // If the original input had structure, rearrange the result to match it
             if (vr > 1) RZ(zz = jtreitem(jt, shape(jt, vres), zz));
@@ -428,7 +428,7 @@ jtcasei12(J jt, A a, A w, A self) {
             if (ZZFLAGWORD & ZZFLAGISDYAD) {
                 zz = rank2ex(a, w, z, ar, wr, ar, wr, FAV(z)->valencefns[1]);  // Execute on all cells
             } else {
-                zz = rank1ex(w, z, wr, FAV(z)->valencefns[0]);  // Execute on all cells8
+                zz = jtrank1ex(jt, w, z, wr, FAV(z)->valencefns[0]);  // Execute on all cells8
             }
         }
         EPILOG(zz);

--- a/jsrc/conjunctions/ch.c
+++ b/jsrc/conjunctions/ch.c
@@ -148,5 +148,5 @@ jthgeom(J jt, A a, A w) {
         ASSERT(1 >= AR(w), EVRANK);
     }
     RZ(h = jtcancel(jt, c, d));
-    return fdef(0, CHGEOM, VERB, jthgeom1, jthgeom2, a, w, h, 0L, 0L, 0L, 0L);
+    return jtfdef(jt, 0, CHGEOM, VERB, jthgeom1, jthgeom2, a, w, h, 0L, 0L, 0L, 0L);
 } /* a H. w */

--- a/jsrc/conjunctions/ch.c
+++ b/jsrc/conjunctions/ch.c
@@ -8,7 +8,7 @@
 static A
 jthparm(J jt, A j, A f, A h) {
     A z;
-    if (!(VERB & AT(f))) return jtshift1(jt, jtaslash(jt, CSTAR, atab(CPLUS, h, j)));
+    if (!(VERB & AT(f))) return jtshift1(jt, jtaslash(jt, CSTAR, jtatab(jt, CPLUS, h, j)));
     RZ(z = CALL1(FAV(f)->valencefns[0], j, f));
     ASSERT(1 >= AR(z), EVRANK);
     ASSERT(!AR(z) || AN(j) == AN(z), EVLENGTH);
@@ -22,9 +22,9 @@ jthgv(J jt, B b, I n, A w, A self) {
     RZ(j = IX(n));
     h  = sv->fgh[2];
     hv = AAV(h);
-    RZ(c = hparm(j, sv->fgh[0], hv[0]));
-    RZ(d = hparm(j, sv->fgh[1], hv[1]));
-    e = jtshift1(jt, divide(w, apv(n, 1L, 1L)));
+    RZ(c = jthparm(jt, j, sv->fgh[0], hv[0]));
+    RZ(d = jthparm(jt, j, sv->fgh[1], hv[1]));
+    e = jtshift1(jt, divide(w, jtapv(jt, n, 1L, 1L)));
     switch ((VERB & AT(sv->fgh[0]) ? 2 : 0) + (VERB & AT(sv->fgh[1]) ? 1 : 0)) {
         case 0: y = jtascan(jt, CSTAR, divide(tymes(c, e), d)); break;
         case 1: y = divide(jtascan(jt, CSTAR, tymes(c, e)), d); break;
@@ -67,7 +67,7 @@ jthgd(J jt, B b, I n, A w, A p, A q) {
         JBREAK0;
     }
     NAN1;
-    return !b ? jtscf(jt, s) : z ? jttake(jt, jtsc(jt, 1 + j), z) : hgd(b, j, w, p, q);
+    return !b ? jtscf(jt, s) : z ? jttake(jt, jtsc(jt, 1 + j), z) : jthgd(jt, b, j, w, p, q);
 } /* real vector p,q; real scalar w; all terms (1=b) or last term (0=b) */
 
 static A
@@ -77,7 +77,7 @@ jthgeom2(J jt, A a, A w, A self) {
     B b;
     I an, *av, j, n;
     V* sv = FAV(self);
-    if (AR(w)) return rank2ex0(a, w, self, jthgeom2);
+    if (AR(w)) return jtrank2ex0(jt, a, w, self, jthgeom2);
     RZ(a = AT(a) & FL + CMPX ? jtvib(jt, a) : jtvi(jt, a));  // kludge just call vib?
     an = AN(a);
     av = AV(a);
@@ -88,20 +88,20 @@ jthgeom2(J jt, A a, A w, A self) {
     hv = AAV(h);
     b  = VERB & (AT(sv->fgh[0]) | AT(sv->fgh[1])) || CMPX & (AT(w) | AT(hv[0]) | AT(hv[1]));
     if (!b)
-        z = hgd((B)(1 < an), n, w, hv[0], hv[1]);
+        z = jthgd(jt, (B)(1 < an), n, w, hv[0], hv[1]);
     else if (2000 > n)
-        z = hgv((B)(1 < an), n, w, self);
+        z = jthgv(jt, (B)(1 < an), n, w, self);
     else {
         j = 10;
         t = mtv;
         z = zeroionei(1);
         while (z && !jtequ(jt, z, t)) {
             t = z;
-            z = hgv(0, j, w, self);
+            z = jthgv(jt, 0, j, w, self);
             j += j;
         }
         RZ(z);
-        if (1 < an) z = hgv(1, j, w, self);
+        if (1 < an) z = jthgv(jt, 1, j, w, self);
     }
     if (1 < an) z = jtfrom(jt, minimum(a, jtsc(jt, SETIC(z, an) - 1)), z);
     EPILOG(z);
@@ -109,7 +109,7 @@ jthgeom2(J jt, A a, A w, A self) {
 
 static A
 jthgeom1(J jt, A w, A self) {
-    return hgeom2(jtsc(jt, IMAX), w, self);
+    return jthgeom2(jt, jtsc(jt, IMAX), w, self);
 }
 
 static A

--- a/jsrc/conjunctions/cip.c
+++ b/jsrc/conjunctions/cip.c
@@ -88,7 +88,7 @@ jtpdtby(J jt, A a, A w) {
     at = AT(a);
     wt = AT(w);
     t  = at & B01 ? wt : at;
-    RZ(z = ipprep(a, w, t, &m, &n, &p));
+    RZ(z = jtipprep(jt, a, w, t, &m, &n, &p));
     zk = n << bplg(t);
     u  = BAV(a);
     v = wv = BAV(w);
@@ -104,7 +104,7 @@ jtpdtby(J jt, A a, A w) {
         case INTX:
             if (at & B01) PDTBY(I, I, IINC) else PDTXB(I, I, IINC, c = *u++);
             if (er >= EWOV) {
-                RZ(z = ipprep(a, w, FL, &m, &n, &p));
+                RZ(z = jtipprep(jt, a, w, FL, &m, &n, &p));
                 zk = n * sizeof(D);
                 u  = BAV(a);
                 v = wv = BAV(w);
@@ -345,7 +345,7 @@ jtpdt(J jt, A a, A w) {
     m = t;
     m = t & INT ? FL : m;
     m = t & B01 ? INT : m;                // type of result, promoting bool and int
-    RZ(z = ipprep(a, w, m, &m, &n, &p));  // allocate the result area, with the needed shape and type
+    RZ(z = jtipprep(jt, a, w, m, &m, &n, &p));  // allocate the result area, with the needed shape and type
     if (AN(z) == 0) return z;             // return without computing if result is empty
     if (!p) {
         memset(AV(z), C0, AN(z) << bplg(AT(z)));
@@ -606,7 +606,7 @@ jtipbx(J jt, A a, A w, C c, C d) {
     B *av, *av0, b, *v0, *v1, *zv;
     C c0, c1;
     I ana, i, j, m, n, p, q, r, *uu, *vv, wc;
-    RZ(z = ipprep(a, w, B01, &m, &n, &p));
+    RZ(z = jtipprep(jt, a, w, B01, &m, &n, &p));
     // m=#1-cells of a, n=# bytes in 1-cell of w, p=length of individual inner product creating an atom
     ana = !!AR(a);
     wc  = AR(w) ? n : 0;
@@ -696,7 +696,7 @@ jtdotprod(J jt, A a, A w, A self) {
     if ((SGNIF(AT(a) & AT(w), B01X) & -AN(a) & -AN(w) & -(FAV(gs)->flag & VISATOMIC2)) < 0 &&
         CSLASH == ID(fs) &&  // fs is c/
         (c = FAV(FAV(fs)->fgh[0])->id, c == CSTARDOT || c == CPLUSDOT || c == CNE))
-        return ipbx(a, w, c, FAV(gs)->id);  // [+.*.~:]/ . boolean
+        return jtipbx(jt, a, w, c, FAV(gs)->id);  // [+.*.~:]/ . boolean
     r = lr(gs);                             // left rank of v
     A z;
     return df2(
@@ -709,7 +709,7 @@ jtdotprod(J jt, A a, A w, A self) {
 static A
 jtminors(J jt, A w) {
     A d, z;
-    RZ(d = apvwr(3L, -1L, 1L));
+    RZ(d = jtapvwr(jt, 3L, -1L, 1L));
     AV(d)[0] = 0;
     return jtdrop(jt, d, df2(z, num(1), w, jtbsdot(jt, ds(CLEFT))));  // 0 0 1 }. 1 [\. w
 }
@@ -734,7 +734,7 @@ jtdet(J jt, A w, A self) {
 A
 jtdetxm(J jt, A w, A self) {
     A z;
-    return dotprod(IRS1(w, 0L, 1L, jthead, z), jtdet(jt, jtminors(jt, w), self), self);
+    return jtdotprod(jt, IRS1(w, 0L, 1L, jthead, z), jtdet(jt, jtminors(jt, w), self), self);
 }
 /* determinant via expansion by minors. w is matrix with >1 columns */
 

--- a/jsrc/conjunctions/cip.c
+++ b/jsrc/conjunctions/cip.c
@@ -755,5 +755,5 @@ jtdot(J jt, A a, A w) {
                      jt, "[: -/\"1 {.\"2 * |.\"1@:({:\"2)"));  // -/ . * - calculate some function used by determinant?
         }
     }
-    return fdef(0, CDOT, VERB, jtdet, f2, a, w, h, 0L, 2L, RMAX, RMAX);
+    return jtfdef(jt, 0, CDOT, VERB, jtdet, f2, a, w, h, 0L, 2L, RMAX, RMAX);
 }

--- a/jsrc/conjunctions/cl.c
+++ b/jsrc/conjunctions/cl.c
@@ -32,7 +32,7 @@ jtlev2(J jt, A a, A w, A self) {
     if (aready & wready) {
         return CALL2(fsf, a, w, fs);
     } else {
-        STACKCHKOFL return every2(aready ? jtbox(jt, a) : a, wready ? jtbox(jt, w) : w, self);
+        STACKCHKOFL return jtevery2(jt, aready ? jtbox(jt, a) : a, wready ? jtbox(jt, w) : w, self);
     }  // since this recurs, check stack
        // We do this with the if statement rather than a computed branch in the hope that the CPU can detect patterns in
     // the conditions. There may be a structure in the user's data that could be detected for branch prediction.
@@ -58,7 +58,7 @@ jtlcapco1(J jt, A w, A self) {
     A recurself                   = (A)&shdr;                  // allocate the block we will recur with
     AM(recurself)                 = (I)v->fgh[0];              // fill in the pointer to u
     FAV(recurself)->valencefns[0] = jtlev1;                    // fill in function pointer
-    AT(recurself)                 = efflev(0L, v->fgh[2], w);  // fill in the trigger level
+    AT(recurself)                 = jtefflev(jt, 0L, v->fgh[2], w);  // fill in the trigger level
     FAV(recurself)->flag          = VFLAGNONE;                 // fill in the inplaceability flags
     return jtlev1(jt, w, recurself);
 }
@@ -71,10 +71,10 @@ jtlcapco2(J jt, A a, A w, A self) {
     A recurself                   = (A)&shdr;      // allocate the block we will recur with
     AM(recurself)                 = (I)v->fgh[0];  // fill in the pointer to u
     FAV(recurself)->valencefns[1] = jtlev2;        // fill in function pointer
-    AT(recurself)                 = efflev(1L, v->fgh[2], a);
-    AC(recurself)                 = efflev(2L, v->fgh[2], w);  // fill in the trigger levels
+    AT(recurself)                 = jtefflev(jt, 1L, v->fgh[2], a);
+    AC(recurself)                 = jtefflev(jt, 2L, v->fgh[2], w);  // fill in the trigger levels
     FAV(recurself)->flag          = VFLAGNONE;                 // fill in the inplaceability flags
-    return lev2(a, w, recurself);
+    return jtlev2(jt, a, w, recurself);
 }
 
 // Result logger for S:   w is the result; we add it to AK(self), reallocating as needed
@@ -117,7 +117,7 @@ jtlevs2(J jt, A a, A w, A self) {
     if (aready & wready) {
         RZ(jtscfn(jt, CALL2(fsf, a, w, fs), self));
     } else {
-        STACKCHKOFL RZ(every2(aready ? jtbox(jt, a) : a, wready ? jtbox(jt, w) : w, self));
+        STACKCHKOFL RZ(jtevery2(jt, aready ? jtbox(jt, a) : a, wready ? jtbox(jt, w) : w, self));
     }  // since this recurs, check stack
        // We do this with the if statement rather than a computed branch in the hope that the CPU can detect patterns in
     // the conditions. There may be a structure in the user's data that could be detected for branch prediction.
@@ -135,7 +135,7 @@ jtscapco1(J jt, A w, A self) {
     A recurself                   = (A)&shdr;                  // allocate the block we will recur with
     AM(recurself)                 = (I)v->fgh[0];              // fill in the pointer to u
     FAV(recurself)->valencefns[0] = jtlevs1;                   // fill in function pointer
-    AT(recurself)                 = efflev(0L, v->fgh[2], w);  // fill in the trigger level
+    AT(recurself)                 = jtefflev(jt, 0L, v->fgh[2], w);  // fill in the trigger level
     FAV(recurself)->flag          = VFLAGNONE;                 // fill in the inplaceability flags
     GAT0(x, INT, 54, 1);
     AKASA(recurself) = x;
@@ -169,8 +169,8 @@ jtscapco2(J jt, A a, A w, A self) {
     A recurself                   = (A)&shdr;      // allocate the block we will recur with
     AM(recurself)                 = (I)v->fgh[0];  // fill in the pointer to u
     FAV(recurself)->valencefns[1] = jtlevs2;       // fill in function pointer
-    AT(recurself)                 = efflev(1L, v->fgh[2], a);
-    AC(recurself)                 = efflev(2L, v->fgh[2], w);  // fill in the trigger levels
+    AT(recurself)                 = jtefflev(jt, 1L, v->fgh[2], a);
+    AC(recurself)                 = jtefflev(jt, 2L, v->fgh[2], w);  // fill in the trigger levels
     FAV(recurself)->flag          = VFLAGNONE;                 // fill in the inplaceability flags
     GAT0(x, INT, 54, 1);
     AKASA(recurself) = x;
@@ -183,7 +183,7 @@ jtscapco2(J jt, A a, A w, A self) {
     // to handle things is to ra() the first one too.  When we fa() at the end we may be freeing a different buffer, but
     // that's OK since all have been raised.
     ras(AKASA(recurself));
-    x = levs2(a, w, recurself);
+    x = jtlevs2(jt, a, w, recurself);
     if (x) {
         AT(AKASA(recurself)) = BOX;
         AN(AKASA(recurself)) = AS(AKASA(recurself))[0];
@@ -217,9 +217,9 @@ jtlsub(J jt, C id, A a, A w) {
 
 A
 jtlcapco(J jt, A a, A w) {
-    return lsub(CLCAPCO, a, w);
+    return jtlsub(jt, CLCAPCO, a, w);
 }
 A
 jtscapco(J jt, A a, A w) {
-    return lsub(CSCAPCO, a, w);
+    return jtlsub(jt, CSCAPCO, a, w);
 }

--- a/jsrc/conjunctions/cl.c
+++ b/jsrc/conjunctions/cl.c
@@ -211,7 +211,7 @@ jtlsub(J jt, C id, A a, A w) {
     hv[0] = v[2 == n];
     hv[1] = v[3 == n];
     hv[2] = v[n - 1];  // monad, left, right
-    return fdef(
+    return jtfdef(jt, 
       0, id, VERB, b ? jtlcapco1 : jtscapco1, b ? jtlcapco2 : jtscapco2, a, w, h, VFLAGNONE, RMAX, RMAX, RMAX);
 }
 

--- a/jsrc/conjunctions/cp.c
+++ b/jsrc/conjunctions/cp.c
@@ -513,9 +513,9 @@ jtpowop(J jt, A a, A w, A self) {
                 flag = (FAV(a)->flag & VASGSAFE) +
                        (h ? FAV(h)->flag & VJTFLGOK1
                           : VJTFLGOK1);  // inv1 inplaces and calculates ip for next step; invh has ip from inverse
-                return fdef(0, CPOWOP, VERB, (AF)(f1), jtinv2, a, w, h, flag, RMAX, RMAX, RMAX);
+                return jtfdef(jt, 0, CPOWOP, VERB, (AF)(f1), jtinv2, a, w, h, flag, RMAX, RMAX, RMAX);
             } else {  // u^:_
-                return fdef(0, CPOWOP, VERB, jtpinf12, jtpinf12, a, w, 0, VFLAGNONE, RMAX, RMAX, RMAX);
+                return jtfdef(jt, 0, CPOWOP, VERB, jtpinf12, jtpinf12, a, w, 0, VFLAGNONE, RMAX, RMAX, RMAX);
             }
         }
         if (IAV(hs)[0] >= 0) {
@@ -526,6 +526,6 @@ jtpowop(J jt, A a, A w, A self) {
     // If not special case, fall through to handle general case
     I m = AN(hs);              // m=#atoms of n; n=1st atom; r=n has rank>0
     ASSERT(m != 0, EVDOMAIN);  // empty power is error
-    return fdef(0, CPOWOP, VERB, f1, jtply2, a, w, hs, flag, RMAX, RMAX, RMAX);  // Create derived verb: pass in integer
+    return jtfdef(jt, 0, CPOWOP, VERB, f1, jtply2, a, w, hs, flag, RMAX, RMAX, RMAX);  // Create derived verb: pass in integer
                                                                                  // powers as h
 }

--- a/jsrc/conjunctions/cpdtsp.c
+++ b/jsrc/conjunctions/cpdtsp.c
@@ -250,17 +250,17 @@ jtpdtspmm(J jt, A a, A w) {
     D *axv, c, d, *dv, *wxv, *zyv;
     I *aiv, *aivm, i, ii, j, k, k0, m, n = 0, p, q, *v, wm, *wiv, *wnv, *zjv, *zjv0;
     P* zp;
-    RZ(mmprep(PAV(a), &m, &aiv, 0L, 0L, &axv));
+    RZ(jtmmprep(jt, PAV(a), &m, &aiv, 0L, 0L, &axv));
     aivm = m + aiv;
-    RZ(mmprep(PAV(w), &m, &wiv, &wm, &wnv, &wxv));
+    RZ(jtmmprep(jt, PAV(w), &m, &wiv, &wm, &wnv, &wxv));
     GATV0(zy, FL, AS(w)[1], 1);
     zyv = DAV(zy);
     memset(zyv, C0, AN(zy) * sizeof(D));
     old = jt->tnextpushp;
-    RZ(zj = exta(INT, 1L, 1L, 1000L));
+    RZ(zj = jtexta(jt, INT, 1L, 1L, 1000L));
     zjv0 = AV(zj);
-    RZ(zi = exta(INT, 2L, 2L, 1000L));
-    RZ(zx = exta(FL, 1L, 1L, 1000L));
+    RZ(zi = jtexta(jt, INT, 2L, 2L, 1000L));
+    RZ(zx = jtexta(jt, FL, 1L, 1L, 1000L));
     NAN0;
     if (wm && aiv < aivm) {
         i   = *aiv++;
@@ -301,8 +301,8 @@ jtpdtspmm(J jt, A a, A w) {
                     k = k0;
             }
             if (aiv >= aivm || i < (p = *aiv++)) { /* done with row i in a, emit row i in z */
-                RZ(mmharvest(i, zjv - zjv0, zj, zyv, &n, &zi, &zx));
-                gc3(&zj, &zi, &zx, old);  // these connot be virtual
+                RZ(jtmmharvest(jt, i, zjv - zjv0, zj, zyv, &n, &zi, &zx));
+                jtgc3(jt, &zj, &zi, &zx, old);  // these connot be virtual
                 zjv = zjv0;
                 k   = -1;
                 i   = p;
@@ -315,7 +315,7 @@ jtpdtspmm(J jt, A a, A w) {
     GASPARSE(z, SFL, 1, 2, AS(a));
     *(1 + AS(z)) = *(1 + AS(w));
     zp           = PAV(z);
-    SPB(zp, a, apvwr(2, 0L, 1L));
+    SPB(zp, a, jtapvwr(jt, 2, 0L, 1L));
     SPB(zp, e, jtscf(jt, 0.0));
     SPB(zp, i, zi);
     SPB(zp, x, zx);

--- a/jsrc/conjunctions/cr.c
+++ b/jsrc/conjunctions/cr.c
@@ -1174,7 +1174,7 @@ jtqq(J jt, A a, A w) {
     // Create the derived verb.  The derived verb (u"n) NEVER supports IRS; it inplaces if the action verb u supports
     // inplacing
     A z;
-    RZ(z = fdef(flag2, CQQ, VERB, f1, f2, a, w, ger, vf, r[0], r[1], r[2]));
+    RZ(z = jtfdef(jt, flag2, CQQ, VERB, f1, f2, a, w, ger, vf, r[0], r[1], r[2]));
     FAV(z)->localuse.lI4[0] = (I4)hv[0];
     FAV(z)->localuse.lI4[1] = (I4)hv[1];
     FAV(z)->localuse.lI4[2] = (I4)hv[2];  // pass the possibly-negative ranks in through localuse

--- a/jsrc/conjunctions/crs.c
+++ b/jsrc/conjunctions/crs.c
@@ -15,7 +15,7 @@ jtsprarg(J jt, I f, A x) {
     xp = PAV(x);
     if (SPARSE & AT(x)) {
         c = 1;
-        RZ(b = bfi(r, SPA(xp, a), 1));
+        RZ(b = jtbfi(jt, r, SPA(xp, a), 1));
         DO(
           f, if (!b[i]) {
               c = 0;
@@ -122,7 +122,7 @@ jtsprz(J jt, A z0, A y, A e, I f, I* s) {
     zp = PAV(z);
     SPB(zp, e, TYPESEQ(m, et) ? e : jtcvt(jt, m, e));
     if (d) {
-        SPB(zp, a, apvwr(f, 0L, 1L));
+        SPB(zp, a, jtapvwr(jt, f, 0L, 1L));
         SPB(zp, i, y);
         SPB(zp, x, TYPESEQ(m, t) ? z0 : jtcvt(jt, m, z0));
         return z;
@@ -184,8 +184,8 @@ jtsprank1(J jt, A w, A fs, I mr, AF f1) {
         c  = v[1];
         wv = AV(wy);
         RZ(wy1 = jtdropr(jt, wf, wy));
-        RZ(wb = spredge(wy, wf, &m));
-        RZ(ww = sprinit(wf, wcr, ws, wt, wp));
+        RZ(wb = jtspredge(jt, wy, wf, &m));
+        RZ(ww = jtsprinit(jt, wf, wcr, ws, wt, wp));
         wq = PAV(ww);
         RZ(ze = CALL1(f1, ww, fs));
         GATV0(z, BOX, m, 1);
@@ -199,7 +199,7 @@ jtsprank1(J jt, A w, A fs, I mr, AF f1) {
             k = 1 + (B*)memchr(wb + j, C1, n - j) - (wb + j);
             ICPY(iv, wv + j * c, wf);
             iv += wf;
-            RZ(q = apv(k, j, 1L));
+            RZ(q = jtapv(jt, k, j, 1L));
             SPB(wq, i, jtfrom(jt, q, wy1));
             SPB(wq, x, jtfrom(jt, q, wx));
             RZ(zv[i] = jtincorp(jt, CALL1(f1, ww, fs)));
@@ -208,10 +208,10 @@ jtsprank1(J jt, A w, A fs, I mr, AF f1) {
         RZ(z = jtope(jt, z));
     } else {
         RZ(zi = jtca(jt, wy));
-        RZ(z = rank1ex(wx, fs, mr, f1));
+        RZ(z = jtrank1ex(jt, wx, fs, mr, f1));
         RZ(ze = CALL1(f1, SPA(wp, e), fs));
     }  // mr is 0
-    z = sprz(z, zi, ze, wf, ws);
+    z = jtsprz(jt, z, zi, ze, wf, ws);
     EPILOG(z);
 } /* f"r w on sparse arrays */
 
@@ -224,7 +224,7 @@ jtspradv(J jt, I n, B* b, I f, I r, I j, P* p, A* z) {
     x = SPA(p, x);
     if (r) {
         q = PAV(*z);
-        RZ(s = apv(k, j, 1L));
+        RZ(s = jtapv(jt, k, j, 1L));
         SPB(q, i, jtfrom(jt, s, jtdropr(jt, f, SPA(p, i))));
         SPB(q, x, jtfrom(jt, s, x));
     } else
@@ -249,8 +249,8 @@ jtsprank2_0w(J jt, A a, A w, A fs, AF f2, I wf, I wcr) {
     wn = v[0];
     wc = v[1];
     wv = AV(y);
-    RZ(wb = spredge(y, wf, &wm));
-    RZ(ww = sprinit(wf, wcr, ws, wt, wp));
+    RZ(wb = jtspredge(jt, y, wf, &wm));
+    RZ(ww = jtsprinit(jt, wf, wcr, ws, wt, wp));
     RZ(we = wcr ? jtca(jt, ww) : SPA(wp, e));
     GATV0(z, BOX, MAX(1, wm), 1);
     zv = AAV(z);
@@ -259,7 +259,7 @@ jtsprank2_0w(J jt, A a, A w, A fs, AF f2, I wf, I wcr) {
     v    = AS(zi);
     v[0] = wm;
     v[1] = f;
-    RE(wj = wk = spradv(wn, wb, wf, wcr, 0L, wp, &ww));
+    RE(wj = wk = jtspradv(jt, wn, wb, wf, wcr, 0L, wp, &ww));
     j = 0;
     while (1) {
         ICPY(iv, wv, f);
@@ -267,12 +267,12 @@ jtsprank2_0w(J jt, A a, A w, A fs, AF f2, I wf, I wcr) {
         RZ(zv[j++] = jtincorp(jt, CALL2(f2, a, ww, fs)));
         if (wj == wn) break;
         wv += wk * wc;
-        RE(wk = spradv(wn, wb, wf, wcr, wj, wp, &ww));
+        RE(wk = jtspradv(jt, wn, wb, wf, wcr, wj, wp, &ww));
         wj += wk;
     }
     RZ(z = jtope(jt, z));
     AS(z)[0] = wm;  // we did one cell of aa to get the shape, but now we have to set back to correct # indexes
-    z        = sprz(z, zi, CALL2(f2, a, we, fs), f, ws);
+    z        = jtsprz(jt, z, zi, CALL2(f2, a, we, fs), f, ws);
     EPILOG(z);
 }
 
@@ -293,8 +293,8 @@ jtsprank2_a0(J jt, A a, A w, A fs, AF f2, I af, I acr) {
     an = v[0];
     ac = v[1];
     av = AV(y);
-    RZ(ab = spredge(y, af, &am));
-    RZ(aa = sprinit(af, acr, as, at, ap));
+    RZ(ab = jtspredge(jt, y, af, &am));
+    RZ(aa = jtsprinit(jt, af, acr, as, at, ap));
     RZ(ae = acr ? jtca(jt, aa) : SPA(ap, e));
     GATV0(z, BOX, MAX(1, am), 1);
     zv = AAV(z);
@@ -303,7 +303,7 @@ jtsprank2_a0(J jt, A a, A w, A fs, AF f2, I af, I acr) {
     v    = AS(zi);
     v[0] = am;
     v[1] = f;
-    RE(aj = ak = spradv(an, ab, af, acr, 0L, ap, &aa));
+    RE(aj = ak = jtspradv(jt, an, ab, af, acr, 0L, ap, &aa));
     j = 0;
     while (1) {
         ICPY(iv, av, f);
@@ -311,12 +311,12 @@ jtsprank2_a0(J jt, A a, A w, A fs, AF f2, I af, I acr) {
         RZ(zv[j++] = jtincorp(jt, CALL2(f2, aa, w, fs)));
         if (aj == an) break;
         av += ak * ac;
-        RE(ak = spradv(an, ab, af, acr, aj, ap, &aa));
+        RE(ak = jtspradv(jt, an, ab, af, acr, aj, ap, &aa));
         aj += ak;
     }
     RZ(z = jtope(jt, z));
     AS(z)[0] = am;  // we did one cell of aa to get the shape, but now we have to set back to correct # indexes
-    z        = sprz(z, zi, CALL2(f2, ae, w, fs), f, as);
+    z        = jtsprz(jt, z, zi, CALL2(f2, ae, w, fs), f, as);
     EPILOG(z);
 }
 
@@ -340,14 +340,14 @@ jtsprank2(J jt, A a, A w, A fs, I lr, I rr, AF f2) {
     if (!af && !wf) return CALL2(f2, a, w, fs);
     DO(af, ASSERT(as[i] != 0, EVNONCE););
     DO(wf, ASSERT(ws[i] != 0, EVNONCE););
-    if (!af) return sprank2_0w(a, w, fs, f2, wf, wcr);
-    if (!wf) return sprank2_a0(a, w, fs, f2, af, acr);
+    if (!af) return jtsprank2_0w(jt, a, w, fs, f2, wf, wcr);
+    if (!wf) return jtsprank2_a0(jt, a, w, fs, f2, af, acr);
     f = MIN(af, wf);
     g = MAX(af, wf);
     m = 1;
     if (f < g) {
         d = g - f;
-        RZ(y = odom(2L, d, f + (af < wf ? ws : as)));
+        RZ(y = jtodom(jt, 2L, d, f + (af < wf ? ws : as)));
         ii = AV(y);
         m  = *AS(y);
     }
@@ -363,16 +363,16 @@ jtsprank2(J jt, A a, A w, A fs, I lr, I rr, AF f2) {
     an = v[0];
     ac = v[1];
     av = an ? AV(y) : 0;
-    RZ(ab = spredge(y, af, &am));
+    RZ(ab = jtspredge(jt, y, af, &am));
     y  = SPA(wp, i);
     v  = AS(y);
     wn = v[0];
     wc = v[1];
     wv = wn ? AV(y) : 0;
-    RZ(wb = spredge(y, wf, &wm));
-    RZ(aa = sprinit(af, acr, as, at, ap));
+    RZ(wb = jtspredge(jt, y, wf, &wm));
+    RZ(aa = jtsprinit(jt, af, acr, as, at, ap));
     RZ(ae = acr ? jtca(jt, aa) : SPA(ap, e));
-    RZ(ww = sprinit(wf, wcr, ws, wt, wp));
+    RZ(ww = jtsprinit(jt, wf, wcr, ws, wt, wp));
     RZ(we = wcr ? jtca(jt, ww) : SPA(wp, e));
     b = af < wf;
     j = am * (af < wf ? m : 1) + wm * (af > wf ? m : 1);
@@ -383,8 +383,8 @@ jtsprank2(J jt, A a, A w, A fs, I lr, I rr, AF f2) {
     v[0] = j;
     v[1] = g;
     iv   = AV(zi);
-    RE(aj = ak = spradv(an, ab, af, acr, 0L, ap, &aa));
-    RE(wj = wk = spradv(wn, wb, wf, wcr, 0L, wp, &ww));
+    RE(aj = ak = jtspradv(jt, an, ab, af, acr, 0L, ap, &aa));
+    RE(wj = wk = jtspradv(jt, wn, wb, wf, wcr, 0L, wp, &ww));
     j = s = k = 0;
     u         = ii;
     y         = 0;
@@ -410,7 +410,7 @@ jtsprank2(J jt, A a, A w, A fs, I lr, I rr, AF f2) {
                     av = 0;
                 else {
                     av += ak * ac;
-                    RE(ak = spradv(an, ab, af, acr, aj, ap, &aa));
+                    RE(ak = jtspradv(jt, an, ab, af, acr, aj, ap, &aa));
                     aj += ak;
                 }
             }
@@ -419,7 +419,7 @@ jtsprank2(J jt, A a, A w, A fs, I lr, I rr, AF f2) {
                     wv = 0;
                 else {
                     wv += wk * wc;
-                    RE(wk = spradv(wn, wb, wf, wcr, wj, wp, &ww));
+                    RE(wk = jtspradv(jt, wn, wb, wf, wcr, wj, wp, &ww));
                     wj += wk;
                 }
             }
@@ -462,7 +462,7 @@ jtsprank2(J jt, A a, A w, A fs, I lr, I rr, AF f2) {
                 else {
                     v = wv;
                     wv += wk * wc;
-                    RE(wk = spradv(wn, wb, wf, wcr, wj, wp, &ww));
+                    RE(wk = jtspradv(jt, wn, wb, wf, wcr, wj, wp, &ww));
                     wj += wk;
                 }
             else if (!b && 0 >= s)
@@ -471,7 +471,7 @@ jtsprank2(J jt, A a, A w, A fs, I lr, I rr, AF f2) {
                 else {
                     v = av;
                     av += ak * ac;
-                    RE(ak = spradv(an, ab, af, acr, aj, ap, &aa));
+                    RE(ak = jtspradv(jt, an, ab, af, acr, aj, ap, &aa));
                     aj += ak;
                 }
             if (b && (!s && !wv || v && ICMP(v, wv, f)) || !b && (!s && !av || v && ICMP(v, av, f))) {
@@ -489,7 +489,7 @@ jtsprank2(J jt, A a, A w, A fs, I lr, I rr, AF f2) {
                     av = 0;
                 else {
                     av += ak * ac;
-                    RE(ak = spradv(an, ab, af, acr, aj, ap, &aa));
+                    RE(ak = jtspradv(jt, an, ab, af, acr, aj, ap, &aa));
                     aj += ak;
                 }
             else if (!b && 0 <= s && (!v || ICMP(v, av, f)))
@@ -497,12 +497,12 @@ jtsprank2(J jt, A a, A w, A fs, I lr, I rr, AF f2) {
                     wv = 0;
                 else {
                     wv += wk * wc;
-                    RE(wk = spradv(wn, wb, wf, wcr, wj, wp, &ww));
+                    RE(wk = jtspradv(jt, wn, wb, wf, wcr, wj, wp, &ww));
                     wj += wk;
                 }
         }
     AN(z) = *AS(z) = *AS(zi) = j;
     AN(zi)                   = j * g;
-    z                        = sprz(jtope(jt, z), zi, CALL2(f2, ae, we, fs), g, g == af ? as : ws);
+    z                        = jtsprz(jt, jtope(jt, z), zi, CALL2(f2, ae, we, fs), g, g == af ? as : ws);
     EPILOG(z);
 } /* a f"r w on sparse arrays */

--- a/jsrc/conjunctions/cu.c
+++ b/jsrc/conjunctions/cu.c
@@ -451,7 +451,7 @@ jtunderai1(J jt, A w, A self) {
     GATV(z, LIT, n, AR(w), AS(w));
     zv = UAV(z);
     wv = UAV(w);
-    if (!bitwisecharamp(f, n, wv, zv)) DQ(n, *zv++ = f[*wv++];);
+    if (!jtbitwisecharamp(jt, f, n, wv, zv)) DQ(n, *zv++ = f[*wv++];);
     return z;
 } /* f&.(a.&i.) w */
 

--- a/jsrc/conjunctions/cu.c
+++ b/jsrc/conjunctions/cu.c
@@ -485,7 +485,7 @@ jtunder(J jt, A a, A w) {
     switch (v->id &
             gside) {  // never special if gerund - this could evaluate to 0 or 1, neither of which is one of these codes
         case COPE:
-            return fdef(VF2WILLOPEN1 | VF2WILLOPEN2A | VF2WILLOPEN2W,
+            return jtfdef(jt, VF2WILLOPEN1 | VF2WILLOPEN2A | VF2WILLOPEN2W,
                         CUNDER,
                         VERB,
                         jteveryself,
@@ -570,7 +570,7 @@ jtunder(J jt, A a, A w) {
         flag2 |= VF2RANKATOP2;
         flag &= FAV(h)->flag | (~VJTFLGOK2);
     }  // allow inplace if v is known inplaceable
-    RZ(h = fdef(flag2, CUNDER, VERB, (AF)(f1), (AF)(f2), a, w, h, (flag), rmr, rlr, rrr));
+    RZ(h = jtfdef(jt, flag2, CUNDER, VERB, (AF)(f1), (AF)(f2), a, w, h, (flag), rmr, rlr, rrr));
     // install wvb into the verb so we can get to it if needed
     FAV(h)->localuse.lvp[0] = wvb;
     return h;
@@ -616,7 +616,7 @@ jtundco(J jt, A a, A w) {
     if (!f1) f1 = flag & VFUNDERHASINV ? jtunderh1 : jtundco1;
     f2 = flag & VFUNDERHASINV ? jtunderh2 : jtundco2;
     flag |= (FAV(a)->flag & FAV(wvb)->flag & VASGSAFE) + (FAV(h)->flag & (VJTFLGOK1 | VJTFLGOK2));
-    RZ(h = fdef(0, CUNDCO, VERB, (AF)(f1), (AF)(f2), a, w, h, flag, RMAX, RMAX, RMAX));
+    RZ(h = jtfdef(jt, 0, CUNDCO, VERB, (AF)(f1), (AF)(f2), a, w, h, flag, RMAX, RMAX, RMAX));
     // install wvb into the verb so we can get to it if needed
     FAV(h)->localuse.lvp[0] = wvb;
     return h;

--- a/jsrc/conjunctions/cv.c
+++ b/jsrc/conjunctions/cv.c
@@ -162,13 +162,13 @@ jtfit(J jt, A a, A w) {
         case CXCO:
         case CSLDOT:
         case CSPARSE:
-        case CEBAR: return fitct(a, w, cno);
+        case CEBAR: return jtfitct(jt, a, w, cno);
         case CEXP: ASSERT(AT(w) & NUMERIC, EVDOMAIN); return CDERIV(CFIT, 0L, jtfitexp2, 0L, m, l, r);
         case CPOLY:
             ASSERT(AT(w) & NUMERIC, EVDOMAIN);
             return CDERIV(CFIT, 0L, jtfitpoly2, 0L, m, l, r);  // CPOLY has no VIRS
         case CPOWOP:                                           // support for #^:_1!.n
-            if (sv->fgh[1] != num(-1)) return fitct(a, w, 0);
+            if (sv->fgh[1] != num(-1)) return jtfitct(jt, a, w, 0);
             f = sv->fgh[0];
             c = ID(f);
             if (c == CPOUND) {

--- a/jsrc/conjunctions/cv.c
+++ b/jsrc/conjunctions/cv.c
@@ -40,7 +40,7 @@ jtfitct(J jt, A a, A w, I cno) {
         d = DAV(w)[0];
     }  // 0 is usual; otherwise it better be FL, but convert in case its value is 0
     ASSERT(0 <= d && d < 5.82076609134675e-11, EVDOMAIN);  // can't be greater than 2^_34
-    A fn = fdef(0,
+    A fn = jtfdef(jt, 0,
                 CFIT,
                 VERB,
                 (AF)(jtfitct1),

--- a/jsrc/conjunctions/cx.c
+++ b/jsrc/conjunctions/cx.c
@@ -913,7 +913,7 @@ xadv(J jt, A w, A self) {
 A
 jtxop2(J jt, A a, A w, A self) {
     A ff, x;
-    RZ(ff = fdef(0,
+    RZ(ff = jtfdef(jt, 0,
                  CCOLON,
                  VERB,
                  xn1,
@@ -1337,7 +1337,7 @@ jtcolon(J jt, A a, A w) {
             a = FAV(a)->fgh[0];  // look for v : v; don't fail if fgh[0]==0 (namerefop).  Must test fgh[0] first
         if (CCOLON == FAV(w)->id && FAV(w)->fgh[0] && VERB & AT(FAV(w)->fgh[0]) && VERB & AT(FAV(w)->fgh[1]))
             w = FAV(w)->fgh[1];
-        return fdef(0,
+        return jtfdef(jt, 0,
                     CCOLON,
                     VERB,
                     xv1,
@@ -1484,11 +1484,11 @@ jtcolon(J jt, A a, A w) {
     }
     switch (n) {
         case 3:
-            return fdef(0, CCOLON, VERB, xn1, jtxdefn, num(n), 0L, h, flag | VJTFLGOK1 | VJTFLGOK2, RMAX, RMAX, RMAX);
-        case 1: return fdef(0, CCOLON, ADV, b ? xop1 : xadv, 0L, num(n), 0L, h, flag, RMAX, RMAX, RMAX);
-        case 2: return fdef(0, CCOLON, CONJ, 0L, b ? jtxop2 : jtxdefn, num(n), 0L, h, flag, RMAX, RMAX, RMAX);
+            return jtfdef(jt, 0, CCOLON, VERB, xn1, jtxdefn, num(n), 0L, h, flag | VJTFLGOK1 | VJTFLGOK2, RMAX, RMAX, RMAX);
+        case 1: return jtfdef(jt, 0, CCOLON, ADV, b ? xop1 : xadv, 0L, num(n), 0L, h, flag, RMAX, RMAX, RMAX);
+        case 2: return jtfdef(jt, 0, CCOLON, CONJ, 0L, b ? jtxop2 : jtxdefn, num(n), 0L, h, flag, RMAX, RMAX, RMAX);
         case 4:
-            return fdef(0, CCOLON, VERB, xn1, jtxdefn, num(n), 0L, h, flag | VJTFLGOK1 | VJTFLGOK2, RMAX, RMAX, RMAX);
+            return jtfdef(jt, 0, CCOLON, VERB, xn1, jtxdefn, num(n), 0L, h, flag | VJTFLGOK1 | VJTFLGOK2, RMAX, RMAX, RMAX);
         case 13: return jtvtrans(jt, w);
         default: ASSERT(0, EVDOMAIN);
     }

--- a/jsrc/conjunctions/cx.c
+++ b/jsrc/conjunctions/cx.c
@@ -66,7 +66,7 @@
                 z = jtparsea(jt, queue, m);                               \
             else {                                                        \
                 thisframe->dclnk->dcix = i;                               \
-                z                      = parsex(queue, m, ci, callframe); \
+                z                      = jtparsex(jt, queue, m, ci, callframe); \
             }                                                             \
         } else {                                                          \
             jtjsignal(jt, EVATTN);                                        \
@@ -161,7 +161,7 @@ trypopgoto(TD *tdv, I tdi, I dest) {
 #define CHECKNOUN                                                                                                     \
     if (!(NOUN & AT(t))) { /* error, T block not creating noun */                                                     \
         /* Signal post-exec error*/                                                                                   \
-        t = pee(line, &cw[ti], EVNONNOUN, gsfctdl << (BW - 2), callframe);                                            \
+        t = jtpee(jt, line, &cw[ti], EVNONNOUN, gsfctdl << (BW - 2), callframe);                                            \
         /* go to error loc; if we are in a try., send this error to the catch.  z may be unprotected, so clear it, to \
          * 0 if error shows, mtm otherwise */                                                                         \
         i = cw[ti].go;                                                                                                \
@@ -362,12 +362,12 @@ jtxdefn(J jt, A a, A w, A self) {
         // Do the other assignments, which occur less frequently, with symbis
         if ((I)u | (I)v) {
             if (u) {
-                (symbis(mnuvxynam[2], u, locsym));
-                if (NOUN & AT(u)) symbis(mnuvxynam[0], u, locsym);
+                (jtsymbis(jt, mnuvxynam[2], u, locsym));
+                if (NOUN & AT(u)) jtsymbis(jt, mnuvxynam[0], u, locsym);
             }  // assign u, and m if u is a noun
             if (v) {
-                (symbis(mnuvxynam[3], v, locsym));
-                if (NOUN & AT(v)) symbis(mnuvxynam[1], v, locsym);
+                (jtsymbis(jt, mnuvxynam[3], v, locsym));
+                if (NOUN & AT(v)) jtsymbis(jt, mnuvxynam[1], v, locsym);
             }  // bug errors here must be detected
         }
     }
@@ -405,7 +405,7 @@ jtxdefn(J jt, A a, A w, A self) {
                 if (d && jt->recurstate <
                            RECSTATEPROMPT) {  // if there is a call and thus we can suspend; and not prompting already
                     BZ(thisframe =
-                         deba(DCPARSE,
+                         jtdeba(jt, DCPARSE,
                               0L,
                               0L,
                               0L));  // if deba fails it will be before it modifies sitop.  Remember our stack frame
@@ -419,7 +419,7 @@ jtxdefn(J jt, A a, A w, A self) {
 
             // if performance monitor is on, collect data for it
             if (PMCTRBPMON & jt->uflags.us.uq.uq_c.pmctrbstk && C1 == jt->pmrec && FAV(self)->flag & VNAMED)
-                pmrecord(jt->curname, jt->global ? LOCNAME(jt->global) : 0, i, isdyad ? VAL2 : VAL1);
+                jtpmrecord(jt, jt->curname, jt->global ? LOCNAME(jt->global) : 0, i, isdyad ? VAL2 : VAL1);
             // If the executing verb was reloaded during debug, switch over to the modified definition
             if ((gsfctdl & 16) && jt->redefined) {
                 DC siparent;
@@ -467,7 +467,7 @@ jtxdefn(J jt, A a, A w, A self) {
                 // Check for assert.  Since this is only for T-blocks we tolerate the test (rather than duplicating
                 // code)
                 if (ci->type == CASSERT && jt->assert &&t && !(NOUN & AT(t) && all1(eq(num(1), t))))
-                    t = pee(line,
+                    t = jtpee(jt, line,
                             ci,
                             EVASSERT,
                             gsfctdl << (BW - 2),
@@ -613,7 +613,7 @@ jtxdefn(J jt, A a, A w, A self) {
             case CTRY:
                 // try.  create a try-stack entry, step to next line
                 BASSERT(tdi < NTD, EVLIMIT);
-                tryinit(tdv + tdi, i, cw);
+                jttryinit(jt, tdv + tdi, i, cw);
                 // turn off debugging UNLESS there is a catchd; then turn on only if user set debug mode
                 // if debugging is already off, it stays off
                 if (jt->uflags.us.cx.cx_c.db)
@@ -682,11 +682,11 @@ jtxdefn(J jt, A a, A w, A self) {
                           z = jtrat(
                             jt,
                             z));  // if z might be the result, protect it over the possible frees during this assignment
-                    symbisdel(
+                    jtsymbisdel(jt, 
                       jtnfs(jt, 6 + cv->k, cv->xv),
                       x = jtsc(jt, cv->j),
                       locsym);  // Assign iteration number.  since there is no sentence, take deletion off nvr stack
-                    symbisdel(jtnfs(jt, cv->k, cv->iv), cv->j < cv->n ? jtfrom(jt, x, cv->t) : mtv, locsym);
+                    jtsymbisdel(jt, jtnfs(jt, cv->k, cv->iv), cv->j < cv->n ? jtfrom(jt, x, cv->t) : mtv, locsym);
                 }
                 if (cv->j < cv->n) {  // if there are more iterations to do...
                     ++i;
@@ -823,7 +823,7 @@ jtxdefn(J jt, A a, A w, A self) {
             // only the first locative in eqch branch
             z = jtfix(jt, z, jtsc(jt, FIXALOCSONLY | FIXALOCSONLYLOWEST));
         } else {
-            pee(line, &cw[bi], EVNONNOUN, gsfctdl << (BW - 2), callframe);
+            jtpee(jt, line, &cw[bi], EVNONNOUN, gsfctdl << (BW - 2), callframe);
             z = 0;
         }  // signal error, set z to 'no result'
     } else {
@@ -899,11 +899,11 @@ xv2(J jt, A a, A w, A self) {
 }
 static A
 xn1(J jt, A w, A self) {
-    return xdefn(0L, w, self);
+    return jtxdefn(jt, 0L, w, self);
 }  // Transfer monadic xdef to the common code - inplaceable
 static A
 xadv(J jt, A w, A self) {
-    return xdefn(w, 0L, self);
+    return jtxdefn(jt, w, 0L, self);
 }  // inplaceable
 
 // This handles adverbs/conjs that refer to x/y.  Install a[/w] into the derived verb as f/h, and copy the flags
@@ -929,7 +929,7 @@ jtxop2(J jt, A a, A w, A self) {
 }
 static A
 xop1(J jt, A w, A self) {
-    return xop2(w, 0, self);
+    return jtxop2(jt, w, 0, self);
 }
 
 // w is a box containing enqueued words for the sentences of a definition, jammed together
@@ -986,10 +986,10 @@ jtcolon0(J jt, I deftype) {
     I isboxed = BETWEENC(deftype, 1, 9);  // do we return boxes?
     // Allocate the return area, which we extend as needed
     if (isboxed) {
-        RZ(z = exta(BOX, 1L, 1L, 20L));
+        RZ(z = jtexta(jt, BOX, 1L, 1L, 20L));
         sb = AAV(z);
     } else {
-        RZ(z = exta(LIT, 1L, 1L, 300L));
+        RZ(z = jtexta(jt, LIT, 1L, 1L, 300L));
         s = CAV(z);
     }
     while (1) {
@@ -1152,7 +1152,7 @@ jtcrelocalsyms(J jt, A l, A c, I type, I dyad, I flags) {
     C *s;
     I j, ln;
     // Allocate a pro-forma symbol table to hash the names into
-    RZ(pfst = stcreate(2, 40, 0L, 0L));
+    RZ(pfst = jtstcreate(jt, 2, 40, 0L, 0L));
     // Do a probe-for-assignment for every name that is locally assigned in this definition.  This will
     // create a symbol-table entry for each such name
     // Start with the argument names.  We always assign y, and x EXCEPT when there is a monadic guaranteed-verb
@@ -1244,7 +1244,7 @@ jtcrelocalsyms(J jt, A l, A c, I type, I dyad, I flags) {
     }
 
     asgct = asgct + (asgct >> 1);            // leave 33% empty space, since we will have resolved most names here
-    RZ(actst = stcreate(2, asgct, 0L, 0L));  // Allocate the symbol table we will use
+    RZ(actst = jtstcreate(jt, 2, asgct, 0L, 0L));  // Allocate the symbol table we will use
     *(UI4 *)LXAV0(actst) =
       (UI4)((SYMHASH(NAV(mnuvxynam[4])->hash, AN(actst) - SYMLINFOSIZE) << 16) +
             SYMHASH(NAV(mnuvxynam[5])->hash,
@@ -1297,7 +1297,7 @@ jtclonelocalsyms(J jt, A a) {
     I j;
     I an   = AN(a);
     LX *av = LXAV0(a), *zv;
-    RZ(z = stcreate(2, AN(a), 0L, 0L));
+    RZ(z = jtstcreate(jt, 2, AN(a), 0L, 0L));
     zv = LXAV0(z);  // allocate the clone; zv->clone hashchains
     // Copy the first hashchain, which has the x/v hashes
     zv[0] = av[0];  // Copy as Lx; really it's a UI4
@@ -1428,10 +1428,10 @@ jtcolon(J jt, A a, A w) {
         GAT0(h, BOX, 2 * HN, 1);
         hv = AAV(h);
         if (n) {  // if not noun, audit the valences as valid sentences and convert to a queue to send into jtparse(jt,)
-            RE(b = preparse(m, hv, hv + 1));
+            RE(b = jtpreparse(jt, m, hv, hv + 1));
             if (b) flag |= VTRY1;
             hv[2] = jt->retcomm ? m : mtv;
-            RE(b = preparse(d, hv + HN, hv + HN + 1));
+            RE(b = jtpreparse(jt, d, hv + HN, hv + HN + 1));
             if (b) flag |= VTRY2;
             hv[2 + HN] = jt->retcomm ? d : mtv;
         }
@@ -1477,10 +1477,10 @@ jtcolon(J jt, A a, A w) {
     // free the components of the explicit def, we'd better do it now, so that the usecounts are all identical
     if (4 >= n) {
         // Don't bother to create a symbol table for an empty definition, since it is a domain error
-        if (AN(hv[1])) RZ(hv[3] = jtincorp(jt, crelocalsyms(hv[0], hv[1], n, 0, flag)));  // wordss,cws,type,monad,flag
+        if (AN(hv[1])) RZ(hv[3] = jtincorp(jt, jtcrelocalsyms(jt, hv[0], hv[1], n, 0, flag)));  // wordss,cws,type,monad,flag
         if (AN(hv[HN + 1]))
             RZ(hv[HN + 3] =
-                 jtincorp(jt, crelocalsyms(hv[HN + 0], hv[HN + 1], n, 1, flag)));  // words,cws,type,dyad,flag
+                 jtincorp(jt, jtcrelocalsyms(jt, hv[HN + 0], hv[HN + 1], n, 1, flag)));  // words,cws,type,dyad,flag
     }
     switch (n) {
         case 3:
@@ -1495,7 +1495,7 @@ jtcolon(J jt, A a, A w) {
 }
 
 // input reader for direct definition
-// This is a drop-in for jttokens(jt,).  It takes a string and env, and returns tokens created by enqueue().  Can
+// This is a drop-in for jttokens(jt,).  It takes a string and env, and returns tokens created by jtenqueue(jt, ).  Can
 // optionally return string
 //
 // Any DDs found are collected and converted into ( m : string ).  This is done recursively.  If an unterminated
@@ -1532,7 +1532,7 @@ jtddtokens(J jt, A w, I env) {
         if (ch2 == DDBGN && (wilv[firstddbgnx][1] - wilv[firstddbgnx][0] == 2)) break;
     }
     if (firstddbgnx >= nw) {
-        ASSERT(AM(wil) >= 0, EVOPENQ) return env & 8 ? w : enqueue(wil, w, env & 3);
+        ASSERT(AM(wil) >= 0, EVOPENQ) return env & 8 ? w : jtenqueue(jt, wil, w, env & 3);
     }  //   If no DD chars found, and caller wants a string, return w fast
     // loop till all DDs found
     while (firstddbgnx < nw) {
@@ -1665,7 +1665,7 @@ jtddtokens(J jt, A w, I env) {
             RZ(remnant =
                  jtstr(jt, AN(w) - enddelimx - 2, CAV(w) + enddelimx + 2));  // get a string for the preserved tail of w
             AS(wil)[0] = ddbgnx;
-            RZ(w = unwordil(wil, w, 0));  // take everything up to the {{)n - it may have been put out of order
+            RZ(w = jtunwordil(jt, wil, w, 0));  // take everything up to the {{)n - it may have been put out of order
             A spacea;
             RZ(spacea = jtscc(jt, ' '));
             RZ(w = apip(w, spacea));                                             // put space before quoted string
@@ -1712,7 +1712,7 @@ jtddtokens(J jt, A w, I env) {
                     wilv[ddendx][1] = bodystart;
                     AN(wil)         = 2 * (AS(wil)[0] = ddendx + 1);
                 }  // make one string of DDEND to end of string
-                RZ(w = unwordil(wil, w, 0));
+                RZ(w = jtunwordil(jt, wil, w, 0));
                 RZ(wil = jtwordil(jt, w));  // run chars in order; get index to words
                 wv   = CAV(w);
                 nw   = AS(wil)[0];
@@ -1740,7 +1740,7 @@ jtddtokens(J jt, A w, I env) {
         AN(wil)            = 2 * (AS(wil)[0] = ddschbgnx + 1);
     }  // make one word of the last part
 
-    w = unwordil(wil, w, 0);                       // the word list is where everything is.  Collect to string
+    w = jtunwordil(jt, wil, w, 0);                       // the word list is where everything is.  Collect to string
     if (!(env & 8)) w = jttokens(jt, w, env & 3);  // enqueue if called for
     EPILOG(w);
 }

--- a/jsrc/debugging/d.c
+++ b/jsrc/debugging/d.c
@@ -40,7 +40,7 @@ jteputl(J jt, A w) {
 static void
 jteputv(J jt, A w) {
     I m = NETX - jt->etxn;
-    if (m > 0) { jt->etxn += thv(w, MIN(m, 200), jt->etx + jt->etxn); }
+    if (m > 0) { jt->etxn += jtthv(jt, w, MIN(m, 200), jt->etx + jt->etxn); }
 }  // stop writing when there is no room in the buffer
    /* numeric vector w */
 
@@ -129,15 +129,15 @@ jtdisp(J jt, A w, I nflag) {
             }
             // If this is an array of names, turn it back into a character string with spaces between
             else {
-                w = jtcurtail(jt, jtraze(jt, every2(jtevery(jt, w, (A)&sfn0overself), chrspace, (A)&sfn0overself)));
+                w = jtcurtail(jt, jtraze(jt, jtevery2(jt, jtevery(jt, w, (A)&sfn0overself), chrspace, (A)&sfn0overself)));
             }  // }: (string&.> names) ,&.> ' '  then fall through to display it
         case LITX: jteputq(jt, w, nflag); break;
         case NAMEX: jtep(jt, AN(w), NAV(w)->s); break;
         case LPARX: jteputc(jt, '('); break;
         case RPARX: jteputc(jt, ')'); break;
-        case ASGNX: dspell(CAV(w)[0], w, nflag); break;
+        case ASGNX: jtdspell(jt, CAV(w)[0], w, nflag); break;
         case MARKX: break;
-        default: dspell(FAV(w)->id, w, nflag); break;
+        default: jtdspell(jt, FAV(w)->id, w, nflag); break;
     }
     return b;  // new nflag
 }
@@ -299,7 +299,7 @@ jtjsigstr(J jt, I e, I n, C* s) {
 
 static void
 jtjsig(J jt, I e, A x) {
-    jsigstr(e, AN(x), CAV(x));
+    jtjsigstr(jt, e, AN(x), CAV(x));
 }
 /* signal error e with error text x */
 
@@ -312,7 +312,7 @@ jtjsigd(J jt, C* s) {
     n = strlen(s);
     p = MIN(n, 100 - m);
     memcpy(buf + m, s, p);
-    jsigstr(EVDOMAIN, m + p, buf);
+    jtjsigstr(jt, EVDOMAIN, m + p, buf);
 }
 
 void
@@ -326,7 +326,7 @@ jtjsignal(J jt, I e) {
     // Errors > NEVM are internal-only errors that should never make it to the end of execution.
     // Ignore them here - they will not be displayed
     x = BETWEENC(e, 1, NEVM) ? AAV(jt->evm)[e] : mtv;
-    jsigstr(e, AN(x), CAV(x));
+    jtjsigstr(jt, e, AN(x), CAV(x));
 }
 
 void

--- a/jsrc/debugging/dc.c
+++ b/jsrc/debugging/dc.c
@@ -67,7 +67,7 @@ jtdbcall(J jt, A w) {
     zv   = AAV(z);
     while (si) {
         if (DCCALL == si->dctype) {
-            RZ(drow(si, s0, zv));
+            RZ(jtdrow(jt, si, s0, zv));
             zv += c;
         }
         s0 = si;

--- a/jsrc/debugging/dss.c
+++ b/jsrc/debugging/dss.c
@@ -69,32 +69,32 @@ jtssdo(J jt, A a, A w, C c) {
 
 A
 jtdbcutback(J jt, A w) {
-    return ssdo(0L, w, SSCUTBACK);
+    return jtssdo(jt, 0L, w, SSCUTBACK);
 } /* 13!:19 */
 
 A
 jtdbstepover1(J jt, A w) {
-    return ssdo(0L, w, SSSTEPOVER);
+    return jtssdo(jt, 0L, w, SSSTEPOVER);
 } /* 13!:20 */
 A
 jtdbstepover2(J jt, A a, A w) {
-    return ssdo(a, w, SSSTEPOVER);
+    return jtssdo(jt, a, w, SSSTEPOVER);
 }
 
 A
 jtdbstepinto1(J jt, A w) {
-    return ssdo(0L, w, SSSTEPINTO);
+    return jtssdo(jt, 0L, w, SSSTEPINTO);
 } /* 13!:21 */
 A
 jtdbstepinto2(J jt, A a, A w) {
-    return ssdo(a, w, SSSTEPINTO);
+    return jtssdo(jt, a, w, SSSTEPINTO);
 }
 
 A
 jtdbstepout1(J jt, A w) {
-    return ssdo(0L, w, SSSTEPOUT);
+    return jtssdo(jt, 0L, w, SSSTEPOUT);
 } /* 13!:22 */
 A
 jtdbstepout2(J jt, A a, A w) {
-    return ssdo(a, w, SSSTEPOUT);
+    return jtssdo(jt, a, w, SSSTEPOUT);
 }

--- a/jsrc/debugging/dsusp.c
+++ b/jsrc/debugging/dsusp.c
@@ -27,10 +27,10 @@ moveparseinfotosi(J jt) {
       jt, jt->parserstackframe.parserqueue, jt->parserstackframe.parserqueuelen, jt->parserstackframe.parsercurrtok);
 }
 
-/* deba() and jtdebz(jt) must be coded and executed in pairs */
+/* jtdeba(jt, ) and jtdebz(jt) must be coded and executed in pairs */
 /* in particular, do NOT do error exits between them     */
 /* e.g. the following is a NO NO:                        */
-/*    d=deba(...);                                       */
+/*    d=jtdeba(jt, ...);                                       */
 /*    ASSERT(blah,EVDOMAIN);                             */
 /*    jtdebz(jt)                                             */
 
@@ -133,7 +133,7 @@ jtsusp(J jt) {
     // top-of-stack if it holds error information.  So, we create an empty frame to take the store from immex.  This
     // frame has no display.
     jt->dbsusact = SUSCLEAR;             // if we can't add a frame, exit suspension
-    if (!deba(DCJUNK, 0, 0, 0)) return;  // create spacer frame
+    if (!jtdeba(jt, DCJUNK, 0, 0, 0)) return;  // create spacer frame
     jt->dbsusact  = SUSCONT;
     A *old        = jt->tnextpushp;  // fence must be after we have allocated out stack block
     d             = jt->dcs;
@@ -279,13 +279,13 @@ jtdbunquote(J jt, A a, A w, A self, L *stabent) {
     V *sv;
     sv = FAV(self);
     t  = sv->fgh[0];
-    RZ(d = deba(DCCALL, a, w, self));
+    RZ(d = jtdeba(jt, DCCALL, a, w, self));
     d->dcn = (I)stabent;
     if (CCOLON == sv->id &&
         (sv->flag & VXOP ||
          t && NOUN & AT(t))) {  // : and executable body: either OP (adv/conj now with noun operands) or m : n
         ras(self);
-        z = a ? dfs2(a, w, self) : jtdfs1(jt, w, self);
+        z = a ? jtdfs2(jt, a, w, self) : jtdfs1(jt, w, self);
         fa(self);
     } else {          /* tacit    */
         d->dcix = 0;  // set a pseudo-line-number for display purposes for the tacit
@@ -297,7 +297,7 @@ jtdbunquote(J jt, A a, A w, A self, L *stabent) {
             }  // if this line is a stop
             else {
                 ras(self);
-                z = a ? dfs2(a, w, self) : jtdfs1(jt, w, self);
+                z = a ? jtdfs2(jt, a, w, self) : jtdfs1(jt, w, self);
                 fa(self);
             }
             // If we hit a stop, or if we hit an error outside of try./catch., enter debug mode.  But if debug mode is

--- a/jsrc/format/f.c
+++ b/jsrc/format/f.c
@@ -204,7 +204,7 @@ jtthn(J jt, A w) {
     GATV0(t, LIT, wd * (1 + n), 1);
     tv = CAV(t);
     if (1 >= r) {
-        p = thv(w, AN(t), tv);
+        p = jtthv(jt, w, AN(t), tv);
         ASSERTSYS(p, "thn");
         AN(t) = AS(t)[0] = p;
         z                = t;
@@ -214,7 +214,7 @@ jtthn(J jt, A w) {
         k = bpnoun(AT(w));
         y = tv - wd;
         x = CAV(w) - k;
-        RZ(d = apvwr(c, 1L, 0L));
+        RZ(d = jtapvwr(jt, c, 1L, 0L));
         dv = AV(d);
         DO(m, DO(c, fmt(jt, y += wd, x += k); p = strlen(y); dv[i] = MAX(dv[i], p);););
         --dv[c - 1];
@@ -276,7 +276,7 @@ jtthsb(J jt, A w, A prxthornuni) {
     q     = jt->sbun;
     if (1 >= r) {
         c = n;
-        RZ(d = apvwr(c, 0L, 0L));
+        RZ(d = jtapvwr(jt, c, 0L, 0L));
         dv = AV(d);
         p  = 2 * n - 1;
         DO(c, p += dv[i] = sbtou8size(jt, SBUV(*x++), 0););
@@ -292,15 +292,15 @@ jtthsb(J jt, A w, A prxthornuni) {
             C *zv1;  // jprx flag, set when result going to display
             c = s[r - 1];
             m = n / c;
-            RZ(d = apvwr(c, 0L, 0L));
+            RZ(d = jtapvwr(jt, c, 0L, 0L));
             dv = AV(d);  // col max byte
-            RZ(dw = apvwr(c, 0L, 0L));
+            RZ(dw = jtapvwr(jt, c, 0L, 0L));
             dwv = AV(dw);  // col max display width
-            RZ(dd = apvwr(c, 0L, 0L));
+            RZ(dd = jtapvwr(jt, c, 0L, 0L));
             ddv = AV(dd);  // col max element byte - display width
-            RZ(e = apvwr(n, 0L, 0L));
+            RZ(e = jtapvwr(jt, n, 0L, 0L));
             ev = AV(e);  // element byte
-            RZ(ew = apvwr(n, 0L, 0L));
+            RZ(ew = jtapvwr(jt, n, 0L, 0L));
             ewv = AV(ew);  // element display width
             j   = 0;
             DO(m,
@@ -338,7 +338,7 @@ jtthsb(J jt, A w, A prxthornuni) {
         } else {
             c = s[r - 1];
             m = n / c;
-            RZ(d = apvwr(c, 0L, 0L));
+            RZ(d = jtapvwr(jt, c, 0L, 0L));
             dv = AV(d);
             DO(m, DO(c, p = sbtou8size(jt, SBUV(*x++), 0); dv[i] = MAX(dv[i], p);););
             p = -1;
@@ -416,7 +416,7 @@ jtthxqe(J jt, A w) {
     m = n / c;
     GATV0(t, BOX, n, 1);
     tv = AAV(t);
-    RZ(d = apvwr(c, 1L, 0L));
+    RZ(d = jtapvwr(jt, c, 1L, 0L));
     dv = AV(d);
     v  = tv;
     switch (CTTZ(AT(w))) {
@@ -457,11 +457,11 @@ jtrc(J jt, A w, A *px, A *py, I *t) {
     v = AAV(w);
     // xn = #rows in 2-cell of joined table, x=vector of (xn+1) 0s, xv->data for vector
     SHAPEN(w, r - 2, xn);
-    RZ(*px = x = apvwr(xn, 0L, 0L));
+    RZ(*px = x = jtapvwr(jt, xn, 0L, 0L));
     xv = AV(x);
     // yn = #rows in 2-cell of joined table, y=vector of (yn+1) 0s, v->data for vector
     SHAPEN(w, r - 1, yn);
-    RZ(*py = y = apvwr(yn, 0L, 0L));
+    RZ(*py = y = jtapvwr(jt, yn, 0L, 0L));
     yv = AV(y);
     // for each atom of w, include height/width in the appropriate row/column cells, and take maximum of types
     DQ(
@@ -549,18 +549,18 @@ jtfminit(J jt, I m, I ht, I wd, A x, A y, C *zv, I cw) {
     // First, install the characters for cells containing data.  We start in the first
     // row of the result, even though this can never keep these characters.
     // Then we propagate this row through all rows except the last.
-    fram(9L, yn, yv, zv, cw);
+    jtfram(jt, 9L, yn, yv, zv, cw);
     u = zv;
     DQ(ht - 2, memcpy(u += wd, zv, wd););
     // Fill in the first interior divider row, whose row index is the height of the first row
     // Then copy this row over all the other interior-divider rows, xn-1 times, which
     //  finishes by writing over the bottom row of the result
-    fram(3L, yn, yv, u = v = zv + wd * *xv, cw);
+    jtfram(jt, 3L, yn, yv, u = v = zv + wd * *xv, cw);
     DO(xn - 1, memcpy(u += wd * xv[1 + i], v, wd););
     // Install the first row, overwriting the data row first put there
-    fram(0L, yn, yv, zv, cw);
+    jtfram(jt, 0L, yn, yv, zv, cw);
     // Install the last row, overwriting the interior-divider row first copied there
-    fram(6L, yn, yv, zv + p - wd, cw);
+    jtfram(jt, 6L, yn, yv, zv + p - wd, cw);
     // First 2-cell is complete.  Copy it over all the others
     u = zv;
     DQ(m - 1, memcpy(u += p, zv, p););
@@ -656,7 +656,7 @@ jtenframe(J jt, A w) {
     // Find the positions of the cell boundaries within each 2-cell of the
     // result. x and y are lists, where x[i] and y[j] give the height/width of cell
     // (i,j) of the result 2-cell. This height/width includes the boxing char
-    RE(rc(w, &x, &y, &t));
+    RE(jtrc(jt, w, &x, &y, &t));
     n  = AN(w);
     wr = MAX(2, AR(w));  // n=#atoms of w, wr=rank of result (2 >. rank of w)
     // Calculate height of result as 1 + sum of row heights.  The 1 is for the final boxing character.
@@ -684,9 +684,9 @@ jtenframe(J jt, A w) {
     zv  = CAV(z);                // zv->result area
     wdb = wd * (t = bpnoun(t));  // Replace t with the length of a character of t; get length of line in bytes
     // Install the boxing characters in each 2-cell of the result
-    fminit(m, ht, wdb, x, y, zv, t);
+    jtfminit(jt, m, ht, wdb, x, y, zv, t);
     // Insert the data for each atom into the result
-    fmfill(p, q, wdb, w, x, y, zv, t);
+    jtfmfill(jt, p, q, wdb, w, x, y, zv, t);
     return z;
 }
 
@@ -734,7 +734,7 @@ jtmat(J jt, A w) {
     x        = CAV(z);
     // If the result has gaps, fill the entire result area with fills
     // (this could be better: just copy the gap, as part of ENGAP; check k above in case of leading unit axes)
-    if (2 < r) fillv(t, zn, x);
+    if (2 < r) jtfillv(jt, t, zn, x);
     // for each 2-cell, leave a gap if required, then copy in the 2-cell.  Change c to size in bytes; qc=size of 2-cell
     if (zn) {
         c <<= bplg(t);
@@ -759,7 +759,7 @@ static EVERYFS(matth1self, 0, jtmatth1, 0, VFLAGNONE)
     // Format the contents of each box; form into a table.  every returns an array of boxes,
     // with the same shape as w, where the contents have been replaced by a table of characters
     // Then call enframe to assemble all the tables into the result table
-    RZ(z = jtenframe(jt, every2(w, prxthornuni, (A)&matth1self)));
+    RZ(z = jtenframe(jt, jtevery2(jt, w, prxthornuni, (A)&matth1self)));
     // Go through each byte of the result, replacing ASCII codes 0, 8, 9, 10, and 13
     // (NUL, BS, TAB, LF, CR) with space
     // Three versions of replacement, depending on datatype of the array
@@ -904,7 +904,7 @@ jtthorn1main(J jt, A w, A prxthornuni) {
 
 // entry point to allow C2T result from thorn1.  But always pass byte arguments unchanged
 // This will enable null insertion/removal for CJK, but that's OK since the result goes to display
-// This is called only from jprx()
+// This is called only from jtjprx(jt, )
 A
 jtthorn1u(J jt, A w) {
     A z;
@@ -1382,7 +1382,7 @@ jtoutstr(J jt, A a, A w) {
     ASSERT(0 <= v[1], EVDOMAIN);
     ASSERT(0 <= v[2], EVDOMAIN);
     ASSERT(0 <= v[3], EVDOMAIN);
-    return jprx(v[0], v[1], v[2], v[3], w);
+    return jtjprx(jt, v[0], v[1], v[2], v[3], w);
 }
 
 // w is a noun.  Convert it to a UTF-8 string and write it to the console
@@ -1391,7 +1391,7 @@ jtjpr1(J jt, A w) {
     PROLOG(0002);
     A z;
     // convert the character array to a null-terminated UTF-8 string
-    RZ(z = jprx(jt->outeol, jt->outmaxlen, jt->outmaxbefore, jt->outmaxafter, w));
+    RZ(z = jtjprx(jt, jt->outeol, jt->outmaxlen, jt->outmaxbefore, jt->outmaxafter, w));
     // write string to stdout, calling it a 'formatted array' unless otherwise overridden
     if (AN(z)) {
         ASSERTSYS(!CAV(z)[AN(z)], "jtjpr1 trailing null byte");

--- a/jsrc/format/f2.c
+++ b/jsrc/format/f2.c
@@ -160,7 +160,7 @@ jtfmtx(J jt, B e, I m, I d, C *s, I t, X *wv) {
     q = c > 999 ? 4 : c > 99 ? 3 : c > 9 ? 2 : 1;
     p = q + XBASEN * (n - 1);
     if (e)
-        return fmtex(m, d, n, xv, b, c, q, p - 1);
+        return jtfmtex(jt, m, d, n, xv, b, c, q, p - 1);
     else if (m && m < b + p + d + !!d) {
         memset(v, '*', m);
         v[m] = 0;
@@ -209,16 +209,16 @@ jtfmtq(J jt, B e, I m, I d, C *s, I t, Q *wv) {
     if (e && c && 0 > jtxcompare(jt, x, y.d)) {
         ex = XBASEN * (AN(y.n) - AN(y.d));
         g  = jtxtymes(jt, x, jtxpow(jt, jtxc(jt, 10L), jtxc(jt, 1 + d - ex)));
-        RZ(x = xdiv(g, y.d, XMFLR));
+        RZ(x = jtxdiv(jt, g, y.d, XMFLR));
         while (1 == jtxcompare(jt, a, x)) {
             --ex;
             g = jtxtymes(jt, jtxc(jt, 10L), g);
-            RZ(x = xdiv(g, y.d, XMFLR));
+            RZ(x = jtxdiv(jt, g, y.d, XMFLR));
         }
         if (b) x = jtnegate(jt, x);
     } else
-        x = xdiv(jtxtymes(jt, y.n, a), y.d, XMFLR);
-    RZ(x = xdiv(jtxplus(jt, x, jtxc(jt, 5L)), jtxc(jt, 10L), XMFLR));
+        x = jtxdiv(jt, jtxtymes(jt, y.n, a), y.d, XMFLR);
+    RZ(x = jtxdiv(jt, jtxplus(jt, x, jtxc(jt, 5L)), jtxc(jt, 10L), XMFLR));
     n  = AN(x);
     xv = AV(x) + n - 1;
     c  = *xv;
@@ -228,7 +228,7 @@ jtfmtq(J jt, B e, I m, I d, C *s, I t, Q *wv) {
     p = q + XBASEN * (n - 1);
     if (c || !e) ex += p - d - 1;
     if (e)
-        return fmtex(m, d, n, xv, b, c, q, ex);
+        return jtfmtex(jt, m, d, n, xv, b, c, q, ex);
     else if (m && m < b + d + (I) !!d + (0 > ex ? 1 : 1 + ex)) {
         memset(v, '*', m);
         v[m] = 0;
@@ -285,8 +285,8 @@ jtfmt1(J jt, B e, I m, I d, C *s, I t, C *wv) {
             }
             sprintf(jt->th2buf, s, (D) * (I *)wv);
             break;
-        case XNUMX: fmtx(e, m, d, s, t, (X *)wv); break;
-        case RATX: fmtq(e, m, d, s, t, (Q *)wv); break;
+        case XNUMX: jtfmtx(jt, e, m, d, s, t, (X *)wv); break;
+        case RATX: jtfmtq(jt, e, m, d, s, t, (Q *)wv); break;
         default:
             y = *(D *)wv;
             y = y ? y : 0.0; /* -0 to 0 */
@@ -307,7 +307,7 @@ jtfmt1(J jt, B e, I m, I d, C *s, I t, C *wv) {
 // No result: the output area is filled
 static void
 jtth2c(J jt, B e, I m, I d, C *s, I n, I t, I wk, C *wv, I zk, C *zv) {
-    DQ(n, fmt1(e, m, d, s, t, wv); c2j(e, m, zv); zv += zk; wv += wk;);
+    DQ(n, jtfmt1(jt, e, m, d, s, t, wv); jtc2j(jt, e, m, zv); zv += zk; wv += wk;);
 } /* format a column */
 
 // Create a column of results (a table) for a single field
@@ -338,7 +338,7 @@ jtth2a(J jt, B e, I m, I d, C *s, I n, I t, I wk, C *wv, B first) {
     zv       = CAV(z);
     // If field length is fixed, format the column to that width & return it
     if (m) {
-        th2c(e, m, d, s, n, t, wk, wv, m, zv);
+        jtth2c(jt, e, m, d, s, n, t, wk, wv, m, zv);
         return z;
     }
     // Otherwise, field has variable width.  Format the values one by one.
@@ -346,7 +346,7 @@ jtth2a(J jt, B e, I m, I d, C *s, I n, I t, I wk, C *wv, B first) {
     // b will be set for exponential fields only, if no result is negative
     b = e;  // init no negative exponential values (if field is exponential).  0 if nonexponential field
     for (i = q = 0; i < n; ++i) {
-        fmt1(e, m0, d, s, t, wv);  // Create the (null-terminated) string in th2buf.  m0=0
+        jtfmt1(jt, e, m0, d, s, t, wv);  // Create the (null-terminated) string in th2buf.  m0=0
         while (p < q + (I)strlen(jt->th2buf) + 1) {
             RZ(z = jtover(jt, z, z));
             p += p;
@@ -355,7 +355,7 @@ jtth2a(J jt, B e, I m, I d, C *s, I n, I t, I wk, C *wv, B first) {
         // u->place to put string; convert th2buf to j form in *u; k=length of string; update string pointer &
         // null-terminate string; advance to next input value
         u       = q + zv;
-        q += k  = c2j(e, 0L, u);
+        q += k  = jtc2j(jt, e, 0L, u);
         zv[q++] = 0;
         wv += wk;
         // Exponential-field sign spacing:
@@ -518,7 +518,7 @@ jtthorn2(J jt, A a, A w) {
     wk = c * k;
     wv = CAV(w) - k;
     // Analyze a to get info for each format
-    RZ(th2ctrl(a, &ea, &ma, &da, &s, &zk));
+    RZ(jtth2ctrl(jt, a, &ea, &ma, &da, &s, &zk));
     // ev->expformat flags, mv->field width, dv->decimal places, sk=length of each sprintf string, sv->sprintf string
     // (prebiased)
     ev = BAV(ea);
@@ -541,7 +541,7 @@ jtthorn2(J jt, A a, A w) {
               e = ev[i];
               m = mv[i];
               d = dv[i];
-          } th2c(e, m, d, sv += sk, n, t, wk, wv += k, zk, zv);
+          } jtth2c(jt, e, m, d, sv += sk, n, t, wk, wv += k, zk, zv);
           zv += m;);  // Set e,m,d (if atomic a, keep the same values each time
     } else {
         // The width is unknown.  Build up the result one field at a time.  Each field becomes a box in this
@@ -554,14 +554,14 @@ jtthorn2(J jt, A a, A w) {
               e = ev[i];
               m = mv[i];
               d = dv[i];
-          } RZ(yv[i] = th2a(e, m, d, sv += sk, n, t, wk, wv += k, (B)!i)););
+          } RZ(yv[i] = jtth2a(jt, e, m, d, sv += sk, n, t, wk, wv += k, (B)!i)););
         // Join the fields of each line to produce an nxc table of characters, one row per 1-cell of w
         RZ(z = jtrazeh(jt, y));
         // If w has rank > 2, we need to rearrange the rows into an array.  Or, if there is a single 1-cell and
         // r was an atom or a list, we need to change the result from a table to a single list.
         if (2 < r || 1 == n && 2 != r) {
             if (!r) r = 1;  // change atomic r to a list
-            RZ(h = vec(INT, r, ws));
+            RZ(h = jtvec(jt, INT, r, ws));
             AV(h)
             [r - 1] = AS(
               z)[1];  // Create a vector out of the shape of w; replace length of 1-cell with length of a row of result

--- a/jsrc/i.c
+++ b/jsrc/i.c
@@ -215,10 +215,10 @@ jtconsinit(J jt) {
                 // Init for u./v.
     A uimp = jtca(jt, mnuvxynam[2]);
     NAV(uimp)->flag |= NMIMPLOC;                                                        // create the name for u.
-    jt->implocref[0] = fdef(0, CTILDE, VERB, 0, 0, uimp, 0L, 0L, 0, RMAX, RMAX, RMAX);  // create 'u.'~
+    jt->implocref[0] = jtfdef(jt, 0, CTILDE, VERB, 0, 0, uimp, 0L, 0L, 0, RMAX, RMAX, RMAX);  // create 'u.'~
     A vimp           = jtca(jt, mnuvxynam[3]);
     NAV(vimp)->flag |= NMIMPLOC;
-    jt->implocref[1] = fdef(0, CTILDE, VERB, 0, 0, vimp, 0L, 0L, 0, RMAX, RMAX, RMAX);  // create 'v.'~
+    jt->implocref[1] = jtfdef(jt, 0, CTILDE, VERB, 0, 0, vimp, 0L, 0L, 0, RMAX, RMAX, RMAX);  // create 'v.'~
 
     return 1;
 }

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -360,7 +360,7 @@
         D stackpos;                                             \
         ASSERT((uintptr_t)&stackpos >= jt->cstackmin, EVSTACK); \
     }
-#define FCONS(x) fdef(0, CFCONS, VERB, jtnum1, jtnum2, 0L, 0L, (x), VFLAGNONE, RMAX, RMAX, RMAX)
+#define FCONS(x) jtfdef(jt, 0, CFCONS, VERB, jtnum1, jtnum2, 0L, 0L, (x), VFLAGNONE, RMAX, RMAX, RMAX)
 // fuzzy-equal is used for tolerant comparisons not related to jt->cct; for example testing whether x in x { y is an
 // integer
 #define FUZZ 0.000000000000056843418860808015  // tolerance

--- a/jsrc/j.h
+++ b/jsrc/j.h
@@ -119,7 +119,7 @@
 #define IOTAVECBEGIN (-20)
 #define IOTAVECLEN 400
 
-// modes for indexofsub()
+// modes for jtindexofsub(jt, )
 #define IIOPMSK 0xf  // operation bits
 #define IIDOT 0      // IIDOT and IICO must be 0-1
 #define IICO 1
@@ -377,14 +377,14 @@
     {                                                \
         if (m < AR(w))                               \
             if (m == 0)                              \
-                return rank1ex0(w, (A)self, f);      \
+                return jtrank1ex0(jt, w, (A)self, f);      \
             else                                     \
-                return rank1ex(w, (A)self, (I)m, f); \
+                return jtrank1ex(jt, w, (A)self, (I)m, f); \
     }  // if there is more than one cell, run rank1ex on them.  m=monad rank, f=function to call for monad cell.  Fall
        // through otherwise
 #define F2RANKcommon(l, r, f, self, extra)                                                                 \
     {                                                                                                      \
-        extra if ((I)((l - AR(a)) | (r - AR(w))) < 0) if ((l | r) == 0) return rank2ex0(a, w, (A)self, f); \
+        extra if ((I)((l - AR(a)) | (r - AR(w))) < 0) if ((l | r) == 0) return jtrank2ex0(jt, a, w, (A)self, f); \
         else {                                                                                             \
             I lr = MIN((I)l, AR(a));                                                                       \
             I rr = MIN((I)r, AR(w));                                                                       \
@@ -488,10 +488,10 @@
             *_d = 1;                             \
         } while (++_r < 0);                      \
     }  // copy all 1s to shape
-#define GA(v, t, n, r, s) RZ(v = ga(t, (I)(n), (I)(r), (I *)(s)))
+#define GA(v, t, n, r, s) RZ(v = jtga(jt, t, (I)(n), (I)(r), (I *)(s)))
 // GAE executes the given expression when there is an error
 #define GAE(v, t, n, r, s, erraction) \
-    if (!(v = ga(t, (I)(n), (I)(r), (I *)(s)))) erraction;
+    if (!(v = jtga(jt, t, (I)(n), (I)(r), (I *)(s)))) erraction;
 
 // When the type and all rank/shape are known at compile time, use GAT.  The compiler precalculates
 // almost everything For best results declare name as: AD* RESTRICT name;  The number of bytes,
@@ -693,7 +693,7 @@
 #define Jmemcpy(d, s, l, lbl, bytelen) memcpy(d, s, bytelen ? (l) : (l) & -SZI);
 #define JMCR(d, s, l, lbl, bytelen, maskname) memcpy(d, s, bytelen ? (l) : (l) & -SZI);
 
-#define IX(n) apv((n), 0L, 1L)
+#define IX(n) jtapv(jt, (n), 0L, 1L)
 #define JATTN                      \
     {                              \
         if (*jt->adbreakr != 0) {  \
@@ -898,7 +898,7 @@
 #define EPILOGNOVIRT(z) \
     return (jtgc(jt, z, _ttop))  // use this when the repercussions of allowing virtual result are too severe
 #define EPILOGZOMB(z)                        \
-    if (!gc3(&(z), 0L, 0L, _ttop)) return 0; \
+    if (!jtgc3(jt, &(z), 0L, 0L, _ttop)) return 0; \
     return z;  // z is the result block.  Use this if z may contain inplaceable contents that would free prematurely
 // Routines that do little except call a function that does PROLOG/EPILOG have EPILOGNULL as a placeholder
 // Routines that do not return A

--- a/jsrc/ja.h
+++ b/jsrc/ja.h
@@ -36,7 +36,7 @@
 #define bfi(x, y, z) jtbfi(jt, (x), (y), (z))
 #define bitwisecharamp(x0, x1, x2, x3) jtbitwisecharamp(jt, (x0), (x1), (x2), (x3))
 #define boxW(x) jtbox((J)((I)jt | JTINPLACEW), (x))
-#define box0(x) irs1((x), 0L, 0, jtbox)
+#define box0(x) jtirs1(jt, (x), 0L, 0, jtbox)
 #define brep(x, y, z) jtbrep(jt, (x), (y), (z))
 #define brephdr(x0, x1, x2, x3) jtbrephdr(jt, (x0), (x1), (x2), (x3))
 #define breps(x, y, z) jtbreps(jt, (x), (y), (z))

--- a/jsrc/ja.h
+++ b/jsrc/ja.h
@@ -6,9 +6,6 @@
 #define apip(x, y) \
     jtapip((J)((I)jt | JTINPLACEA), (x), (y))  // use apip instead of over when a is an inplaceable context
 
-#define assembleresults(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) \
-    jtassembleresults(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9), (x10))
-
 #define beheadW(x) jtbehead((J)((I)jt | JTINPLACEW), (x))
 #define boxW(x) jtbox((J)((I)jt | JTINPLACEW), (x))
 #define box0(x) jtirs1(jt, (x), 0L, 0, jtbox)
@@ -120,9 +117,6 @@
         }                                                                                                 \
     }
 
-#define fdef(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) \
-    jtfdef(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9), (x10), (x11))
-
 #define floor1(x) jtatomic1(jt, (x), ds(CFLOOR))
 
 #define fr(x)                    \
@@ -140,15 +134,6 @@
 #define fx(x) jtfx(jt, (x), 0L)
 #define gcd(x, y) jtatomic2(jt, (x), (y), ds(CPLUSDOT))
 #define ge(x, y) jtatomic2(jt, (x), (y), ds(CGE))
-
-#define grd1spdd(x, y, z) jtgrd1spdd(jt, (x), (y), (z))
-#define grd1spds(x, y, z) jtgrd1spds(jt, (x), (y), (z))
-#define grd1spsd(x, y, z) jtgrd1spsd(jt, (x), (y), (z))
-#define grd1spss(x, y, z) jtgrd1spss(jt, (x), (y), (z))
-#define grd1spz(x, y, z) jtgrd1spz(jt, (x), (y), (z))
-#define grd2spsd(x, y, z) jtgrd2spsd(jt, (x), (y), (z))
-#define grd2spss(x, y, z) jtgrd2spss(jt, (x), (y), (z))
-
 #define gt(x, y) jtatomic2(jt, (x), (y), ds(CGT))
 
 #define inv(x) jtinv(jt, (x), 0)
@@ -190,9 +175,6 @@
 #define minusA(x, y) jtatomic2((J)((I)jt | JTINPLACEA), (x), (y), ds(CMINUS))
 
 #define mr(x) ((I)(FAV(x)->mr))
-#define msmerge(x, y, z) jtmsmerge(jt, (x), (y), (z))
-#define msort(x, y, z) jtmsort(jt, (x), (y), (z))
-#define msortitems(w, x, y, z) jtmsortitems(jt, (w), (x), (y), (z))
 #define mult(x, y) \
     jtmult(jt, (x), (y))  // there is a second macro in dtoa.c so when we mass remove one it hits both of them.
 
@@ -200,10 +182,8 @@
 #define negateW(x) jtnegate((J)((I)jt | JTINPLACEW), (x))
 #define nmhash(x, y) hic((x), (y))
 
-#define nodupgrade(x0, x1, x2, x3, x4, x5, x6, x7, x8) \
-    jtnodupgrade(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8))
-
 #define nor(x, y) jtatomic2(jt, (x), (y), ds(CPLUSCO))
+
 #define numb(x0, x1, x2, x3) jtnumb(jt, (x0), (x1), (x2), (x3))
 #define numbpx(x, y, z) jtnumbpx(jt, (x), (y), (z))
 #define numd(x, y, z) jtnumd(jt, (x), (y), (z))
@@ -343,8 +323,6 @@
             z = rpsa->actrtns[3 * tmax + (rps)];               \
         }                                                      \
     }
-#define vec(x, y, z) jtvec(jt, (x), (y), (z))
-
 #define words(x) jtwords(jt, (x), ds(CWORDS))
 #define xcompare(x, y) jtxcompare(jt, (x), (y))  // used in multiple macros in multiple files.
 #define xplus(x, y) jtxplus(jt, (x), (y))    // 5 files use this in macros.

--- a/jsrc/ja.h
+++ b/jsrc/ja.h
@@ -2,107 +2,41 @@
 /* Licensed use only. Any other use is in violation of copyright.          */
 /*                                                                         */
 /* Aliases for jt (JST* - J Syntax Tree)                                   */
-#define BfromD(x, y, z) jtBfromD(jt, (x), (y), (z))
-#define DfromZ(x, y, z) jtDfromZ(jt, (x), (y), (z))
-#define DXfI(x, y, z) jtDXfI(jt, (x), (y), (z))
-#define IfromD(x, y, z) jtIfromD(jt, (x), (y), (z))
-#define QfromD(x, y, z) jtQfromD(jt, (x), (y), (z))
-#define XfromD(x, y, z) jtXfromD(jt, (x), (y), (z))
-#define aaxis(x0, x1, x2, x3, x4, x5, x6, x7) jtaaxis(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
-#define add2(x, y, z) jtadd2(jt, (x), (y), (z))
-#define afrom2(x0, x1, x2, x3) jtafrom2(jt, (x0), (x1), (x2), (x3))
-#define aindex(x0, x1, x2, x3) jtaindex(jt, (x0), (x1), (x2), (x3))
-#define aindex1(x0, x1, x2, x3) jtaindex1(jt, (x0), (x1), (x2), (x3))
-#define am1a(x0, x1, x2, x3) jtam1a(jt, (x0), (x1), (x2), (x3))
-#define am1e(x0, x1, x2, x3) jtam1e(jt, (x0), (x1), (x2), (x3))
-#define am1sp(x0, x1, x2, x3) jtam1sp(jt, (x0), (x1), (x2), (x3))
-#define amendn2(x0, x1, x2, x3) jtamendn2(jt, (x0), (x1), (x2), (x3))
-#define amna(x0, x1, x2, x3) jtamna(jt, (x0), (x1), (x2), (x3))
-#define amne(x0, x1, x2, x3) jtamne(jt, (x0), (x1), (x2), (x3))
-#define amnsp(x0, x1, x2, x3) jtamnsp(jt, (x0), (x1), (x2), (x3))
+
 #define apip(x, y) \
     jtapip((J)((I)jt | JTINPLACEA), (x), (y))  // use apip instead of over when a is an inplaceable context
-#define apv(x, y, z) jtapv(jt, (x), (y), (z))
-#define apvwr(x, y, z) jtapvwr(jt, (x), (y), (z))
+
 #define assembleresults(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) \
     jtassembleresults(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9), (x10))
-#define astd1(x, y, z) jtastd1(jt, (x), (y), (z))
-#define astdn(x, y, z) jtastdn(jt, (x), (y), (z))
-#define atab(x, y, z) jtatab(jt, (x), (y), (z))
-#define atcompf(x, y, z) jtatcompf(jt, (x), (y), (z))
-#define axbytes1(x0, x1, x2, x3, x4) jtaxbytes1(jt, (x0), (x1), (x2), (x3), (x4))
-#define bdot2(x, y, z) jtbdot2(jt, (x), (y), (z))
+
 #define beheadW(x) jtbehead((J)((I)jt | JTINPLACEW), (x))
-#define bfi(x, y, z) jtbfi(jt, (x), (y), (z))
-#define bitwisecharamp(x0, x1, x2, x3) jtbitwisecharamp(jt, (x0), (x1), (x2), (x3))
 #define boxW(x) jtbox((J)((I)jt | JTINPLACEW), (x))
 #define box0(x) jtirs1(jt, (x), 0L, 0, jtbox)
-#define brep(x, y, z) jtbrep(jt, (x), (y), (z))
-#define brephdr(x0, x1, x2, x3) jtbrephdr(jt, (x0), (x1), (x2), (x3))
-#define breps(x, y, z) jtbreps(jt, (x), (y), (z))
-#define c2j(x, y, z) jtc2j(jt, (x), (y), (z))
-#define cants(x, y, z) jtcants(jt, (x), (y), (z))
+
 // if we ensured that setting AFRO always removed inplaceability, we could simplify this test
 #define makewritable(x) \
     RZ(x = (AC(x) < (AFLAG(x) << ((BW - 1) - AFROX))) ? x : jtca(jt, x))  // OK if AC is 0x8..1 and AFRO is 0
-#define ccvt(x, y, z) jtccvt(jt, (x), (y), (z))
-#define cdload(x, y, z) jtcdload(jt, (x), (y), (z))
+
 #define ceil1(x) jtatomic1(jt, (x), ds(CCEIL))
-#define center(x0, x1, x2, x3) jtcenter(jt, (x0), (x1), (x2), (x3))
-#define cex(x, y, z) jtcex(jt, (x), (y), (z))
-#define charmap(x, y, z) jtcharmap(jt, (x), (y), (z))
-#define cirx(x0, x1, x2, x3) jtcirx(jt, (x0), (x1), (x2), (x3))
-#define congoto(x, y, z) jtcongoto(jt, (x), (y), (z))
-#define congotochk(x, y, z) jtcongotochk(jt, (x), (y), (z))
 #define conjug(x) jtatomic1(jt, (x), ds(CPLUS))
-#define convert0(x0, x1, x2, x3) jtconvert0(jt, (x0), (x1), (x2), (x3))
-#define crelocalsyms(x, y, t, v, f) jtcrelocalsyms(jt, (x), (y), (t), (v), (f))
-#define cut02(x, y, z) jtcut02(jt, (x), (y), (z))
-#define cut2(x, y, z) jtcut2(jt, (x), (y), (z))
-#define cut2bx(x, y, z) jtcut2bx(jt, (x), (y), (z))
-#define cut2sx(x, y, z) jtcut2sx(jt, (x), (y), (z))
-#define dbunquote(x, y, z, w) jtdbunquote(jt, (x), (y), (z), (w))
-#define deba(x0, x1, x2, x3) jtdeba(jt, (x0), (x1), (x2), (x3))
-#define deflate(x0, x1, x2, x3) jtdeflate(jt, (x0), (x1), (x2), (x3))
-#define deflateq(x0, x1, x2, x3) jtdeflateq(jt, (x0), (x1), (x2), (x3))
+
 #define df1(r, x, y) (r = ((r = (y)) ? (FAV(r)->valencefns[0])(jt, (x), r) : r))
 #define df2(r, x, y, z) (r = ((r = (z)) ? (FAV(r)->valencefns[1])(jt, (x), (y), r) : r))
 #define df2ip(r, x, y, z) (r = ((r = (z)) ? (FAV(r)->valencefns[1])(jtinplace, (x), (y), r) : r))
-#define dfs2(x, y, z) jtdfs2(jt, (x), (y), (z))
 #define divide(x, y) jtatomic2(jt, (x), (y), ds(CDIV))
 #define divideAW(x, y) jtatomic2((J)((I)jt | JTINPLACEA | JTINPLACEW), (x), (y), ds(CDIV))
 #define divideW(x, y) jtatomic2((J)((I)jt | JTINPLACEW), (x), (y), ds(CDIV))
-#define dolock(x0, x1, x2, x3) jtdolock(jt, (x0), (x1), (x2), (x3))
-#define dotprod(x, y, z) jtdotprod(jt, (x), (y), (z))
-#define drow(x, y, z) jtdrow(jt, (x), (y), (z))
-#define dspell(x, y, z) jtdspell(jt, (x), (y), (z))
-#define eachl(x, y, z) jteachl(jt, (x), (y), (z))
-#define ebarprep(x0, x1, x2, x3, x4) jtebarprep(jt, (x0), (x1), (x2), (x3), (x4))
-#define ecvt(x0, x1, x2, x3, x4) jtecvt(jt, (x0), (x1), (x2), (x3), (x4))
-#define efflev(x, y, z) jtefflev(jt, (x), (y), (z))
+
 #define efr(z, ar, r)                                    \
     (z = ((r) > (ar) ? (ar) : (r)) + (REPSGN(r) & (ar)), \
      z = (z < 0) ? 0 : z)  // effective rank: ar is rank of argument, r is rank of verb (may be negative), z becomes
                            // rank of argument cell
-#define enqueue(x, y, z) jtenqueue(jt, (x), (y), (z))
 #define eq(x, y) jtatomic2(jt, (x), (y), ds(CEQ))
-#define eqa(x0, x1, x2) jteqa(jt, (x0), (x1), (x2))
-#define eqd(x, y, z) jteqd(jt, (x), (y), (z))
-#define eqq(x, y, z) jteqq(jt, (x), (y), (z))
-#define eqx(x, y, z) jteqx(jt, (x), (y), (z))
 #define equ(x, y) \
     jtequ(jt, (x), (y))  // this macro is used in many other macros. Need to resolve the usage before removal.
-#define eqz(x, y, z) jteqz(jt, (x), (y), (z))
-#define ev2(x, y, z) jtev2(jt, (x), (y), (z))
-#define evc(x, y, z) jtevc(jt, (x), (y), (z))
-#define every2(x0, x1, x2) jtevery2(jt, (x0), (x1), (x2))
-#define exec2q(x0, x1, x2, x3, x4) jtexec2q(jt, (x0), (x1), (x2), (x3), (x4))
-#define exec2r(x0, x1, x2, x3, x4, x5) jtexec2r(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define exec2x(x0, x1, x2, x3, x4) jtexec2x(jt, (x0), (x1), (x2), (x3), (x4))
-#define exec2z(x0, x1, x2, x3, x4) jtexec2z(jt, (x0), (x1), (x2), (x3), (x4))
+
 #define expn1(x) jtatomic1(jt, (x), ds(CEXP))
 #define expn2(x, y) jtatomic2(jt, (x), (y), ds(CEXP))  // bypass sqrt test for internal calls
-#define exta(x0, x1, x2, x3) jtexta(jt, (x0), (x1), (x2), (x3))
 // Handle top level of fa(), which decrements use count and decides whether recursion is needed.  We recur if the
 // contents are traversible and the current block is being decremented to 0 usecount or does not have recursive usecount
 // fa() audits the tstack, for use outside the tpop system.  fadecr does just the decrement (for when AC is known > 1)
@@ -185,21 +119,12 @@
             if ((c) != ACUC1) AC(z) = (c);                                                                \
         }                                                                                                 \
     }
+
 #define fdef(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) \
     jtfdef(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9), (x10), (x11))
-#define fillv(x, y, z) jtfillv(jt, (x), (y), (z))
-#define fitct(x, y, n) jtfitct(jt, (x), (y), (n))
+
 #define floor1(x) jtatomic1(jt, (x), ds(CFLOOR))
-#define fmfill(x0, x1, x2, x3, x4, x5, x6, x7) jtfmfill(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
-#define fminit(x0, x1, x2, x3, x4, x5, x6) jtfminit(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6))
-#define fmt1(x0, x1, x2, x3, x4, x5) jtfmt1(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define fmtallcol(x, y, z) jtfmtallcol(jt, (x), (y), (z))
-#define fmtcomma(x0, x1, x2, x3) jtfmtcomma(jt, (x0), (x1), (x2), (x3))
-#define fmtex(x0, x1, x2, x3, x4, x5, x6, x7) jtfmtex(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
-#define fmtq(x0, x1, x2, x3, x4, x5) jtfmtq(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define fmtx(x0, x1, x2, x3, x4, x5) jtfmtx(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define fmtxi(x0, x1, x2, x3) jtfmtxi(jt, (x0), (x1), (x2), (x3))
-#define folk(x, y, z) jtfolk(jt, (x), (y), (z))
+
 #define fr(x)                    \
     {                            \
         if ((x) != 0) {          \
@@ -212,20 +137,10 @@
             }                    \
         }                        \
     }
-#define fram(x0, x1, x2, x3, x4) jtfram(jt, (x0), (x1), (x2), (x3), (x4))
-#define frombs1(x, y, z) jtfrombs1(jt, (x), (y), (z))
-#define frombsn(x, y, z) jtfrombsn(jt, (x), (y), (z))
-#define frombu(x, y, z) jtfrombu(jt, (x), (y), (z))
-#define fromis1(x0, x1, x2, x3) jtfromis1(jt, (x0), (x1), (x2), (x3))
-#define fslashatg(x, y, z) jtfslashatg(jt, (x), (y), (z))
-#define fsm0(x, y, z) jtfsm0(jt, (x), (y), (z))
-#define fsmdo(x0, x1, x2, x3, x4, x5) jtfsmdo(jt, (x0), (x1), (x2), (x3), (x4), (x5))
 #define fx(x) jtfx(jt, (x), 0L)
-#define ga(x0, x1, x2, x3) jtga(jt, (x0), (x1), (x2), (x3))
-#define gc3(x0, x1, x2, x3) jtgc3(jt, (x0), (x1), (x2), (x3))
 #define gcd(x, y) jtatomic2(jt, (x), (y), ds(CPLUSDOT))
-#define gconj(x, y, z) jtgconj(jt, (x), (y), (z))
 #define ge(x, y) jtatomic2(jt, (x), (y), ds(CGE))
+
 #define grd1spdd(x, y, z) jtgrd1spdd(jt, (x), (y), (z))
 #define grd1spds(x, y, z) jtgrd1spds(jt, (x), (y), (z))
 #define grd1spsd(x, y, z) jtgrd1spsd(jt, (x), (y), (z))
@@ -233,76 +148,34 @@
 #define grd1spz(x, y, z) jtgrd1spz(jt, (x), (y), (z))
 #define grd2spsd(x, y, z) jtgrd2spsd(jt, (x), (y), (z))
 #define grd2spss(x, y, z) jtgrd2spss(jt, (x), (y), (z))
-#define gri(x0, x1, x2, x3, x4) jtgri(jt, (x0), (x1), (x2), (x3), (x4))
-#define gri1(x0, x1, x2, x3, x4) jtgri1(jt, (x0), (x1), (x2), (x3), (x4))
-#define gru1(x0, x1, x2, x3, x4) jtgru1(jt, (x0), (x1), (x2), (x3), (x4))
-#define grx(x0, x1, x2, x3, x4) jtgrx(jt, (x0), (x1), (x2), (x3), (x4))
+
 #define gt(x, y) jtatomic2(jt, (x), (y), ds(CGT))
-#define hgd(x0, x1, x2, x3, x4) jthgd(jt, (x0), (x1), (x2), (x3), (x4))
-#define hgeom2(x, y, z) jthgeom2(jt, (x), (y), (z))
-#define hgv(x0, x1, x2, x3) jthgv(jt, (x0), (x1), (x2), (x3))
-#define hparm(x, y, z) jthparm(jt, (x), (y), (z))
-#define hrep(x, y, z) jthrep(jt, (x), (y), (z))
-#define iaddr(x0, x1, x2, x3) jtiaddr(jt, (x0), (x1), (x2), (x3))
-#define idenv0(x0, x1, x2, x3, x4) jtidenv0(jt, (x0), (x1), (x2), (x3), (x4))
-#define iixBX(x0, x1, x2, x3, x4) jtiixBX(jt, (x0), (x1), (x2), (x3), (x4))
-#define iixI(x0, x1, x2, x3, x4) jtiixI(jt, (x0), (x1), (x2), (x3), (x4))
-#define indexofprehashed(x, y, z) jtindexofprehashed(jt, (x), (y), (z))
-#define indexofss(x, y, z) jtindexofss(jt, (x), (y), (z))
-#define indexofsub(x, y, z) jtindexofsub(jt, (x), (y), (z))
-#define indexofxx(x, y, z) jtindexofxx(jt, (x), (y), (z))
-#define infix(x, y, z) jtinfix(jt, (x), (y), (z))
-#define inpl(x, y, z) jtinpl(jt, (x), (y), (z))
+
 #define inv(x) jtinv(jt, (x), 0)
 #define invrecur(x) jtinv(jt, (x), 1)  // call inv(), indicating recursive call
-#define iocol(x, y, z) jtiocol(jt, (x), (y), (z))
-#define iopart(x0, x1, x2, x3, x4, x5, x6) jtiopart(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6))
-#define ioresparse(x, y, z) jtioresparse(jt, (x), (y), (z))
-#define iovsd(x, y, z) jtiovsd(jt, (x), (y), (z))
-#define iovxs(x, y, z) jtiovxs(jt, (x), (y), (z))
-#define ipart(x0, x1, x2, x3) jtipart(jt, (x0), (x1), (x2), (x3))
-#define ipbx(x0, x1, x2, x3) jtipbx(jt, (x0), (x1), (x2), (x3))
-#define ipprep(x0, x1, x2, x3, x4, x5) jtipprep(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define irs1(x0, x1, x2, x3) jtirs1(jt, (x0), (x1), (x2), (x3))
-#define irs2(x0, x1, x2, x3, x4, x5) jtirs2(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define ixin(x0, x1, x2, x3) jtixin(jt, (x0), (x1), (x2), (x3))
-#define jprx(x0, x1, x2, x3, x4) jtjprx(jt, (x0), (x1), (x2), (x3), (x4))
-#define jsignal3(x, y, z) jtjsignal3(jt, (x), (y), (z))
-#define jsigstr(x, y, z) jtjsigstr(jt, (x), (y), (z))
-#define jstd(x, y, z) jtjstd(jt, (x), (y), (z))
-#define key(x, y, z) jtkey(jt, (x), (y), (z))
-#define keysp(x, y, z) jtkeysp(jt, (x), (y), (z))
-#define keytally(x, y, z) jtkeytally(jt, (x), (y), (z))
-#define laguerre(x, y, z) jtlaguerre(jt, (x), (y), (z))
+
 #define lbox(x) jtlbox(jtinplace, (x), ltext)
 #define lchar(x) jtlchar(jtinplace, (x), ltext)
 #define lcm(x, y) jtatomic2(jt, (x), (y), ds(CSTARDOT))
 #define lcolon(x) jtlcolon(jtinplace, (x), ltext)
 #define le(x, y) jtatomic2(jt, (x), (y), ds(CLE))
-#define lev2(x, y, z) jtlev2(jt, (x), (y), (z))
-#define levs2(x, y, z) jtlevs2(jt, (x), (y), (z))
-#define line(x0, x1, x2, x3) jtline(jt, (x0), (x1), (x2), (x3))
-#define linf(x0, x1, x2, x3) jtlinf(jt, (x0), (x1), (x2), (x3))
+
 #define link(x, y) jtlink(jt, (x), (y), UNUSED_VALUE)
 #define linsert(x, y) jtlinsert(jtinplace, (x), (y), ltext)
 #define lnoun(x) jtlnoun(jtinplace, (x), ltext)
 #define lnoun0(x) jtlnoun0(jtinplace, (x), ltext)
 #define lnum(x) jtlnum(jtinplace, (x), ltext)
 #define lnum1(x) jtlnum1(jtinplace, (x), ltext)
-#define locindirect(x, y, z) jtlocindirect(jt, (x), (y), (z))
 #define logar1(x) jtatomic1(jt, (x), ds(CLOG))
 #define lrv(x) ((UI)((x)->lrr) >> RANKTX)  // left rank of V
 #define lr(x) lrv(FAV(x))                  // left rank of A
-#define lr2(x, y, z) jtlr2(jt, (x), (y), (z))
 #define lrr(x) jtlrr(jtinplace, (x), 0L, ltext)
 #define lsh(x) jtlsh(jtinplace, (x), ltext)
 #define lshape(x) jtlshape(jtinplace, (x), ltext)
 #define lsparse(x) jtlsparse(jtinplace, (x), ltext)
-#define lsub(x, y, z) jtlsub(jt, (x), (y), (z))
 #define lsymb(x, y) jtlsymb(jtinplace, (x), (y), ltext)
 #define lt(x, y) jtatomic2(jt, (x), (y), ds(CLT))
 #define mag(x) jtatomic1(jt, (x), ds(CSTILE))
-#define matchsub(x0, x1, x2, x3, x4, x5, x6, x7) jtmatchsub(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
 #define maximum(x, y) jtatomic2(jt, (x), (y), ds(CMAX))
 // typepriority is 0, 1, 4, 9, 10, 5, 6, 7, 8, 2, 3
 // prioritytype is B01X, LITX, C2TX, C4TX, INTX, BOXX, XNUMX, RATX, SBTX, FLX, CMPXX
@@ -311,36 +184,25 @@
 #define maxtype(x, y) (((x) == (y)) ? (x) : jtmaxtype(jt, x, y))
 #define maxtypedne(x, y) (jt->typepriority[CTTZ(x)] > jt->typepriority[CTTZ(y)] ? (x) : (y))
 #define maxtyped(x, y) (((x) == (y)) ? (x) : maxtypedne(x, y))
-// For sparse types, we encode here the corresponding dense type
-#define memoget(x, y, z) jtmemoget(jt, (x), (y), (z))
-#define memoput(x0, x1, x2, x3) jtmemoput(jt, (x0), (x1), (x2), (x3))
-#define merge2(x0, x1, x2, x3, x4) jtmerge2(jt, (x0), (x1), (x2), (x3), (x4))
+
 #define minimum(x, y) jtatomic2(jt, (x), (y), ds(CMIN))
 #define minus(x, y) jtatomic2(jt, (x), (y), ds(CMINUS))
 #define minusA(x, y) jtatomic2((J)((I)jt | JTINPLACEA), (x), (y), ds(CMINUS))
-#define mmharvest(x0, x1, x2, x3, x4, x5, x6) jtmmharvest(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6))
-#define mmprep(x0, x1, x2, x3, x4, x5) jtmmprep(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define movandor(x0, x1, x2, x3) jtmovandor(jt, (x0), (x1), (x2), (x3))
-#define movbwneeq(x0, x1, x2, x3) jtmovbwneeq(jt, (x0), (x1), (x2), (x3))
-#define movfslash(x, y, z) jtmovfslash(jt, (x), (y), (z))
-#define movminmax(x0, x1, x2, x3) jtmovminmax(jt, (x0), (x1), (x2), (x3))
-#define movneeq(x0, x1, x2, x3) jtmovneeq(jt, (x0), (x1), (x2), (x3))
-#define movsumavg(x0, x1, x2, x3) jtmovsumavg(jt, (x0), (x1), (x2), (x3))
-#define movsumavg1(x0, x1, x2, x3) jtmovsumavg1(jt, (x0), (x1), (x2), (x3))
+
 #define mr(x) ((I)(FAV(x)->mr))
 #define msmerge(x, y, z) jtmsmerge(jt, (x), (y), (z))
 #define msort(x, y, z) jtmsort(jt, (x), (y), (z))
 #define msortitems(w, x, y, z) jtmsortitems(jt, (w), (x), (y), (z))
 #define mult(x, y) \
     jtmult(jt, (x), (y))  // there is a second macro in dtoa.c so when we mass remove one it hits both of them.
-#define mvw(x0, x1, x2, x3, x4, x5, x6) jtmvw(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6))
-#define nch1(x0, x1, x2, x3) jtnch1(jt, (x0), (x1), (x2), (x3))
+
 #define ne(x, y) jtatomic2(jt, (x), (y), ds(CNE))
 #define negateW(x) jtnegate((J)((I)jt | JTINPLACEW), (x))
-#define newt(x0, x1, x2, x3) jtnewt(jt, (x0), (x1), (x2), (x3))
 #define nmhash(x, y) hic((x), (y))
+
 #define nodupgrade(x0, x1, x2, x3, x4, x5, x6, x7, x8) \
     jtnodupgrade(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8))
+
 #define nor(x, y) jtatomic2(jt, (x), (y), ds(CPLUSCO))
 #define numb(x0, x1, x2, x3) jtnumb(jt, (x0), (x1), (x2), (x3))
 #define numbpx(x, y, z) jtnumbpx(jt, (x), (y), (z))
@@ -350,29 +212,12 @@
 #define numq(x, y, z) jtnumq(jt, (x), (y), (z))
 #define numr(x, y, z) jtnumr(jt, (x), (y), (z))
 #define numx(x, y, z) jtnumx(jt, (x), (y), (z))
-#define odom(x, y, z) jtodom(jt, (x), (y), (z))
-#define ofxassoc(x, y, z) jtofxassoc(jt, (x), (y), (z))
-#define opes(x, y, z) jtopes(jt, (x), (y), (z))
-#define opes1(x0, x1, x2, x3, x4, x5) jtopes1(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define opes2(x0, x1, x2, x3, x4, x5, x6) jtopes2(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6))
-#define outfix(x, y, z) jtoutfix(jt, (x), (y), (z))
-#define ovgmove(x0, x1, x2, x3, x4, x5, x6) jtovgmove(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6))
-#define ovs0(x0, x1, x2, x3) jtovs0(jt, (x0), (x1), (x2), (x3))
-#define pad(x, y, z) jtpad(jt, (x), (y), (z))
-#define parsex(x0, x1, x2, x3) jtparsex(jt, (x0), (x1), (x2), (x3))
-#define pee(a, b, c, d, e) jtpee(jt, (a), (b), (c), (d), (e))
+
 #define pix(x) jtpix(jt, (x), ds(CCIRCLE))
 #define plus(x, y) jtatomic2(jt, (x), (y), ds(CPLUS))
 #define plusA(x, y) jtatomic2((J)((I)jt | JTINPLACEA), (x), (y), ds(CPLUS))
 #define plusW(x, y) jtatomic2((J)((I)jt | JTINPLACEW), (x), (y), ds(CPLUS))
-#define pmrecord(x0, x1, x2, x3) jtpmrecord(jt, (x0), (x1), (x2), (x3))
-#define polymult(x, y, z) jtpolymult(jt, (x), (y), (z))
-#define powop(x, y, z) jtpowop(jt, (x), (y), (z))
-#define preparse(x, y, z) jtpreparse(jt, (x), (y), (z))
-#define probe(x, y, z, w) jtprobe(jt, (x), (y), (z), (w))
-#define probedel(x, y, z, w) jtprobedel(jt, (x), (y), (z), (w))
-#define pscangt(x0, x1, x2, x3, x4, x5) jtpscangt(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define pscanlt(x0, x1, x2, x3, x4, x5) jtpscanlt(jt, (x0), (x1), (x2), (x3), (x4), (x5))
+
 #define qplus(x, y) jtqplus(jt, (x), (y))    // used by 2 macros in 2 different files.
 #define qtymes(x, y) jtqtymes(jt, (x), (y))  // used by 3 macros in 3 different files.
 // Handle top level of ra().  Increment usecount.  Set usecount recursive usecount if recursible type; recur on contents
@@ -417,18 +262,10 @@
             jtra((x), (tt));             \
         }                                \
     }
-#define rank1ex(x0, x1, x2, x3) jtrank1ex(jt, (x0), (x1), (x2), (x3))
-#define rank1ex0(x0, x1, x2) jtrank1ex0(jt, (x0), (x1), (x2))
 #define REX2R(lr, rr, lcr, rcr) (((I)(lr) << RANKTX) + (I)(rr) + ((((I)(lcr) << RANKTX) + (I)(rcr)) << 2 * RANKTX))
 #define rank2ex(x0, x1, x2, x3, x4, x5, x6, x7) jtrank2ex(jt, (x0), (x1), (x2), REX2R((x3), (x4), (x5), (x6)), (x7))
-#define rank2ex0(x0, x1, x2, x3) jtrank2ex0(jt, (x0), (x1), (x2), (x3))
-#define rankingb(x0, x1, x2, x3, x4, x5) jtrankingb(jt, (x0), (x1), (x2), (x3), (x4), (x5))
 // ras does rifv followed by ra
 #define ras(x) ((x) = jtras(jt, x))
-#define razecut2(x, y, z) jtrazecut2(jt, (x), (y), (z))
-#define razeg(x0, x1, x2, x3, x4, x5) jtrazeg(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define rc(x, y, z, t) jtrc(jt, (x), (y), (z), (t))
-#define rd(x, y, z) jtrd(jt, (x), (y), (z))
 #define realizeifvirtual(x)                                          \
     {                                                                \
         if ((AFLAG(x) & AFVIRTUAL) != 0) RZ((x) = jtrealize(jt, x)); \
@@ -437,82 +274,20 @@
 // In some cases, the call is to an internal routine that we know will not return a virtual block normally, and is in an
 // important performance path.  We use rifvsdebug for these places.  rifvs is called only during debugging.  Review them
 // from time to time.
-#define redcatsp(x, y, z) jtredcatsp(jt, (x), (y), (z))
 #define redg(x, y) jtredg(jtinplace, (x), (y))
-#define redsp1(x0, x1, x2, x3, x4, x5, x6, x7) jtredsp1(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
-#define redsp1a(x0, x1, x2, x3, x4, x5) jtredsp1a(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define redspd(x0, x1, x2, x3, x4, x5, x6, x7) jtredspd(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
-#define redsps(x0, x1, x2, x3, x4, x5, x6, x7) jtredsps(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
-#define redspse(x0, x1, x2, x3, x4, x5, x6, x7) jtredspse(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
+
 #define redspsprep(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) \
     jtredspsprep(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9), (x10), (x11), (x12))
-#define rep1d(x0, x1, x2, x3) jtrep1d(jt, (x0), (x1), (x2), (x3))
-#define rep1sa(x, y, z) jtrep1sa(jt, (x), (y), (z))
-#define repidx(x0, x1, x2, x3) jtrepidx(jt, (x0), (x1), (x2), (x3))
-#define repzdx(x0, x1, x2, x3) jtrepzdx(jt, (x0), (x1), (x2), (x3))
+
 #define reshapeW(x, y) jtreshape((J)((I)jt | JTINPLACEW), (x), (y))
-#define reshapesp(x0, x1, x2, x3) jtreshapesp(jt, (x0), (x1), (x2), (x3))
-#define reshapesp0(x0, x1, x2, x3) jtreshapesp0(jt, (x0), (x1), (x2), (x3))
 #define residue(x, y) jtresidue(jt, (x), (y), ds(CSTILE))
-#define rfcq(x0, x1, x2, x3) jtrfcq(jt, (x0), (x1), (x2), (x3))
-#define rngstates1(x0, x1, x2, x3, x4, x5, x6) jtrngstates1(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6))
-#define rollk(x, y, z) jtrollk(jt, (x), (y), (z))
-#define rot(x0, x1, x2, x3, x4, x5, x6, x7) jtrot(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
+
 #define rrv(x) ((UI)((x)->lrr) & RANKTMSK)  // rr of V
 #define rr(x) rrv(FAV(x))                   // rr of A
-#define sbcheck1(x0, x1, x2, x3, x4, x5, x6, x7) jtsbcheck1(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
-#define sbextend(x0, x1, x2, x3) jtsbextend(jt, (x0), (x1), (x2), (x3))
-#define sbinsert(x0, x1, x2, x3, x4, x5) jtsbinsert(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define sbprobe(x0, x1, x2, x3) jtsbprobe(jt, (x0), (x1), (x2), (x3))
-#define scansp(x, y, z) jtscansp(jt, (x), (y), (z))
-#define scuba(x, y, z) jtscuba(jt, (x), (y), (z))
-#define scubc(x, y, z) jtscubc(jt, (x), (y), (z))
-#define scube(x, y, z) jtscube(jt, (x), (y), (z))
-#define selx(x, y, z) jtselx(jt, (x), (y), (z))
-#define sely(x0, x1, x2, x3) jtsely(jt, (x0), (x1), (x2), (x3))
+
 #define signum(x) jtatomic1(jt, (x), ds(CSTAR))
-#define sortb2(x0, x1, x2) jtsortb2(jt, (x0), (x1), (x2))
-#define sortb4(x0, x1, x2) jtsortb4(jt, (x0), (x1), (x2))
-#define sortc2(x0, x1, x2) jtsortc2(jt, (x0), (x1), (x2))
-#define sortu1(x0, x1, x2) jtsortu1(jt, (x0), (x1), (x2))
-#define sorti1(x0, x1, x2) jtsorti1(jt, (x0), (x1), (x2))
-#define sparse1a(x0, x1, x2, x3, x4) jtsparse1a(jt, (x0), (x1), (x2), (x3), (x4))
-#define sparseit(x, y, z) jtsparseit(jt, (x), (y), (z))
-#define spdscell(x0, x1, x2, x3, x4) jtspdscell(jt, (x0), (x1), (x2), (x3), (x4))
-#define spmult(x0, x1, x2, x3, x4, x5, x6, x7) jtspmult(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7))
-#define spradv(x0, x1, x2, x3, x4, x5, x6) jtspradv(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6))
-#define sprank1(x0, x1, x2, x3) jtsprank1(jt, (x0), (x1), (x2), (x3))
-#define sprank2(x0, x1, x2, x3, x4, x5) jtsprank2(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define sprank2_0w(x0, x1, x2, x3, x4, x5) jtsprank2_0w(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define sprank2_a0(x0, x1, x2, x3, x4, x5) jtsprank2_a0(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define spredge(x, y, z) jtspredge(jt, (x), (y), (z))
-#define sprinit(x0, x1, x2, x3, x4) jtsprinit(jt, (x0), (x1), (x2), (x3), (x4))
-#define sprintfeD(x0, x1, x2, x3, x4) jtsprintfeD(jt, (x0), (x1), (x2), (x3), (x4))
-#define sprintfnD(x0, x1, x2, x3, x4) jtsprintfnD(jt, (x0), (x1), (x2), (x3), (x4))
-#define sprintfI(x0, x1, x2, x3, x4) jtsprintfI(jt, (x0), (x1), (x2), (x3), (x4))
-#define sprz(x0, x1, x2, x3, x4) jtsprz(jt, (x0), (x1), (x2), (x3), (x4))
-#define spspd(x0, x1, x2, x3) jtspspd(jt, (x0), (x1), (x2), (x3))
-#define spspx(x0, x1, x2, x3) jtspspx(jt, (x0), (x1), (x2), (x3))
-#define spsscell(x0, x1, x2, x3, x4) jtspsscell(jt, (x0), (x1), (x2), (x3), (x4))
 #define sqroot(x) jtatomic1(jt, (x), ds(CROOT))
-#define ssdo(x, y, z) jtssdo(jt, (x), (y), (z))
-#define stcreate(x0, x1, x2, x3) jtstcreate(jt, (x0), (x1), (x2), (x3))
-#define stfind(x, y, z) jtstfind(jt, (x), (y), (z))
-#define stfindcre(x, y, z) jtstfindcre(jt, (x), (y), (z))
-#define sumatgbool(x, y, z) jtsumatgbool(jt, (x), (y), (z))
-#define symbis(x, y, z) jtsymbis(jt, (x), (y), (z))
-#define symbisdel(x, y, z) jtsymbisdel(jt, (x), (y), (z))
-#define syrd1(x, y, z, w) jtsyrd1(jt, (x), (y), (z), (w))
-#define syrd1forlocale(x, y, z, w) jtsyrd1forlocale(jt, (x), (y), (z), (w))
-#define tesos(x, y, z, w) jttesos(jt, (x), (y), (z), (w))
-#define tess2(x, y, z) jttess2(jt, (x), (y), (z))
-#define th2a(x0, x1, x2, x3, x4, x5, x6, x7, x8) jtth2a(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8))
-#define th2c(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9) \
-    jtth2c(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9))
-#define th2ctrl(x0, x1, x2, x3, x4, x5) jtth2ctrl(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define thv(x, y, z) jtthv(jt, (x), (y), (z))
 #define tine(x) jttine(jt, (x), tmonad)
-#define tk0(x, y, z) jttk0(jt, (x), (y), (z))
 // if jttg(jt,) fails, tpush leaves nextpushx unchanged
 // Handle top level of tpush().  push the current block, and recur if it is traversible and does not have recursive
 // usecount We can have an inplaceable but recursible block, if it was gc'd.  We never push a PERMANENT block, so that
@@ -547,20 +322,11 @@
         if (!((I)pushp & (NTSTACKBLOCK - 1))) { RZ(pushp = jttg(jt, pushp)); } \
         jt->tnextpushp = pushp;                                                \
     }
-#define tridiag(x, y, z) jttridiag(jt, (x), (y), (z))
-#define tryinit(x, y, z) jttryinit(jt, (x), (y), (z))
+
 #define tymes(x, y) jtatomic2(jt, (x), (y), ds(CSTAR))
 #define tymesA(x, y) jtatomic2((J)((I)jt | JTINPLACEA), (x), (y), ds(CSTAR))
 #define tymesW(x, y) jtatomic2((J)((I)jt | JTINPLACEW), (x), (y), ds(CSTAR))
-#define unbinr(x0, x1, x2, x3, x4) jtunbinr(jt, (x0), (x1), (x2), (x3), (x4))
-#define unparse1(x0, x1, x2, x3) jtunparse1(jt, (x0), (x1), (x2), (x3))
-#define unparse1a(x, y, z) jtunparse1a(jt, (x), (y), (z))
-#define unquote(x, y, z) jtunquote(jt, (x), (y), (z))
-#define unwordil(x, y, z) jtunwordil(jt, (x), (y), (z))
-#define upon2(x, y, z) jtupon2(jt, (x), (y), (z))
-#define usebs(x, y, z) jtusebs(jt, (x), (y), (z))
-#define va1s(x0, x1, x2, x3) jtva1s(jt, (x0), (x1), (x2), (x3))
-#define var(x0, x1, x2) jtvar(jt, (x0), (x1), (x2))
+
 // fetch adocv for an rps function (i. e. f/ f/\ f/\.) in self.  rps is 0-2 for / /\ /\.   t is the type of the input.
 // Assign result to z, which is a VARPS
 #define varps(z, self, t, rps)                                 \
@@ -577,34 +343,15 @@
             z = rpsa->actrtns[3 * tmax + (rps)];               \
         }                                                      \
     }
-#define vasp(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) \
-    jtvasp(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9), (x10), (x11), (x12))
-#define vasp0(x0, x1, x2, x3, x4, x5) jtvasp0(jt, (x0), (x1), (x2), (x3), (x4), (x5))
-#define vaspc(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) \
-    jtvaspc(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9), (x10), (x11), (x12))
-#define vaspeq(x0, x1, x2, x3, x4, x5, x6, x7, x8) jtvaspeq(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8))
-#define vaspeqprep(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) \
-    jtvaspeqprep(jt, (x0), (x1), (x2), (x3), (x4), (x5), (x6), (x7), (x8), (x9), (x10), (x11))
 #define vec(x, y, z) jtvec(jt, (x), (y), (z))
-#define vecb01(x, y, z) jtvecb01(jt, (x), (y), (z))
-#define wa(x, y, z) jtwa(jt, (x), (y), (z))
-#define widthdp(x, y, z) jtwidthdp(jt, (x), (y), (z))
+
 #define words(x) jtwords(jt, (x), ds(CWORDS))
-#define xdefn(x, y, z) jtxdefn(jt, (x), (y), (z))
-#define xdiv(x, y, z) jtxdiv(jt, (x), (y), (z))
-#define xdivrem(x0, x1, x2, x3) jtxdivrem(jt, (x0), (x1), (x2), (x3))
-#define xev2(x, y, z) jtxev2(jt, (x), (y), (z))
 #define xcompare(x, y) jtxcompare(jt, (x), (y))  // used in multiple macros in multiple files.
-#define xop2(x, y, z) jtxop2(jt, (x), (y), (z))
 #define xplus(x, y) jtxplus(jt, (x), (y))    // 5 files use this in macros.
 #define xtymes(x, y) jtxtymes(jt, (x), (y))  // 4 files use this in macros
 #define zdiv(x, y) jtzdiv(jt, (x), (y))      // 3 files' use this in macros
 #define zeq(x, y) jtzeq(jt, (x), (y))        // 3 files' use this in macros
-#define zhorner(x, y, z) jtzhorner(jt, (x), (y), (z))
 #define zminus(x, y) jtzminus(jt, (x), (y))  // 3 files' use this in macros
-#define zpad1(x, y, z) jtzpad1(jt, (x), (y), (z))
-#define zpadn(x, y, z) jtzpadn(jt, (x), (y), (z))
 #define zplus(x, y) jtzplus(jt, (x), (y))  // 4 files' use this in macros
 #define zpow(x, y) jtzpow(jt, (x), (y))    // 2 files' use this in macros
-#define ztridiag(x, y, z) jtztridiag(jt, (x), (y), (z))
 #define ztymes(x, y) jtztymes(jt, (x), (y))  // 4 files' use this in macros

--- a/jsrc/jtype.h
+++ b/jsrc/jtype.h
@@ -340,7 +340,7 @@ enum {
 #define SYMBSIZE sizeof(LX)
 #define CONWSIZE sizeof(CW)
 #define ADVSIZE sizeof(V)
-#define VERBSIZE sizeof(V)  // Note: size of ACV in bp() is INTSIZE because the allocation in fdef() is of INTs
+#define VERBSIZE sizeof(V)  // Note: size of ACV in bp() is INTSIZE because the allocation in jtfdef(jt, ) is of INTs
 #define LPARSIZE sizeof(I)
 #define CONJSIZE sizeof(V)
 #define RPARSIZE sizeof(I)

--- a/jsrc/jtype.h
+++ b/jsrc/jtype.h
@@ -593,8 +593,8 @@ typedef struct {
 // definition.  0 means we don't know yet.
 
 #define DCPARSE 1  /* sentence for parser                                          */
-#define DCSCRIPT 2 /* script              -- line()                                */
-#define DCCALL 3   /* verb/adv/conj call  -- dbunquote()                           */
+#define DCSCRIPT 2 /* script              -- jtline(jt, )                                */
+#define DCCALL 3   /* verb/adv/conj call  -- jtdbunquote(jt, )                           */
 #define DCJUNK 4   /* stack entry is stale                                      */
 
 typedef struct DS {   /* 1 2 3                                                        */

--- a/jsrc/m.c
+++ b/jsrc/m.c
@@ -291,7 +291,7 @@ jtspforloc(J jt, A w) {
             ASSERT(vlocnm(m, s), EVILNAME);
             bucketx = BUCKETXLOC(m, s);
         }
-        y = stfind(m, s, bucketx);  // y is the block for the locale
+        y = jtstfind(jt, m, s, bucketx);  // y is the block for the locale
         ASSERT(y != 0, EVLOCALE);
         *v = (D)(FHRHSIZE(AFHRH(y)));  // start with the size of the locale block (always a normal block)
         jtspfor1(jt, LOCPATH(y));
@@ -464,7 +464,7 @@ jtfh(J jt, A w) {
 // jtgc(jt,) protects a result, and pops the stack.  It preserves inplacing and virtuality if possible.  It cannot be
 // used on blocks
 //   that contain contents younger than the block
-// gc3() is a simple-minded jtgc(jt,) that works on all blocks, and can handle up to 3 at a time.
+// jtgc3(jt, ) is a simple-minded jtgc(jt,) that works on all blocks, and can handle up to 3 at a time.
 // virtual() creates a virtual block that refers to a part of another block.  It looks at the inplacing flags to see if
 // it can get away with modifying the
 //    block given rather than creating a new one
@@ -697,8 +697,8 @@ jtgc(J jt, A w, A* old) {
     // NOTE: certain functions (ex: rational determinant) perform operations 'in place' on non-direct names and then
     // protect those names using jtgc(jt,).  The protection is ineffective if the code goes through the fa() path here,
     // because components that were modified will be freed immediately rather than later.  In those places we must
-    // either use gc3() which always does the tpush, or do ACIPNO to force us through the tpush path here.  We generally
-    // use gc3(). Since w now has recursive usecounts (except for sparse, which is never inplaceable), we don't have to
+    // either use jtgc3(jt, ) which always does the tpush, or do ACIPNO to force us through the tpush path here.  We generally
+    // use jtgc3(jt, ). Since w now has recursive usecounts (except for sparse, which is never inplaceable), we don't have to
     // do a full fa() on a block that is returning inplaceable - we just reset the usecount in the block.  If the block
     // is returning inplaceable, we must update AM if we tpush
     I cafter = AC(w);
@@ -823,7 +823,7 @@ jtfa(J jt, AD* RESTRICT wd, I t) {
 // Note: wd CANNOT be virtual
 // tpush, the macro parent of this routine, calls here only if a nonrecursive block is pushed.  This never happens for
 // non-sparse nouns, because they always go through ra() somewhere before the tpush().  Pushing is mostly in jtgc(jt,)
-// and on allocation in ga().
+// and on allocation in jtga(jt, ).
 A*
 jttpush(J jt, AD* RESTRICT wd, I t, A* pushp) {
     I af = AFLAG(wd);

--- a/jsrc/parsing/pv.c
+++ b/jsrc/parsing/pv.c
@@ -15,8 +15,8 @@
 #define CHK3 (!(stack[b].t || stack[1 + b].t || stack[e].t))
 #define CP ds(CCAP)
 #define DCASE(x, y) (6 * (x) + (y))
-#define FGL(v) folk(v->fgh[0], v->fgh[1], ds(CLEFT))
-#define FGR(v) folk(v->fgh[0], v->fgh[1], ds(CRIGHT))
+#define FGL(v) jtfolk(jt, v->fgh[0], v->fgh[1], ds(CLEFT))
+#define FGR(v) jtfolk(jt, v->fgh[0], v->fgh[1], ds(CRIGHT))
 #define LF ds(CLEFT)
 #define RT ds(CRIGHT)
 #define RZZ(exp)               \
@@ -120,11 +120,11 @@ jtvmonad(J jt, I b, I e, TA *stack, A locsyms, I tmonad, I tsubst, TA *ttab, I *
     else {
         v = FAV(y.t);
         if (!(CFORK == v->id && 0 <= tvi(v->fgh[2])))
-            z.t = folk(CP, fs, tine(y.t));
+            z.t = jtfolk(jt, CP, fs, tine(y.t));
         else if (NOUN & AT(v->fgh[0]))
-            z.t = folk(CP, folk(CP, fs, folk(v->fgh[0], v->fgh[1], RT)), tine(v->fgh[2]));
+            z.t = jtfolk(jt, CP, jtfolk(jt, CP, fs, jtfolk(jt, v->fgh[0], v->fgh[1], RT)), tine(v->fgh[2]));
         else
-            z.t = folk(tine(v->fgh[0]), folk(CP, fs, v->fgh[1]), tine(v->fgh[2]));
+            z.t = jtfolk(jt, tine(v->fgh[0]), jtfolk(jt, CP, fs, v->fgh[1]), tine(v->fgh[2]));
     }
     return z;
 }
@@ -176,8 +176,8 @@ jtvdyad(J jt, I b, I e, TA *stack, A locsyms, I tmonad, I tsubst, TA *ttab, I *t
     }
     if (0 > xi && 0 > yi) switch ((xt ? 2 : 0) + (yt ? 1 : 0)) {
             case 0: df2(z.a, x.a, y.a, fs); break;
-            case 1: z.t = folk(x.a, fs, yt); break;
-            case 2: z.t = folk(y.a, sf, xt); break;
+            case 1: z.t = jtfolk(jt, x.a, fs, yt); break;
+            case 2: z.t = jtfolk(jt, y.a, sf, xt); break;
             case 3:
                 xl = xt == LF;
                 xr = xt == RT;
@@ -190,7 +190,7 @@ jtvdyad(J jt, I b, I e, TA *stack, A locsyms, I tmonad, I tsubst, TA *ttab, I *t
                 else if (xr && yr && tmonad)
                     z.t = jtswap(jt, fs);
                 else
-                    z.t = CFORK == u->id && jtprimitive(jt, yt) ? folk(yt, sf, xt) : folk(xt, fs, yt);
+                    z.t = CFORK == u->id && jtprimitive(jt, yt) ? jtfolk(jt, yt, sf, xt) : jtfolk(jt, xt, fs, yt);
         }
     else {
         B b, c;
@@ -215,69 +215,69 @@ jtvdyad(J jt, I b, I e, TA *stack, A locsyms, I tmonad, I tsubst, TA *ttab, I *t
         b   = xj == yj;
         c   = xj == yi;
         switch (DCASE(i, j)) {
-            case DCASE(0, 2): z.t = folk(x.a, fs, yt); break;
-            case DCASE(2, 0): z.t = folk(y.a, sf, xt); break;
-            case DCASE(0, 3): z.t = folk(CP, folk(x.a, fs, FGR(v)), v->fgh[2]); break;
-            case DCASE(0, 4): z.t = folk(CP, folk(x.a, fs, v->fgh[1]), v->fgh[2]); break;
-            case DCASE(1, 2): z.t = folk(xt, fs, yt); break;
+            case DCASE(0, 2): z.t = jtfolk(jt, x.a, fs, yt); break;
+            case DCASE(2, 0): z.t = jtfolk(jt, y.a, sf, xt); break;
+            case DCASE(0, 3): z.t = jtfolk(jt, CP, jtfolk(jt, x.a, fs, FGR(v)), v->fgh[2]); break;
+            case DCASE(0, 4): z.t = jtfolk(jt, CP, jtfolk(jt, x.a, fs, v->fgh[1]), v->fgh[2]); break;
+            case DCASE(1, 2): z.t = jtfolk(jt, xt, fs, yt); break;
             case DCASE(1, 3):
-            case DCASE(1, 4): z.t = folk(xt, folk(LF, fs, FGR(v)), v->fgh[2]); break;
-            case DCASE(2, 1): z.t = folk(xt, fs, yt); break;
-            case DCASE(3, 1): z.t = folk(xt, fs, yt); break;
-            case DCASE(4, 1): z.t = folk(xt, fs, yt); break;
-            case DCASE(2, 2): z.t = folk(xt, fs, yt); break;
+            case DCASE(1, 4): z.t = jtfolk(jt, xt, jtfolk(jt, LF, fs, FGR(v)), v->fgh[2]); break;
+            case DCASE(2, 1): z.t = jtfolk(jt, xt, fs, yt); break;
+            case DCASE(3, 1): z.t = jtfolk(jt, xt, fs, yt); break;
+            case DCASE(4, 1): z.t = jtfolk(jt, xt, fs, yt); break;
+            case DCASE(2, 2): z.t = jtfolk(jt, xt, fs, yt); break;
             case DCASE(2, 3):
-                z.t = b ? folk(CP, folk(RT, fs, FGR(v)), v->fgh[2]) : folk(xt, folk(LF, fs, FGR(v)), v->fgh[2]);
+                z.t = b ? jtfolk(jt, CP, jtfolk(jt, RT, fs, FGR(v)), v->fgh[2]) : jtfolk(jt, xt, jtfolk(jt, LF, fs, FGR(v)), v->fgh[2]);
                 break;
             case DCASE(2, 4):
-                z.t = b ? folk(CP, folk(RT, fs, v->fgh[1]), v->fgh[2]) : folk(xt, folk(LF, fs, FGR(v)), v->fgh[2]);
+                z.t = b ? jtfolk(jt, CP, jtfolk(jt, RT, fs, v->fgh[1]), v->fgh[2]) : jtfolk(jt, xt, jtfolk(jt, LF, fs, FGR(v)), v->fgh[2]);
                 break;
             case DCASE(3, 2):
-                z.t = b ? folk(CP, folk(FGR(u), fs, RT), yt) : folk(u->fgh[2], folk(FGL(u), fs, RT), yt);
+                z.t = b ? jtfolk(jt, CP, jtfolk(jt, FGR(u), fs, RT), yt) : jtfolk(jt, u->fgh[2], jtfolk(jt, FGL(u), fs, RT), yt);
                 break;
             case DCASE(3, 3):
-                z.t = b ? folk(CP, folk(FGR(u), fs, FGR(v)), v->fgh[2])
-                        : folk(u->fgh[2], folk(FGL(u), fs, FGR(v)), v->fgh[2]);
+                z.t = b ? jtfolk(jt, CP, jtfolk(jt, FGR(u), fs, FGR(v)), v->fgh[2])
+                        : jtfolk(jt, u->fgh[2], jtfolk(jt, FGL(u), fs, FGR(v)), v->fgh[2]);
                 break;
             case DCASE(3, 4):
-                z.t = b ? folk(CP, folk(FGR(u), fs, v->fgh[1]), v->fgh[2])
-                        : folk(u->fgh[2], folk(FGL(u), fs, FGR(v)), v->fgh[2]);
+                z.t = b ? jtfolk(jt, CP, jtfolk(jt, FGR(u), fs, v->fgh[1]), v->fgh[2])
+                        : jtfolk(jt, u->fgh[2], jtfolk(jt, FGL(u), fs, FGR(v)), v->fgh[2]);
                 break;
             case DCASE(4, 2):
-                z.t = b ? folk(CP, folk(u->fgh[1], fs, RT), yt) : folk(u->fgh[2], folk(FGL(u), fs, RT), yt);
+                z.t = b ? jtfolk(jt, CP, jtfolk(jt, u->fgh[1], fs, RT), yt) : jtfolk(jt, u->fgh[2], jtfolk(jt, FGL(u), fs, RT), yt);
                 break;
             case DCASE(4, 3):
-                z.t = b ? folk(CP, folk(u->fgh[1], fs, FGR(v)), v->fgh[2])
-                        : folk(u->fgh[2], folk(FGL(u), fs, FGR(v)), v->fgh[2]);
+                z.t = b ? jtfolk(jt, CP, jtfolk(jt, u->fgh[1], fs, FGR(v)), v->fgh[2])
+                        : jtfolk(jt, u->fgh[2], jtfolk(jt, FGL(u), fs, FGR(v)), v->fgh[2]);
                 break;
             case DCASE(4, 4):
-                z.t = b ? folk(CP, folk(u->fgh[1], fs, v->fgh[1]), v->fgh[2])
-                        : folk(u->fgh[2], folk(FGL(u), fs, FGR(v)), v->fgh[2]);
+                z.t = b ? jtfolk(jt, CP, jtfolk(jt, u->fgh[1], fs, v->fgh[1]), v->fgh[2])
+                        : jtfolk(jt, u->fgh[2], jtfolk(jt, FGL(u), fs, FGR(v)), v->fgh[2]);
                 break;
-            case DCASE(0, 5): z.t = folk(v->fgh[0], folk(x.a, fs, v->fgh[1]), v->fgh[2]); break;
+            case DCASE(0, 5): z.t = jtfolk(jt, v->fgh[0], jtfolk(jt, x.a, fs, v->fgh[1]), v->fgh[2]); break;
             case DCASE(2, 5):
-                if (b || c) z.t = folk(v->fgh[0], folk(b ? RT : LF, fs, v->fgh[1]), v->fgh[2]);
+                if (b || c) z.t = jtfolk(jt, v->fgh[0], jtfolk(jt, b ? RT : LF, fs, v->fgh[1]), v->fgh[2]);
                 break;
             case DCASE(3, 5):
             case DCASE(4, 5):
-                if (b || c) z.t = folk(v->fgh[0], folk(b ? FGR(u) : FGL(u), fs, v->fgh[1]), v->fgh[2]);
+                if (b || c) z.t = jtfolk(jt, v->fgh[0], jtfolk(jt, b ? FGR(u) : FGL(u), fs, v->fgh[1]), v->fgh[2]);
                 break;
-            case DCASE(5, 0): z.t = folk(u->fgh[0], folk(y.a, sf, u->fgh[1]), u->fgh[2]); break;
+            case DCASE(5, 0): z.t = jtfolk(jt, u->fgh[0], jtfolk(jt, y.a, sf, u->fgh[1]), u->fgh[2]); break;
             case DCASE(5, 2):
-                if (b || c) z.t = folk(u->fgh[0], folk(u->fgh[1], fs, b ? RT : LF), yt);
+                if (b || c) z.t = jtfolk(jt, u->fgh[0], jtfolk(jt, u->fgh[1], fs, b ? RT : LF), yt);
                 break;
             case DCASE(5, 3):
             case DCASE(5, 4):
-                if (b || c) z.t = folk(u->fgh[0], folk(u->fgh[1], fs, b ? FGR(v) : FGL(v)), v->fgh[2]);
+                if (b || c) z.t = jtfolk(jt, u->fgh[0], jtfolk(jt, u->fgh[1], fs, b ? FGR(v) : FGL(v)), v->fgh[2]);
                 break;
             case DCASE(5, 5):
                 if (xi == yi && xj == yj || xi == yj && xj == yi)
                     if (b || v->fgh[1] == jtswapc(jt, v->fgh[1]))
-                        z.t = folk(u->fgh[0], folk(u->fgh[1], fs, v->fgh[1]), u->fgh[2]);
+                        z.t = jtfolk(jt, u->fgh[0], jtfolk(jt, u->fgh[1], fs, v->fgh[1]), u->fgh[2]);
                     else if (u->fgh[1] == jtswapc(jt, u->fgh[1]))
-                        z.t = folk(v->fgh[0], folk(u->fgh[1], fs, v->fgh[1]), v->fgh[2]);
+                        z.t = jtfolk(jt, v->fgh[0], jtfolk(jt, u->fgh[1], fs, v->fgh[1]), v->fgh[2]);
                     else
-                        z.t = folk(u->fgh[0], folk(u->fgh[1], fs, jtswap(jt, v->fgh[1])), u->fgh[2]);
+                        z.t = jtfolk(jt, u->fgh[0], jtfolk(jt, u->fgh[1], fs, jtswap(jt, v->fgh[1])), u->fgh[2]);
         }
         RZZ(z.t);
     }
@@ -301,7 +301,7 @@ jtvconj(J jt, I b, I e, TA *stack, A locsyms, I tmonad, I tsubst, TA *ttab, I *t
 TA
 jtvfolk(J jt, I b, I e, TA *stack, A locsyms, I tmonad, I tsubst, TA *ttab, I *ttabi, I ttabi0) {
     TA z = {0, 0};
-    if (CHK3) z.a = folk(stack[b].a, stack[1 + b].a, stack[e].a);
+    if (CHK3) z.a = jtfolk(jt, stack[b].a, stack[1 + b].a, stack[e].a);
     return z;
 }
 
@@ -331,7 +331,7 @@ jtvis(J jt, I b, I e, TA *stack, A locsyms, I tmonad, I tsubst, TA *ttab, I *tta
     DQ(j, if (jtequ(jt, t, u->a)) return z; ++u;);
     ea = stack[e].a;
     et = stack[e].t;
-    symbisdel(n, ea, locsyms);
+    jtsymbisdel(jt, n, ea, locsyms);
     ++*ttabi;
     u->a = t;
     u->t = et ? et : jtcfn(jt, ea);
@@ -383,7 +383,7 @@ jtvfinal(J jt, A w, I tmonad, I tsubst, TA *ttab, I *ttabi, I ttabi0) {
             v->fgh[0] = u->fgh[2];  // must be incorped already
         else if (CQQ == u->id && NOUN & AT(u->fgh[0]) && jtequ(jt, ainf, u->fgh[1]))
             v->fgh[0] = u->fgh[0];  // must be incorped already
-        if (NOUN & AT(v->fgh[0])) RZ(w = folk(v->fgh[0], v->fgh[1], v->fgh[2]));
+        if (NOUN & AT(v->fgh[0])) RZ(w = jtfolk(jt, v->fgh[0], v->fgh[1], v->fgh[2]));
     }
     return tine(w);
 }
@@ -446,9 +446,9 @@ jtvtrans(J jt, A w) {
         RZ(y = jtvtokens(jt, w));  // return AM bit0=monad
         I tmonad = AM(y);
         ttabi    = c;
-        RZ(locsyms = stcreate(2, 40, 0L, 0L));  // not necessary to set global pointers
-        symbis(mnuvxynam[5], num(1), locsyms);
-        if (!tmonad) symbis(mnuvxynam[4], num(1), locsyms);
+        RZ(locsyms = jtstcreate(jt, 2, 40, 0L, 0L));  // not necessary to set global pointers
+        jtsymbis(jt, mnuvxynam[5], num(1), locsyms);
+        if (!tmonad) jtsymbis(jt, mnuvxynam[4], num(1), locsyms);
         z = jttparse(jt, y, locsyms, tmonad, 0 == i, ttab, &ttabi, c);
         RESETERR;
         if (i && !z) z = jtcolon(jt, num(4 - tmonad), w);

--- a/jsrc/px.c
+++ b/jsrc/px.c
@@ -112,14 +112,14 @@ jtexg(J jt, A w) {
     GATV0(z, BOX, n, 1);
     v = AAV(z);
     DO(n, x = wv[i];
-       RZ(*v++ = (y = cex(x, jtfx, 0L)) ? y : jtexg(jt, x)););  // if the AR can be converted to an A, do so; otherwise
+       RZ(*v++ = (y = jtcex(jt, x, jtfx, 0L)) ? y : jtexg(jt, x)););  // if the AR can be converted to an A, do so; otherwise
                                                                 // it should be a list of ARs, recur on each
     return jtparse(jt, z);
 }
 
 L*
 jtjset(J jt, C* name, A x) {
-    return symbisdel(jtnfs(jt, (I)strlen(name), name), x, jt->global);
+    return jtsymbisdel(jt, jtnfs(jt, (I)strlen(name), name), x, jt->global);
 }
 
 A

--- a/jsrc/representations/r.c
+++ b/jsrc/representations/r.c
@@ -189,7 +189,7 @@ jtfx(J jt, A w, A self) {
             ASSERT(AT(g) & VERB, EVSYNTAX);
             RZ(h = fx(yv[2]));
             ASSERT(AT(h) & VERB, EVSYNTAX);
-            return folk(f, g, h);
+            return jtfolk(jt, f, g, h);
         default:
             if (id) fs = ds(id);
             ASSERT(fs && RHS & AT(fs), EVDOMAIN);
@@ -444,8 +444,8 @@ jtunparse1a(J jt, I m, A *hv, A *zv) {
     j = k = -1;
     for (i = 0; i < m; ++i, ++u) {  // for each word
         RZ(
-          x = unparse1(
-            u, vec(BOX, u->n, v + u->i), j, y));  // append new line to y or else return it as x if it is on a new line.
+          x = jtunparse1(jt, 
+            u, jtvec(jt, BOX, u->n, v + u->i), j, y));  // append new line to y or else return it as x if it is on a new line.
         k = u->source;
         if (j < k) {
             if (y) *zv++ = jtunDD(jt, y);
@@ -482,9 +482,9 @@ jtunparsem(J jt, A a, A w) {
         if (n) dn = 1 + ((CW *)AV(dc) + n - 1)->source;
         GATV0(z, BOX, p + mn + dn, 1);
         zu = zv = AAV(z);
-        RZ(zv = unparse1a(m, hv, zv));
+        RZ(zv = jtunparse1a(jt, m, hv, zv));
         if (p) RZ(*zv++ = chrcolon);
-        RZ(zv = unparse1a(n, hv + HN, zv));
+        RZ(zv = jtunparse1a(jt, n, hv + HN, zv));
         ASSERTSYS(AN(z) == zv - zu, "unparsem zn");
     } else {
         // commented text found.  Use it
@@ -533,8 +533,8 @@ jtxrep(J jt, A a, A w) {
         q[0] = u->type;
         q[1] = u->go;
         q[2] = u->source;
-        RZ(*zv++ = jtincorp(jt, vec(INT, 3L, q)));
-        RZ(*zv++ = jtincorp(jt, unparse1(u, vec(BOX, u->n, v + u->i), -1L, 0L)));
+        RZ(*zv++ = jtincorp(jt, jtvec(jt, INT, 3L, q)));
+        RZ(*zv++ = jtincorp(jt, jtunparse1(jt, u, jtvec(jt, BOX, u->n, v + u->i), -1L, 0L)));
     }
     return z;
 } /* explicit representation -- h parameter for : definitions */

--- a/jsrc/representations/rl.c
+++ b/jsrc/representations/rl.c
@@ -208,7 +208,7 @@ jtlchar(J jt, A w, A *ltext) {
     if (!p) {  // if the string contains a nonprintable, represent it as nums { a.
         k = (UC)d;
         RZ(y = jtindexof(jt, ds(CALP), w));
-        if (r1 && n < m && (!k || k == m - n) && jtequ(jt, y, apv(n, k, 1L)))
+        if (r1 && n < m && (!k || k == m - n) && jtequ(jt, y, jtapv(jt, n, k, 1L)))
             return jtover(jt, jtthorn1(jt, jtsc(jt, d ? -n : n)), jtcstr(jt, "{.a."));
         RZ(y = lnum(y));
         return jtlp(jt, y) ? jtover(jt, jtcstr(jt, "a.{~"), y) : jtover(jt, y, jtcstr(jt, "{a."));

--- a/jsrc/representations/rt.c
+++ b/jsrc/representations/rt.c
@@ -16,10 +16,10 @@ jttrc(J jt, A w) {
     s  = AS(w);
     v  = AAV(w);
     xn = s[0];
-    RZ(x = apvwr(xn, 0L, 0L));
+    RZ(x = jtapvwr(jt, xn, 0L, 0L));
     xv = AV(x);
     yn = s[1];
-    RZ(y = apvwr(yn, 0L, 0L));
+    RZ(y = jtapvwr(jt, yn, 0L, 0L));
     yv = AV(y);
     j  = 0;
     DO(xn, xv[i] = SETIC(v[j], k); j += yn;);
@@ -100,7 +100,7 @@ jtgraft(J jt, A w) {
         memset(v, ' ', AN(q));
         pv[1] = yv[j];
         k     = j - yn;
-        DO(xn, *pv = xv[i]; RE(v += pad(p, u[k += yn], v)););
+        DO(xn, *pv = xv[i]; RE(v += jtpad(jt, p, u[k += yn], v)););
         zv[j] = jtincorp(jt, q);
     }
     t = zv[0];
@@ -187,7 +187,7 @@ jttroot(J jt, A a, A w) {
           k = i;
           break;
       } u -= n;);
-    return link(center(x, j, k, m), w);
+    return link(jtcenter(jt, x, j, k, m), w);
 }
 
 static A

--- a/jsrc/result.h
+++ b/jsrc/result.h
@@ -187,7 +187,7 @@ do {
                                                // filled yet in this cell make negative to tell ccvt that the value to
                                                // change are at the end of the block
 #endif
-                            ASSERT(ccvt(zt | NOUNCVTVALIDCT, zz, (A *)&zatomct), EVDOMAIN);
+                            ASSERT(jtccvt(jt, zt | NOUNCVTVALIDCT, zz, (A *)&zatomct), EVDOMAIN);
                             zz = (A)zatomct;  // flag means convert only # atoms given in zatomct
                             // change the strides to match the new cellsize
                             if (zexpshift >= 0) {
@@ -484,7 +484,7 @@ if (ZZFLAGWORD & ZZFLAGWILLBEOPENED) { return zz; }  // no need to check for inh
 ASSERT((ZZFLAGWORD & (ZZFLAGHASUNBOX | ZZFLAGHASBOX)) != (ZZFLAGHASUNBOX | ZZFLAGHASBOX),
        EVDOMAIN);  // if there is a mix of boxed and non-boxed results, fail
 if (ZZFLAGWORD & ZZFLAGBOXALLO) {
-    RZ(zz = assembleresults(ZZFLAGWORD,
+    RZ(zz = jtassembleresults(jt, ZZFLAGWORD,
                             zz,
                             zzbox,
                             zzboxp,

--- a/jsrc/sc.c
+++ b/jsrc/sc.c
@@ -39,14 +39,14 @@ jtunquote(J jt, A a, A w, A self) {
             if (!(thisnameinfo->flag & (NMLOC | NMILOC | NMIMPLOC))) {  // simple name, and not u./v.
                 explocale = 0;                                          // flag no explicit locale
                 if (!(stabent = jtprobelocal(jt, thisname, jt->locsyms)))
-                    stabent = syrd1(thisnameinfo->m,
+                    stabent = jtsyrd1(jt, thisnameinfo->m,
                                     thisnameinfo->s,
                                     thisnameinfo->hash,
                                     jt->global);         // Try local, then look up the name starting in jt->global
             } else {                                     // locative or u/v
                 if (!(thisnameinfo->flag & NMIMPLOC)) {  // locative
                     RZ(explocale = jtsybaseloc(jt, thisname));  //  get the explicit locale.  0 if erroneous locale
-                    stabent = syrd1(thisnameinfo->m,
+                    stabent = jtsyrd1(jt, thisnameinfo->m,
                                     thisnameinfo->s,
                                     thisnameinfo->hash,
                                     explocale);  // Look up the name starting in the locale of the locative
@@ -133,7 +133,7 @@ jtunquote(J jt, A a, A w, A self) {
     } else {
         // Extra processing is required.  Check each option individually
         if (PMCTRBPMON & jt->uflags.us.uq.uq_c.pmctrbstk)
-            pmrecord(thisname,
+            jtpmrecord(jt, thisname,
                      jt->global ? LOCNAME(jt->global) : 0,
                      -1L,
                      dyadex ? VAL2 : VAL1);  // Record the call to the name, if perf monitoring on
@@ -146,7 +146,7 @@ jtunquote(J jt, A a, A w, A self) {
             jt->recurstate <
               RECSTATEPROMPT) {  // The verb is locked if it is marked as locked, or if the script is locked; if
                                  // recursive JDo, can't enter debug suspension so ignore debug
-            z = dbunquote(dyadex ? a : 0,
+            z = jtdbunquote(jt, dyadex ? a : 0,
                           dyadex ? w : a,
                           fs,
                           stabent);  // if debugging, go do that.  save last sym lookup as debug parm
@@ -160,7 +160,7 @@ jtunquote(J jt, A a, A w, A self) {
             fa(fs);
         }
         if (PMCTRBPMON & jt->uflags.us.uq.uq_c.pmctrbstk)
-            pmrecord(thisname,
+            jtpmrecord(jt, thisname,
                      jt->global ? LOCNAME(jt->global) : 0,
                      -2L,
                      dyadex ? VAL2 : VAL1);                    // record the return from call
@@ -262,7 +262,7 @@ jtunquote(J jt, A a, A w, A self) {
 // The monad calls the bivalent case with (w,self,self) so that the inputs can pass through to the executed function
 static A
 jtunquote1(J jt, A w, A self) {
-    return unquote(w, self, self);
+    return jtunquote(jt, w, self, self);
 }  // This just transfers to jtunquote.  It passes jt, with inplacing bits, unmodified
 
 // return ref to adv/conj/verb whose name is a and whose symbol-table entry is w
@@ -347,5 +347,5 @@ jtimplocref(J jt, A a, A w, A self) {
     self = AT(w) & NOUN ? self : w;
     self = jt->implocref[FAV(self)->id & 1];
     w    = AT(w) & NOUN ? w : self;
-    return unquote(a, w, self);  // call as (w,self,self) or (a,w,self)
+    return jtunquote(jt, a, w, self);  // call as (w,self,self) or (a,w,self)
 }

--- a/jsrc/sc.c
+++ b/jsrc/sc.c
@@ -286,7 +286,7 @@ jtnamerefacv(J jt, A a, L* w) {
     // result, and we just set INPLACE for everything and let unquote use the up-to-date value. ASGSAFE has a similar
     // problem, and that's more serious, because unquote is too late to stop the inplacing.  We try to ameliorate the
     // problem by making [: unsafe.
-    A z = fdef(0,
+    A z = jtfdef(jt, 0,
                CTILDE,
                AT(y),
                jtunquote1,
@@ -330,7 +330,7 @@ A
 jtnamerefop(J jt, A a, A w) {
     V* v;
     v = FAV(w);
-    return fdef(0, CCOLON, VERB, jtunquote1, jtunquote, 0L, a, w, VXOPCALL | v->flag, v->mr, lrv(v), rrv(v));
+    return jtfdef(jt, 0, CCOLON, VERB, jtunquote1, jtunquote, 0L, a, w, VXOPCALL | v->flag, v->mr, lrv(v), rrv(v));
 }
 
 /* jtnamerefop(jt,) is used by explicit defined operators when: */

--- a/jsrc/sn.c
+++ b/jsrc/sn.c
@@ -371,13 +371,13 @@ jtnch(J jt, A w) {
             if (*e) {
                 d = *e + LAV0(jt->symp);
                 while (1) {
-                    RZ(ch = nch1(b, d->val, &m, ch));
+                    RZ(ch = jtnch1(jt, b, d->val, &m, ch));
                     if (!d->next) break;
                     d = d->next + LAV0(jt->symp);
                 }
             }
         // now numbered locales
-        DO(jtcountnl(jt), A loc = jtindexnl(jt, i); if (loc) RZ(ch = nch1(b, loc, &m, ch)););
+        DO(jtcountnl(jt), A loc = jtindexnl(jt, i); if (loc) RZ(ch = jtnch1(jt, b, loc, &m, ch)););
     }
     jt->stch = b;
     AN(ch) = AS(ch)[0] = m;
@@ -425,7 +425,7 @@ jtex(J jt, A w) {
             }
             if (!(v->name->flag & NMDOT) && v->val && AT(v->val) & (VERB | ADV | CONJ))
                 modifierchg = 1;  // if we delete a modifier, remember that fact
-            probedel(NAV(v->name)->m,
+            jtprobedel(jt, NAV(v->name)->m,
                      NAV(v->name)->s,
                      NAV(v->name)->hash,
                      locfound);  // delete the symbol (incl name and value) in the locale in which it is defined

--- a/jsrc/u.c
+++ b/jsrc/u.c
@@ -117,7 +117,7 @@ jtapv(J jt, I n, I b, I m) {
         AFLAG(z) = AFRO;  // mark block readonly and not inplaceable
         return z;
     }
-    return apvwr(n, b, m);
+    return jtapvwr(jt, n, b, m);
 } /* b+m*i.n */
 // same, but never return a readonly block
 A

--- a/jsrc/verbs/dyadic/take_drop.cpp
+++ b/jsrc/verbs/dyadic/take_drop.cpp
@@ -79,7 +79,7 @@ jttks(J jt, array a, array w) { // take_sparse
 
     if (b) {
         jt->fill = SPA(wp, e);
-        x        = irs2(vec(INT, r - m, m + u), SPA(wp, x), 0L, 1L, -1L, reinterpret_cast<AF>(jttake));
+        x        = jtirs2(jt, jtvec(jt, INT, r - m, m + u), SPA(wp, x), 0L, 1L, -1L, reinterpret_cast<AF>(jttake));
         jt->fill = 0;
         RZ(x);
     }  // fill cannot be virtual
@@ -160,7 +160,7 @@ jttk(J jt, A a, A w) {
               b = 1;
               break;
           });                                         // if empty take, or take from empty cell, set b
-    if (((b - 1) & AN(w)) == 0) return tk0(b, a, w);  // this handles empty w, so PROD OK below   b||!AN(w)
+    if (((b - 1) & AN(w)) == 0) return jttk0(jt, b, a, w);  // this handles empty w, so PROD OK below   b||!AN(w)
     k = bpnoun(t);
     z = w;
     c = q = 1;  // c will be #cells for this axis
@@ -427,7 +427,7 @@ jthead(J jt, A w) {
             return jtfrom(jtinplace, zeroionei(0), w);  // could call jtfromi directly for non-sparse w
         }
     } else {
-        return SPARSE & AT(w) ? irs2(num(0), jttake(jt, num(1), w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))
+        return SPARSE & AT(w) ? jtirs2(jt, num(0), jttake(jt, num(1), w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))
                               : jtrsh0(jt, w);  // cell of w is empty - create a cell of fills  jt->ranks is still set
                                                 // for use in take.  Left rank is garbage, but that's OK
     }
@@ -445,7 +445,7 @@ jttail(J jt, A w) {
     return !wcr || AS(w)[wf] ? jtfrom(jtinplace, num(-1), w)
                              :  // if cells are atoms, or if the cells are nonempty arrays, result is last cell(s) scaf
                                 // should generate virtual block here for speed
-             SPARSE & AT(w) ? irs2(num(0), jttake(jt, num(-1), w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))
+             SPARSE & AT(w) ? jtirs2(jt, num(0), jttake(jt, num(-1), w), 0L, 0L, wcr, reinterpret_cast<AF>(jtfrom))
                             : jtrsh0(jt, w);
     // pristinity from other verbs
 }

--- a/jsrc/verbs/dyadic/take_drop.cpp
+++ b/jsrc/verbs/dyadic/take_drop.cpp
@@ -60,7 +60,7 @@ jttks(J jt, array a, array w) { // take_sparse
     wp = PAV(w); // pointer to array values
 
     if (an <= r) {
-        RZ(a = vec(INT, r, s));
+        RZ(a = jtvec(jt, INT, r, s));
         MCISH(AV(a), u, an);
     }  // vec is not virtual
 
@@ -278,7 +278,7 @@ jttake(J jt, A a, A w) {
     }
     // full processing for more complex a
     if ((-wcr & (wf - 1)) >= 0) {  // if y is an atom, or y has multiple cells:
-        RZ(s = vec(INT, wf + n, AS(w)));
+        RZ(s = jtvec(jt, INT, wf + n, AS(w)));
         v = wf + AV(s);  // s is a block holding shape of a cell of input to the result: w-frame followed by #$a axes,
                          // all taken from w.  vec is never virtual
         if (!wcr) {
@@ -386,7 +386,7 @@ jtrsh0(J jt, A w) {
     wf  = wr - wcr;
     RESETRANK;
     ws = AS(w);
-    RZ(x = vec(INT, wr - 1, ws));
+    RZ(x = jtvec(jt, INT, wr - 1, ws));
     MCISH(wf + AV(x), ws + wf + 1, wcr - 1);
     RZ(w = jtsetfv(jt, w, w));
     GA(y, AT(w), 1, 0, 0);

--- a/jsrc/verbs/v.c
+++ b/jsrc/verbs/v.c
@@ -77,7 +77,7 @@ jtravel(J jt, A w) {
     AS(z)[f] = m;  // allocate result area, shape=frame+1 more to hold size of cell; fill in shape
     wp       = PAV(w);
     zp       = PAV(z);
-    RZ(b = bfi(AR(w), SPA(wp, a), 1));
+    RZ(b = jtbfi(jt, AR(w), SPA(wp, a), 1));
     if (memchr(b + f, C1, r)) {
         if (memchr(b + f, C0, r)) {
             memset(b + f, C1, r);
@@ -153,7 +153,7 @@ jtlr2(J jt, RANK2T ranks, A a, A w) {
     if (wf >= af) { return w; }  // no replication - quick out
     RESETRANK;
     return jtreitem(
-      jt, vec(INT, af - wf, AS(a)), jtlamin1(jt, w));  // could use virtual block, but this case is so rare...
+      jt, jtvec(jt, INT, af - wf, AS(a)), jtlamin1(jt, w));  // could use virtual block, but this case is so rare...
 }
 
 A
@@ -161,14 +161,14 @@ jtleft2(J jt, A a, A w) {
     FPREFIP;
     RANK2T jtr = jt->ranks;
     if (jtr == (RANK2T)~0) a;
-    return lr2((jtr << RMAXX) | (jtr >> RMAXX), w, a);
+    return jtlr2(jt, (jtr << RMAXX) | (jtr >> RMAXX), w, a);
 }  // swap a & w, and their ranks
 A
 jtright2(J jt, A a, A w) {
     FPREFIP;
     RANK2T jtr = jt->ranks;
     if (jtr == (RANK2T)~0) w;
-    return lr2(jtr, a, w);
+    return jtlr2(jt, jtr, a, w);
 }
 
 // i. y
@@ -184,7 +184,7 @@ jtiota(J jt, A w) {
     v = AV(w);
     if (1 == n) {
         m = *v;
-        return 0 > m ? apv(-m, -m - 1, -1L) : IX(m);
+        return 0 > m ? jtapv(jt, -m, -m - 1, -1L) : IX(m);
     }
     A mg;
     RZ(mg = mag(w));
@@ -213,10 +213,10 @@ jtjico1(J jt, A w) {
     b = FFIEQ(d, n);
     c = (2 * ABS(n)) / (m ? m : 1);  // try as integer
     if (b && m * c == 2 * ABS(n))
-        z = apv(1 + m, -n, 0 > d ? -c : c);  // if integer works, use it
+        z = jtapv(jt, 1 + m, -n, 0 > d ? -c : c);  // if integer works, use it
     else
         z = plusW(jtscf(jt, 0 > d ? d : -d),
-                  tymesW(jtscf(jt, 2 * ABS(d) / m), apv(1 + m, 0 > d ? m : 0L, 0 > d ? -1L : 1L)));  // otherwise FL
+                  tymesW(jtscf(jt, 2 * ABS(d) / m), jtapv(jt, 1 + m, 0 > d ? m : 0L, 0 > d ? -1L : 1L)));  // otherwise FL
     if (AT(w) & XNUM + RAT)
         z = jtcvt(jt, AT(w) & XNUM || jtequ(jt, w, floor1(w)) ? XNUM : RAT, z);  // cvrt to XNUM as needed
     return z;
@@ -299,7 +299,7 @@ jtcharmap(J jt, A w, A x, A y) {
     if (((k - 1) & (n - AN(y))) >= 0)
         DQ(wn, c = *u++; ASSERT(bb[c], EVINDEX);
            *v++ = zz[c];)  // not all codes mapped AND #x>=#y, meaning index error possible on {
-    else if (!bitwisecharamp(zz, wn, u, v))
+    else if (!jtbitwisecharamp(jt, zz, wn, u, v))
         DQ(wn, *v++ = zz[*u++];);  // no index error possible, and special case not handled
     return z;
 } /* y {~ x i. w */

--- a/jsrc/verbs/v1.c
+++ b/jsrc/verbs/v1.c
@@ -387,7 +387,7 @@ jtmatch(J jt, A a, A w) {
     PROD(n, wf - af, AS(w) + af);
     mn = m * n;  // total number of matches to do, i. e. # results
     GATV(z, B01, mn, wf, AS(w));
-    matchsub(a, w, BAV(z), af, wf, m, n, eqis0 ^ 1);  // matchsub stores, and we ignore the result
+    jtmatchsub(jt, a, w, BAV(z), af, wf, m, n, eqis0 ^ 1);  // matchsub stores, and we ignore the result
     // We do not check for a==w here & thus will compare them
     return z;
 } /* a -:"r w */

--- a/jsrc/verbs/v2.c
+++ b/jsrc/verbs/v2.c
@@ -415,7 +415,7 @@ jtnextprime(J jt, A w) {
               b = 0;
               break;
           } else *xv++ = 2 > k ? 2 : (k + 1) | 1;);
-        if (b) return rank1ex0(x, fs, FAV(fs)->valencefns[0]);
+        if (b) return jtrank1ex0(jt, x, fs, FAV(fs)->valencefns[0]);
         RZ(w = jtcvt(jt, XNUM, w));
     }
     if (AT(w) & FL + RAT) RZ(w = jtcvt(jt, XNUM, floor1(w)));
@@ -425,7 +425,7 @@ jtnextprime(J jt, A w) {
     wv = XAV(w);
     DQ(n, y = *wv++; yv = AV(y); *bv++ = 0 < yv[AN(y) - 1]; k = *yv;
        *xv++ = AN(y) == 1 && 2 > k ? 2 - k : (k & 1) + 1;);
-    return rank1ex0(tymes(b, plus(w, x)), fs, FAV(fs)->valencefns[0]);
+    return jtrank1ex0(jt, tymes(b, plus(w, x)), fs, FAV(fs)->valencefns[0]);
 }
 
 static A
@@ -441,14 +441,14 @@ jtprevprime(J jt, A w) {
     if (INT & AT(w)) {
         I *wv = AV(w);
         DQ(n, k = *wv++; ASSERT(2 < k, EVDOMAIN); *xv++ = 3 == k ? 2 : (k - 2) | 1;);
-        return rank1ex0(x, fs, FAV(fs)->valencefns[0]);
+        return jtrank1ex0(jt, x, fs, FAV(fs)->valencefns[0]);
     }
     if (AT(w) & FL + RAT) RZ(w = jtcvt(jt, XNUM, ceil1(w)));
     if (AT(w) & CMPX) RZ(w = jtcvt(jt, XNUM, ceil1(jtcvt(jt, FL, w))));
     wv = XAV(w);
     DQ(n, y = *wv++; yv = AV(y); m = AN(y); k = *yv; ASSERT(0 < yv[m - 1] && (1 < m || 2 < k), EVDOMAIN);
        *xv++ = 1 == m && 3 == k ? 1 : 1 + (k & 1););
-    return rank1ex0(minus(w, x), fs, FAV(fs)->valencefns[0]);
+    return jtrank1ex0(jt, minus(w, x), fs, FAV(fs)->valencefns[0]);
 }
 
 static A
@@ -558,11 +558,11 @@ jtdetmr(J jt, A w) {
             d >>= 1;
         }
         if (n < 9080191)
-            *zv++ = spspd(31, n, d, h) && spspd(73, n, d, h);
+            *zv++ = jtspspd(jt, 31, n, d, h) && jtspspd(jt, 73, n, d, h);
         else if (n < 94906266)
-            *zv++ = spspd(2, n, d, h) && spspd(7, n, d, h) && spspd(61, n, d, h);
+            *zv++ = jtspspd(jt, 2, n, d, h) && jtspspd(jt, 7, n, d, h) && jtspspd(jt, 61, n, d, h);
         else
-            *zv++ = spspx(2, n, d, h) && spspx(7, n, d, h) && spspx(61, n, d, h);
+            *zv++ = jtspspx(jt, 2, n, d, h) && jtspspx(jt, 7, n, d, h) && jtspspx(jt, 61, n, d, h);
     }
     RE(0);
     return z;
@@ -611,7 +611,7 @@ jtqco2x(J jt, I m, A w) {
         c   = 0;
         *dv = pv[i];
         while (1) {
-            RZ(xdivrem(x, d, &q, &r));
+            RZ(jtxdivrem(jt, x, d, &q, &r));
             if (AV(r)[0]) break;
             ++c;
             x = q;
@@ -631,7 +631,7 @@ jtqco2(J jt, A a, A w) {
     wr = AR(w);
     b  = all1(lt(a, zeroionei(0)));
     xt = 1 && AT(w) & XNUM + RAT;
-    if (AR(a) || wr && (b || xt)) return rank2ex0(a, w, UNUSED_VALUE, jtqco2);
+    if (AR(a) || wr && (b || xt)) return jtrank2ex0(jt, a, w, UNUSED_VALUE, jtqco2);
     if (!b && xt) {
         RE(m = jti0(jt, jtvib(jt, a)));
         if (BETWEENO(m, 0, 1229)) return jtqco2x(jt, m, w);
@@ -725,7 +725,7 @@ jtxprimeq(J jt, I n, X y) {
     RZ(m = y1 = jtxminus(jt, y, iv1));
     while (0 == (AV(m)[0] & 1)) {
         ++k;
-        RZ(m = xdiv(m, t, XMFLR));
+        RZ(m = jtxdiv(jt, m, t, XMFLR));
     }
     GAT0(d, INT, 1, 1);
     dv     = AV(d);  // could use faux block

--- a/jsrc/verbs/va1.c
+++ b/jsrc/verbs/va1.c
@@ -212,7 +212,7 @@ jtva1(J jt, A w, A self) {
         RESETERR;
     }
     if (ado == 0) return w;                                           // if function is identity, return arg
-    if ((-(AT(w) & SPARSE) & -n) < 0) return va1s(w, self, cv, ado);  // branch off to do sparse
+    if ((-(AT(w) & SPARSE) & -n) < 0) return jtva1s(jt, w, self, cv, ado);  // branch off to do sparse
     // from here on is dense va1
     t  = atype(cv);
     zt = rtype(cv);  // extract required type of input and result

--- a/jsrc/verbs/va2.c
+++ b/jsrc/verbs/va2.c
@@ -1151,12 +1151,12 @@ jtva2(J jt, AD *RESTRICT a, AD *RESTRICT w, AD *RESTRICT self, UI allranks) {  /
 
             // Figure out the result type.  Don't signal the error from it yet, because domain has lower priority than
             // agreement
-            adocv  = var(self, at, wt);
+            adocv  = jtvar(jt, self, at, wt);
             aadocv = &adocv;
         }
     }
 
-    // finish up the computation of sizes.  We have to defer this till after var() because
+    // finish up the computation of sizes.  We have to defer this till after jtvar(jt, ) because
     // if we are retrying the operation, we may be in error state until var clears it; and prod and mult can fail,
     // so we have to RE when we call them
 
@@ -1401,7 +1401,7 @@ jtva2(J jt, AD *RESTRICT a, AD *RESTRICT w, AD *RESTRICT self, UI allranks) {  /
     }
 
     RESETRANK;  // Ranks are required for xnum/rat/sparse, which call IRS-enabled routines internally.  We could
-                // suppress this for mainline types, perhaps in var().  Anyone who sets this must set it back, so it's
+                // suppress this for mainline types, perhaps in jtvar(jt, ).  Anyone who sets this must set it back, so it's
                 // OK that we don't clear it if we have error
 
     // Signal domain error if appropriate. Must do this after agreement tests
@@ -1410,7 +1410,7 @@ jtva2(J jt, AD *RESTRICT a, AD *RESTRICT w, AD *RESTRICT self, UI allranks) {  /
                            // Not sparse.
 
         // If op specifies forced input conversion AND if both arguments are non-sparse: convert them to the selected
-        // type. Incompatible arguments were detected in var().  If there is an empty operand, skip conversions which
+        // type. Incompatible arguments were detected in jtvar(jt, ).  If there is an empty operand, skip conversions which
         // might fail because the type in t is incompatible with the actual type in a.  t is rare.
         //
         // Because of the priority of errors we mustn't check the type until we have verified agreement above
@@ -1625,7 +1625,7 @@ jtva2(J jt, AD *RESTRICT a, AD *RESTRICT w, AD *RESTRICT self, UI allranks) {  /
                 jt->jerr = (UC)rc;
         }
     } else {
-        z = vasp(a,
+        z = jtvasp(jt, a,
                  w,
                  FAV(self)->id,
                  aadocv->f,
@@ -1990,7 +1990,7 @@ jtfslashatg(J jt, A a, A w, A self) {
     CCM(w, CGE) + CCM(w, CLE) + CCM(w, CGT) + CCM(w, CLT) + CCM(w, CPLUSCO) + CCM(w, CSTARCO) + CCM(w, CNE) + \
       CCM(w, CEQ) + CCM(w, CSTARDOT) + CCM(w, CPLUSDOT) + CCM(w, CMIN) + CCM(w, CMAX) + CCM(w, CSTAR)
             CCMWDS(sumbf)
-            CCMCAND(sumbf, cand, d) if (CCMTST(cand, d)) return sumatgbool(
+            CCMCAND(sumbf, cand, d) if (CCMTST(cand, d)) return jtsumatgbool(jt, 
               a, w, d);  // quickly handle verbs that have primitive inverses
         }
         if (d == CSTAR) {
@@ -2002,11 +2002,11 @@ jtfslashatg(J jt, A a, A w, A self) {
                 return jtsumattymes(jt, a, w, b, at, m, n, nn, r, s, zn);  // +/@:*
         }
     }
-    adocv = var(gs, at, wt);
+    adocv = jtvar(jt, gs, at, wt);
     ASSERT(adocv.f, EVDOMAIN);
     yt     = rtype(adocv.cv);
     t      = atype(adocv.cv);
-    adocvf = var(y, yt, yt);
+    adocvf = jtvar(jt, y, yt, yt);
     ASSERT(adocvf.f, EVDOMAIN);
     zt = rtype(adocvf.cv);
     sb = yt & (c == CPLUS);  // +/@:g where g produces Boolean.

--- a/jsrc/verbs/va2s.c
+++ b/jsrc/verbs/va2s.c
@@ -16,13 +16,13 @@ jtvaspc(J jt, A a, A w, C id, VF ado, I cv, I t, I zt, I af, I acr, I wf, I wcr,
     v = AV(q);
     if (r > acr) {
         ICPY(v, wf + ws, r);
-        RZ(a = irs2(vec(INT, r - acr, acr + v), a, 0L, 1L, 0L, jtreshape));
+        RZ(a = jtirs2(jt, jtvec(jt, INT, r - acr, acr + v), a, 0L, 1L, 0L, jtreshape));
     }
     if (r > wcr) {
         ICPY(v, af + as, r);
-        RZ(w = irs2(vec(INT, r - wcr, wcr + v), w, 0L, 1L, 0L, jtreshape));
+        RZ(w = jtirs2(jt, jtvec(jt, INT, r - wcr, wcr + v), w, 0L, 1L, 0L, jtreshape));
     }
-    return vasp(a, w, id, ado, cv, t, zt, af, r, wf, r, f, r);
+    return jtvasp(jt, a, w, id, ado, cv, t, zt, af, r, wf, r, f, r);
 } /* prefix agreement on cells */
 
 A
@@ -122,8 +122,8 @@ static B jtvaspprep(J jt,A a,A w,I t,I af,I acr,I wf,I wcr,I f,I r,A*ae,A*ay,A*a
  if(sw){wp=PAV(w); wa=SPA(wp,a); v=AV(wa); d=f-wf; DO(AN(wa), c=v[i]; if(wf<=c)b[c+d]=1;);}
  GATV0(x,INT,f+r,1); u=AV(x); m=0; DO(af, if(b[i])u[m++]=i;); DO(acr, if(b[f+i])u[m++]=af+i;);
  GATV0(x,INT,f+r,1); v=AV(x); n=0; DO(wf, if(b[i])v[n++]=i;); DO(wcr, if(b[f+i])v[n++]=wf+i;);
- if(!sa||m!=AN(aa)||memcmp(u,AV(aa),m*SZI))RZ(a=jtreaxis(jt,vec(INT,m,u),a));
- if(!sw||n!=AN(wa)||memcmp(v,AV(wa),n*SZI))RZ(w=jtreaxis(jt,vec(INT,n,v),w));
+ if(!sa||m!=AN(aa)||memcmp(u,AV(aa),m*SZI))RZ(a=jtreaxis(jt,jtvec(jt, INT,m,u),a));
+ if(!sw||n!=AN(wa)||memcmp(v,AV(wa),n*SZI))RZ(w=jtreaxis(jt,jtvec(jt, INT,n,v),w));
  ap=PAV(a); *ae=e=SPA(ap,e); *ay=SPA(ap,i); *ax=x=SPA(ap,x); if(t&&TYPESNE(t,AT(x))){RZ(*ae=jtcvt(jt,t,e));
 RZ(*ax=jtcvt(jt,t,x));} wp=PAV(w); *we=e=SPA(wp,e); *wy=SPA(wp,i); *wx=x=SPA(wp,x);
 if(t&&TYPESNE(t,AT(x))){RZ(*we=jtcvt(jt,t,e)); RZ(*wx=jtcvt(jt,t,x));} RZ(*za=jtifb(jt,f+r,b)); return 1;
@@ -236,7 +236,7 @@ jtvaspeq(J jt, A a, A w, C id, VF ado, I cv, I t, I zt, I f, I r) {
     I ak, c, d, i, j, m, n, *u, *v, wk, xc, yc, zk, *zyv;
     P *zp;
     I rc = EVOK;
-    RZ(vaspeqprep(a, w, t, f, r, &ae, &ay, &ax, &we, &wy, &wx, &za));
+    RZ(jtvaspeqprep(jt, a, w, t, f, r, &ae, &ay, &ax, &we, &wy, &wx, &za));
     if (id == CSTAR || id == CSTARDOT) {
         ab = !jtequ(jt, ae, num(0));
         wb = !jtequ(jt, we, num(0));
@@ -329,12 +329,12 @@ jtvaspeq(J jt, A a, A w, C id, VF ado, I cv, I t, I zt, I f, I r) {
 A
 jtvasp(J jt, A a, A w, C id, VF ado, I cv, I t, I zt, I af, I acr, I wf, I wcr, I f, I r) {
     A fs, z;
-    if (!AR(a) || !AR(w)) return vasp0(a, w, ado, cv, t, zt);
-    if ((SPARSE & AT(a) || SPARSE & AT(w)) && spmult(&z, a, w, id, af, acr, wf, wcr)) return z;
+    if (!AR(a) || !AR(w)) return jtvasp0(jt, a, w, ado, cv, t, zt);
+    if ((SPARSE & AT(a) || SPARSE & AT(w)) && jtspmult(jt, &z, a, w, id, af, acr, wf, wcr)) return z;
     if (af != wf) {
         RZ(fs = ds(id));
-        return sprank2(a, w, fs, acr, wcr, VAV(fs)->valencefns[1]);
+        return jtsprank2(jt, a, w, fs, acr, wcr, VAV(fs)->valencefns[1]);
     }
-    if (acr != wcr) return vaspc(a, w, id, ado, cv, t, zt, af, acr, wf, wcr, f, r);
-    return vaspeq(a, w, id, ado, cv, t, zt, f, r);
+    if (acr != wcr) return jtvaspc(jt, a, w, id, ado, cv, t, zt, af, acr, wf, wcr, f, r);
+    return jtvaspeq(jt, a, w, id, ado, cv, t, zt, f, r);
 } /* scalar dyadic fns with one or both arguments sparse */

--- a/jsrc/verbs/vb.c
+++ b/jsrc/verbs/vb.c
@@ -215,7 +215,7 @@ jtebar(J jt, A a, A w) {
     ASSERT(!((AT(a) | AT(w)) & SPARSE), EVNONCE);
     ASSERT((AR(a) == AR(w)) || (AR(a) + (AR(w) ^ 1)) == 0, EVRANK);
     if (AN(a) == 1) return eq(jtreshape(jt, mtv, a), w);  // if a is a singleton, just revert to =
-    RE(d = ebarprep(a, w, &a, &w, &c));
+    RE(d = jtebarprep(jt, a, w, &a, &w, &c));
     av = CAV(a);
     m  = AN(a);
     wv = CAV(w);
@@ -265,7 +265,7 @@ jti1ebar(J jt, A a, A w) {
     C *av, *wv;
     I c, d, i, k = 0, m, n, p, *yv;
 
-    RE(d = ebarprep(a, w, &a, &w, &c));
+    RE(d = jtebarprep(jt, a, w, &a, &w, &c));
     av = CAV(a);
     m  = AN(a);
     wv = CAV(w);
@@ -308,7 +308,7 @@ jtsumebar(J jt, A a, A w) {
     A y;
     C *av, *wv;
     I c, d, i, k = 0, m, n, p, *yv, z = 0;
-    RE(d = ebarprep(a, w, &a, &w, &c));
+    RE(d = jtebarprep(jt, a, w, &a, &w, &c));
     av = CAV(a);
     m  = AN(a);
     wv = CAV(w);
@@ -354,7 +354,7 @@ jtanyebar(J jt, A a, A w) {
     A y;
     C *av, *wv;
     I c, d, i, k = 0, m, n, p, *yv;
-    RE(d = ebarprep(a, w, &a, &w, &c));
+    RE(d = jtebarprep(jt, a, w, &a, &w, &c));
     av = CAV(a);
     m  = AN(a);
     wv = CAV(w);
@@ -411,7 +411,7 @@ jtifbebar(J jt, A a, A w) {
     A y, z;
     C *av, *wv;
     I c, d, i, k = 0, m, n, p, *yv, *zu, *zv;
-    RE(d = ebarprep(a, w, &a, &w, &c));
+    RE(d = jtebarprep(jt, a, w, &a, &w, &c));
     av = CAV(a);
     m  = AN(a);
     wv = CAV(w);

--- a/jsrc/verbs/vbang.c
+++ b/jsrc/verbs/vbang.c
@@ -56,7 +56,7 @@ dgps(D v) {
 
 static Z
 jtzgps(J jt, Z z) {
-    return jtzdiv(jt, z1, zhorner(terms, coeff, z));
+    return jtzdiv(jt, z1, jtzhorner(jt, terms, coeff, z));
 }
 
 D
@@ -122,7 +122,7 @@ jtzstirling(J jt, Z z) {
     Z p, q;
     p = jtztymes(
       jt, jtzsqrt(jt, jtzdiv(jt, zrj0(2 * PI), z)), jtzpow(jt, jtzdiv(jt, z, zrj0(2.718281828459045235360287)), z));
-    q = zhorner(5L, c, jtzdiv(jt, z1, z));
+    q = jtzhorner(jt, 5L, c, jtzdiv(jt, z1, z));
     return jtztymes(jt, p, q);
 } /* Abramowitz & Stegun, 6.1.37 */
 

--- a/jsrc/verbs/vcant.c
+++ b/jsrc/verbs/vcant.c
@@ -20,7 +20,7 @@ jtcants(J jt, A a, A w, A z) {
     zr = AR(z);
     zp = PAV(z);
     ASSERT(wr == zr, EVNONCE);
-    RZ(b = bfi(wr, a1, 1));
+    RZ(b = jtbfi(jt, wr, a1, 1));
     GATV0(q, B01, wr, 1);
     c = BAV(q);
     u = AV(a);
@@ -136,7 +136,7 @@ jtcanta(J jt, A a, A w) {
     }
     if ((SPARSE & AT(w)) != 0) {
         GASPARSE(z, AT(w), 1, zr, sv);
-        return cants(a, w, z);
+        return jtcants(jt, a, w, z);
     }  // if sparse, go to sparse transpose code.
     GA(z, AT(w), zn, zr, sv);
     if (!zn) return z;  // allocate result.  If result is empty, return it now
@@ -164,7 +164,7 @@ jtcant1(J jt, A w) {
     FPREFIP;
     r   = (RANKT)jt->ranks;
     r   = AR(w) < r ? AR(w) : r;  // no RESETRANK; we pass the rank of w on
-    A z = jtcanta(jt, apv(r, r - 1, -1L), w);
+    A z = jtcanta(jt, jtapv(jt, r, r - 1, -1L), w);
     RZ(z);  // rank is set
     // We extracted from w, so mark it (or its backer if virtual) non-pristine.  If w was pristine and inplaceable,
     // transfer its pristine status to the result But if we are returning the input block unchanged, leave pristinity

--- a/jsrc/verbs/vcat.c
+++ b/jsrc/verbs/vcat.c
@@ -24,7 +24,7 @@ jtovs0(J jt, B p, I r, A a, A w) {
     a1 = SPA(wp, a);
     c  = AN(a1);
     av = AV(a1);
-    RZ(b = bfi(zr, a1, 1));
+    RZ(b = jtbfi(jt, zr, a1, 1));
     at = AT(a);
     wt = AT(x);
     ASSERT(HOMO(at, wt), EVDOMAIN);
@@ -40,20 +40,20 @@ jtovs0(J jt, B p, I r, A a, A w) {
     switch (2 * b[f] + !jtequ(jt, a, e)) {
         case 0: /* dense and a equal e */
             RZ(y = jtca(jt, y));
-            RZ(x = p ? irs2(x, a, 0L, AR(x) - (1 + k), 0L, jtover) : irs2(a, x, 0L, 0L, AR(x) - (1 + k), jtover));
+            RZ(x = p ? jtirs2(jt, x, a, 0L, AR(x) - (1 + k), 0L, jtover) : jtirs2(jt, a, x, 0L, 0L, AR(x) - (1 + k), jtover));
             break;
         case 1: /* dense and a not equal to e */
             GATV0(q, INT, c, 1);
             v = AV(q);
             DO(c, v[i] = ws[av[i]];);
-            RZ(q = odom(2L, c, v));
+            RZ(q = jtodom(jt, 2L, c, v));
             if (AN(q) >= AN(y)) {
                 RZ(z = shape(jt, x));
                 *AV(z) = *AS(q);
                 RZ(x = jtfrom(jt, jtgrade1(jt, jtover(jt, y, jtless(jt, q, y))), jtover(jt, x, jtreshape(jt, z, e))));
                 y = q;
             }
-            RZ(x = p ? irs2(x, a, 0L, AR(x) - (1 + k), 0L, jtover) : irs2(a, x, 0L, 0L, AR(x) - (1 + k), jtover));
+            RZ(x = p ? jtirs2(jt, x, a, 0L, AR(x) - (1 + k), 0L, jtover) : jtirs2(jt, a, x, 0L, 0L, AR(x) - (1 + k), jtover));
             break;
         case 2: /* sparse and a equals e */
             RZ(y = jtca(jt, y));
@@ -67,7 +67,7 @@ jtovs0(J jt, B p, I r, A a, A w) {
             v = AV(q);
             DO(c, v[i] = ws[av[i]];);
             v[j] = 1;
-            RZ(q = odom(2L, c, v));
+            RZ(q = jtodom(jt, 2L, c, v));
             n = *AS(q);
             if (p) {
                 RZ(y = jtover(jt, y, q));
@@ -119,29 +119,29 @@ jtovs(J jt, A a, A w) {
     wt  = AT(w);
     wcr = wr < wcr ? wr : wcr;
     RESETRANK;
-    if (!ar) return ovs0(0, wcr, a, w);
-    if (!wr) return ovs0(1, acr, w, a);
-    if (ar > acr || wr > wcr) return sprank2(a, w, 0L, acr, wcr, jtover);
+    if (!ar) return jtovs0(jt, 0, wcr, a, w);
+    if (!wr) return jtovs0(jt, 1, acr, w, a);
+    if (ar > acr || wr > wcr) return jtsprank2(jt, a, w, 0L, acr, wcr, jtover);
     r = MAX(ar, wr);
-    if (r > ar) RZ(a = jtreshape(jt, jtover(jt, apv(r - ar, 1L, 0L), shape(jt, a)), a));
+    if (r > ar) RZ(a = jtreshape(jt, jtover(jt, jtapv(jt, r - ar, 1L, 0L), shape(jt, a)), a));
     as = AS(a);
-    if (r > wr) RZ(w = jtreshape(jt, jtover(jt, apv(r - wr, 1L, 0L), shape(jt, w)), w));
+    if (r > wr) RZ(w = jtreshape(jt, jtover(jt, jtapv(jt, r - wr, 1L, 0L), shape(jt, w)), w));
     ws = AS(w);
     ASSERT(*as < IMAX - *ws, EVLIMIT);
     if (!(at & SPARSE)) {
         wp = PAV(w);
-        RZ(a = sparseit(a, SPA(wp, a), SPA(wp, e)));
+        RZ(a = jtsparseit(jt, a, SPA(wp, a), SPA(wp, e)));
     }
     if (!(wt & SPARSE)) {
         ap = PAV(a);
-        RZ(w = sparseit(w, SPA(ap, a), SPA(ap, e)));
+        RZ(w = jtsparseit(jt, w, SPA(ap, a), SPA(ap, e)));
     }
     ap = PAV(a);
-    RZ(ab = bfi(r, SPA(ap, a), 1));
+    RZ(ab = jtbfi(jt, r, SPA(ap, a), 1));
     ae = SPA(ap, e);
     at = AT(ae);
     wp = PAV(w);
-    RZ(wb = bfi(r, SPA(wp, a), 1));
+    RZ(wb = jtbfi(jt, r, SPA(wp, a), 1));
     we = SPA(wp, e);
     wt = AT(we);
     ASSERT(jtequ(jt, ae, we), EVNONCE);
@@ -277,7 +277,7 @@ jtovgmove(J jt, I k, I c, I m, A s, A w, C *x, A z) {
             if (n < p) {
                 I *v = AV(s);
                 *v   = m;
-                RZ(w = jttake(jt, d ? vec(INT, AR(w), d + v) : s, w));
+                RZ(w = jttake(jt, d ? jtvec(jt, INT, AR(w), d + v) : s, w));
             }                                        // incoming cell smaller than result area: take to result-cell size
             Jmemcpy(x, AV(w), k * AN(w), loop1, 1);  // copy in the data, now the right cell shape but possibly shorter
                                                      // than the fill  kludge could avoid double copy
@@ -308,7 +308,7 @@ jtovg(J jt, A a, A w) {
     ar = AR(a);
     wr = AR(w);
     r  = ar + wr ? MAX(ar, wr) : 1;
-    RZ(s = r ? vec(INT, r, AS(r == ar ? a : w)) : num(2));
+    RZ(s = r ? jtvec(jt, INT, r, AS(r == ar ? a : w)) : num(2));
     sv = AV(s);  // Allocate list for shape of composite item
     // Calculate the shape of the result: the shape of the item, max of input shapes
     if (m = MIN(ar, wr)) {
@@ -329,8 +329,8 @@ jtovg(J jt, A a, A w) {
     AS(z)[0] = m + n;
     x        = CAV(z);
     k        = bpnoun(AT(a));
-    RZ(x = ovgmove(k, c, m, s, a, x, z));
-    RZ(x = ovgmove(k, c, n, s, w, x, z));
+    RZ(x = jtovgmove(jt, k, c, m, s, a, x, z));
+    RZ(x = jtovgmove(jt, k, c, n, s, w, x, z));
     return z;
 } /* a,w general case for dense array with the same type; jt->ranks=~0 */
 
@@ -695,7 +695,7 @@ jtapip(J jt, A a, A w) {
                         // rank is implicit in the shape of a.
                         // The take relies on the fill value
                         if (p) {
-                            h = vec(INT, wr, AS(a) + ar - wr);
+                            h = jtvec(jt, INT, wr, AS(a) + ar - wr);
                             makewritable(h);
                             if (ar == wr) AV(h)[0] = AS(w)[0];
                             RZ(w = jttake(jt, h, w));

--- a/jsrc/verbs/vcatsp.c
+++ b/jsrc/verbs/vcatsp.c
@@ -10,5 +10,5 @@ jtstitchsp2(J jt, A a, A w) {
     I ar, wr;
     ar = AR(a);
     wr = AR(w);
-    return irs2(a, w, 0L, ar ? ar - 1 : 0, wr ? wr - 1 : 0, jtover);
+    return jtirs2(jt, a, w, 0L, ar ? ar - 1 : 0, wr ? wr - 1 : 0, jtover);
 } /* sparse arrays with rank 2 or less */

--- a/jsrc/verbs/vcompsc.c
+++ b/jsrc/verbs/vcompsc.c
@@ -503,31 +503,31 @@ INDF(i0neS, SB, SB, AEQ) JNDF(j0eqS, SB, SB, ANE) JNDF(j0neS, SB, SB, AEQ) SUMF(
 // the special case for compounds like +/@e.
 static A
 jti0eps(J jt, A a, A w) {
-    return indexofsub(II0EPS, w, a);
+    return jtindexofsub(jt, II0EPS, w, a);
 }
 static A
 jti1eps(J jt, A a, A w) {
-    return indexofsub(II1EPS, w, a);
+    return jtindexofsub(jt, II1EPS, w, a);
 }
 static A
 jtj0eps(J jt, A a, A w) {
-    return indexofsub(IJ0EPS, w, a);
+    return jtindexofsub(jt, IJ0EPS, w, a);
 }
 static A
 jtj1eps(J jt, A a, A w) {
-    return indexofsub(IJ1EPS, w, a);
+    return jtindexofsub(jt, IJ1EPS, w, a);
 }
 static A
 jtsumeps(J jt, A a, A w) {
-    return indexofsub(ISUMEPS, w, a);
+    return jtindexofsub(jt, ISUMEPS, w, a);
 }
 static A
 jtanyeps(J jt, A a, A w) {
-    return indexofsub(IANYEPS, w, a);
+    return jtindexofsub(jt, IANYEPS, w, a);
 }
 static A
 jtalleps(J jt, A a, A w) {
-    return indexofsub(IALLEPS, w, a);
+    return jtindexofsub(jt, IALLEPS, w, a);
 }
 
 // This table is indexed by m[5 4 3 0]

--- a/jsrc/verbs/vd.c
+++ b/jsrc/verbs/vd.c
@@ -396,7 +396,7 @@ jtmdivsp(J jt, A a, A w) {
     RE(t = maxtype(t, FL));
     RZ(a = jtcvt(jt, t, a));
     RZ(x = jtcvt(jt, t, x));
-    if (t & CMPX) RZ(ztridiag(n, a, x)) else RZ(tridiag(n, a, x));
+    if (t & CMPX) RZ(jtztridiag(jt, n, a, x)) else RZ(jttridiag(jt, n, a, x));
     return a;
 } /* currently only handles tridiagonal sparse w */
 

--- a/jsrc/verbs/vf.c
+++ b/jsrc/verbs/vf.c
@@ -22,7 +22,7 @@ jtsetfv(J jt, A a, A w) {
         jt->fillv = CAV(q);                              // jt->fillv points to the fill atom
     } else {
         if (!t) t = AT(w);
-        fillv(t, 1L, jt->fillv0);
+        jtfillv(jt, t, 1L, jt->fillv0);
         jt->fillv = jt->fillv0;
     }  // empty fill.  move 1 std fill atom to fillv0 and point jt->fillv at it
     return TYPESEQ(t, AT(w)) ? w : jtcvt(jt, t, w);  // note if w is boxed and nonempty this won't change it
@@ -32,7 +32,7 @@ A
 jtfiller(J jt, A w) {
     A z;
     GA(z, AT(w), 1, 0, 0);
-    fillv(AT(w), 1L, CAV(z));
+    jtfillv(jt, AT(w), 1L, CAV(z));
     return z;
 }
 
@@ -94,7 +94,7 @@ jtrotsp(J jt, A a, A w) {
     RESETRANK;
     if (1 < acr || af) return df2(z, a, w, jtqq(jt, jtqq(jt, ds(CROT), jtv2(jt, 1L, RMAX)), jtv2(jt, acr, wcr)));
     if (!wcr && 1 < p) {
-        RZ(w = jtreshape(jt, jtover(jt, shape(jt, w), apv(p, 1L, 0L)), w));
+        RZ(w = jtreshape(jt, jtover(jt, shape(jt, w), jtapv(jt, p, 1L, 0L)), w));
         wr = wcr = p;
     }
     ASSERT(!wcr || p <= wcr, EVLENGTH);
@@ -128,7 +128,7 @@ jtrotsp(J jt, A a, A w) {
           bx = 1;
           break;
       });
-    RZ(x = !bx ? jtca(jt, SPA(wp, x)) : irs2(vec(INT, wr - n, n + qv), SPA(wp, x), 0L, 1L, -1L, jtrotate));
+    RZ(x = !bx ? jtca(jt, SPA(wp, x)) : jtirs2(jt, jtvec(jt, INT, wr - n, n + qv), SPA(wp, x), 0L, 1L, -1L, jtrotate));
     if (by) {
         DO(
           n, if (k = qv[i]) {
@@ -241,7 +241,7 @@ jtrotate(J jt, A a, A w) {
                         jtv2(jt, acr, wcr)));  // if multiple a-lists per cell, or a has frame and (a cell is not an
                                                // atom or w has frame) handle rank by using " for it
     if (((wcr - 1) & (1 - p)) < 0) {
-        RZ(w = jtreshape(jt, apip(shape(jt, w), apv(p, 1L, 0L)), w));
+        RZ(w = jtreshape(jt, apip(shape(jt, w), jtapv(jt, p, 1L, 0L)), w));
         wr = wcr = p;
     }  // if cell is an atom, extend it up to #axes being rotated   !wcr && p>1
     ASSERT(((-wcr) & (wcr - p)) >= 0, EVLENGTH);  // !wcr||p<=wcr  !(wcr&&p>wcr)
@@ -257,14 +257,14 @@ jtrotate(J jt, A a, A w) {
     PROD(m, wf, s);
     PROD(d, wr - wf - 1, s + wf + 1);
     SETICFR(w, wf, wcr, n);  // m=#cells of w, n=#items per cell  d=#atoms per item of cell
-    rot(m, d, n, k, 1 >= p ? AN(a) : 1L, av, u, v);
+    jtrot(jt, m, d, n, k, 1 >= p ? AN(a) : 1L, av, u, v);
     if (1 < p) {
         GA(y, AT(w), wn, wr, s);
         u = CAV(y);
         b = 0;
         s += wf;
         DO(p - 1, m *= n; n = *++s; PROD(d, wr - wf - i - 2, s + 1);
-           rot(m, d, n, k, 1L, av + i + 1, b ? u : v, b ? v : u);
+           jtrot(jt, m, d, n, k, 1L, av + i + 1, b ? u : v, b ? v : u);
            b ^= 1;);  // s has moved past the frame
         z = b ? y : z;
     }
@@ -303,7 +303,7 @@ jtrevsp(J jt, A w) {
     if (!r)
         RZ(x = jtca(jt, x))
     else if (k >= n)
-        RZ(x = irs2(apv(m, m - 1, -1L), x, 0L, 1L, wr - k, jtfrom))
+        RZ(x = jtirs2(jt, jtapv(jt, m, m - 1, -1L), x, 0L, 1L, wr - k, jtfrom))
     else {
         v = k + AV(y);
         c = m - 1;
@@ -382,7 +382,7 @@ jtreshapesp0(J jt, A a, A w, I wf, I wcr) {
     wr = AR(w);
     ws = AS(w);
     wp = PAV(w);
-    RZ(b = bfi(wr, SPA(wp, a), 1));
+    RZ(b = jtbfi(jt, wr, SPA(wp, a), 1));
     RZ(e = jtca(jt, SPA(wp, e)));
     x = SPA(wp, x);
     y = SPA(wp, i);
@@ -415,7 +415,7 @@ jtreshapesp0(J jt, A a, A w, I wf, I wcr) {
        ++pv;
        v += c;);
     SPB(zp, i, jtrepeat(jt, p, jttaker(jt, d, y)));
-    SPB(zp, x, irs2(mtv, jtrepeat(jt, p, x), 0L, 1L, wcr - (c - d), jtreshape));
+    SPB(zp, x, jtirs2(jt, mtv, jtrepeat(jt, p, x), 0L, 1L, wcr - (c - d), jtreshape));
     return z;
 } /* '' ($,)"wcr w for sparse w */
 
@@ -436,11 +436,11 @@ jtreshapesp(J jt, A a, A w, I wf, I wcr) {
     wz = 0;
     DO(wcr, if (!ws[wf + i]) wz = 1;);
     ASSERT(az || !wz, EVLENGTH);
-    if (!an) return reshapesp0(a, w, wf, wcr);
+    if (!an) return jtreshapesp0(jt, a, w, wf, wcr);
     wp = PAV(w);
     a1 = SPA(wp, a);
     c  = AN(a1);
-    RZ(b = bfi(wr, a1, 1));  // b=bitmask, length wr, with 1s for each value in a1
+    RZ(b = jtbfi(jt, wr, a1, 1));  // b=bitmask, length wr, with 1s for each value in a1
     RZ(e = jtca(jt, SPA(wp, e)));
     x = SPA(wp, x);
     y = SPA(wp, i);
@@ -452,7 +452,7 @@ jtreshapesp(J jt, A a, A w, I wf, I wcr) {
           m = 1;
           break;
       });
-    if (m || an < wcr) return reshapesp(a, IRS1(w, 0L, wcr, jtravel, z), wf, 1L);
+    if (m || an < wcr) return jtreshapesp(jt, a, IRS1(w, 0L, wcr, jtravel, z), wf, 1L);
     ASSERT(!jt->fill, EVDOMAIN);
     GASPARSE(z, AT(w), 1, wf + an, ws);
     MCISH(wf + AS(z), av, an);
@@ -489,7 +489,7 @@ jtreshapesp(J jt, A a, A w, I wf, I wcr) {
               v = v0;
               m += ws[wf];
           });
-        SPB(zp, i, jtstitch(jt, jtabase2(jt, vec(INT, 1 + d, av), t), jtreitem(jt, jtsc(jt, q), jtdropr(jt, 1L, y))));
+        SPB(zp, i, jtstitch(jt, jtabase2(jt, jtvec(jt, INT, 1 + d, av), t), jtreitem(jt, jtsc(jt, q), jtdropr(jt, 1L, y))));
         SPB(zp, x, jtreitem(jt, jtsc(jt, q), x));
     } else { /* dense  */
         GATV0(t, INT, an, 1);
@@ -499,7 +499,7 @@ jtreshapesp(J jt, A a, A w, I wf, I wcr) {
         j = wf;
         DO(wcr, if (!b[j++]) v[m++] = av[i + d];);
         SPB(zp, i, jtca(jt, y));
-        SPB(zp, x, irs2(vec(INT, m, v), x, 0L, 1L, wcr - (an - m), jtreshape));
+        SPB(zp, x, jtirs2(jt, jtvec(jt, INT, m, v), x, 0L, 1L, wcr - (an - m), jtreshape));
     }
     return z;
 } /* a ($,)"wcr w for sparse w and scalar or vector a */
@@ -529,7 +529,7 @@ jtreshape(J jt, A a, A w) {
     RZ(a = jtvip(jt, a));
     r = AN(a);
     u = AV(a);  // r=length of a   u->values of a
-    if ((SPARSE & AT(w)) != 0) { return reshapesp(a, w, wf, wcr); }
+    if ((SPARSE & AT(w)) != 0) { return jtreshapesp(jt, a, w, wf, wcr); }
     wn = AN(w);
     PRODX(m, r, u, 1)
     CPROD(c, wf, ws);

--- a/jsrc/verbs/vfrom.c
+++ b/jsrc/verbs/vfrom.c
@@ -30,7 +30,7 @@ jtcatalog(J jt, A w) {
     qv = AV(x);  // allocate vector of max-indexes for each box - only the address is used  qv->max-index 0
     GATV0(x, BOX, n, 1);
     pv = (C **)AV(x);  // allocate vector of pointers to each box's data  pv->box-data-base 0
-    RZ(x = apvwr(n, 0L, 0L));
+    RZ(x = jtapvwr(jt, n, 0L, 0L));
     cv = AV(x);  // allocate vector of current indexes, init to 0  cv->current-index 0
     DO(n, x = wv[i]; if (TYPESNE(t, AT(x))) RZ(x = jtcvt(jt, t, x)); r += AR(x); qv[i] = p = AN(x); DPMULDE(m, p, m);
        pv[i] = CAV(x););  // fill in *qv and *pv; calculate r=+/ #@$@> w, m=*/ */@$@> w
@@ -478,8 +478,8 @@ jtafrom(J jt, A a, A w) {
     RESETRANK;
     if (ar) {  // if there is an array of boxes
         if (((ar ^ acr) | (wr ^ wcr)) == 0) {
-            RE(aindex(a, w, wf, &ind));
-            if (ind) return frombu(ind, w, wf);
+            RE(jtaindex(jt, a, w, wf, &ind));
+            if (ind) return jtfrombu(jt, ind, w, wf);
         }  // if boxing doesn't contribute to shape, open the boxes of a and copy the values
         return wr == wcr ? rank2ex(a, w, UNUSED_VALUE, 0L, wcr, 0L, wcr, jtafrom) :  // if a has frame, rank-loop over a
                  df2(p,
@@ -495,8 +495,8 @@ jtafrom(J jt, A a, A w) {
     ASSERT(1 >= AR(c), EVRANK);
     ASSERT(n <= wcr, EVLENGTH);
     if ((-n & SGNIFNOT(t, BOXX)) < 0) {
-        RE(aindex(a, w, wf, &ind));
-        if (ind) return frombu(ind, w, wf);
+        RE(jtaindex(jt, a, w, wf, &ind));
+        if (ind) return jtfrombu(jt, ind, w, wf);
     }  // not empty and not boxed, handle as 1 index list
     if (wcr == wr) {
         for (i = m = pr = 0; i < n; ++i) {
@@ -529,7 +529,7 @@ jtafrom(J jt, A a, A w) {
         q = j < n ? jtafi(jt, s[j], v[j]) : ds(CACE);
         if (!(p && q)) break;  // pq are 0 if error.  Result of ds(CACE)=axis in full
         if (p != ds(CACE) && q != ds(CACE)) {
-            y = afrom2(p, q, y, wcr - i);
+            y = jtafrom2(jt, p, q, y, wcr - i);
         } else {
             if (q == ds(CACE)) {
                 q = p;
@@ -671,8 +671,8 @@ jtsfrom(J jt, A a, A w) {
     } else {
         A ind;
         // sparse.  See if we can audit the index list.  If we can, use it, else execute the slow way
-        RE(aindex1(a, w, 0L, &ind));
-        if (ind) return frombsn(ind, w, 0L);
+        RE(jtaindex1(jt, a, w, 0L, &ind));
+        if (ind) return jtfrombsn(jt, ind, w, 0L);
     }
     // If we couldn't handle it as a special case, do it the hard way
     A z;
@@ -687,9 +687,9 @@ static EVERYFS(mapxself, 0, jtmapx, 0, VFLAGNONE)
     if (!(BOX & AT(w))) return jtope(jt, a);
     RZ(z1 = jtcatalog(jt, jtevery(jt, shape(jt, w), ds(CIOTA))));  // create index list of each box
     IRS1(z1, 0, 0, jtbox, z2);
-    RZ(z2 = every2(a, z2, (A)&sfn0overself));
+    RZ(z2 = jtevery2(jt, a, z2, (A)&sfn0overself));
     IRS1(z2, 0, 0, jtbox, z3);
-    return every2(z3, w, (A)&mapxself);
+    return jtevery2(jt, z3, w, (A)&mapxself);
 }
 
 A

--- a/jsrc/verbs/vfromsp.c
+++ b/jsrc/verbs/vfromsp.c
@@ -54,7 +54,7 @@ jtfromis1(J jt, A ind, A w, A z, I wf) {
         RZ(y = jtifrom(jt, q, y));
         RZ(x = jtifrom(jt, q, x));
     }
-    RZ(q = odom(2L, r, AS(ind)));
+    RZ(q = jtodom(jt, 2L, r, AS(ind)));
     iv = AV(q);
     m  = *AS(y);
     s  = 0;
@@ -161,12 +161,12 @@ jtfromis(J jt, A a, A w) {
     RZ(a = jtca(jt, SPA(wp, a)));
     av = AV(a);
     an = AN(a);
-    RZ(b = bfi(wr, a, 1));                     // get boolean mask with a 1 for every axis that is sparse
-    if (b[wf]) return fromis1(ind, w, z, wf);  // if the selection is along a sparse axis, go do it
+    RZ(b = jtbfi(jt, wr, a, 1));                     // get boolean mask with a 1 for every axis that is sparse
+    if (b[wf]) return jtfromis1(jt, ind, w, z, wf);  // if the selection is along a sparse axis, go do it
     // selection is along a dense axis...
     m = wcr;
     DO(wcr, m -= b[wf + i];);
-    RZ(x = irs2(ind, SPA(wp, x), 0L, ar, m, jtifrom));
+    RZ(x = jtirs2(jt, ind, SPA(wp, x), 0L, ar, m, jtifrom));
     if (k = ar - 1) DO(an, if (av[i] >= wf) av[i] += k;);
     if (AR(z)) {
         SPB(zp, a, a);
@@ -184,7 +184,7 @@ jtaaxis(J jt, A w, I wf, A a, I r, I h, I *pp, I *qq, I *rr) {
     I wr, x, y, z, zr;
     wr = AR(w);
     zr = wr + r - h;
-    RZ(b = bfi(wr, a, 1));
+    RZ(b = jtbfi(jt, wr, a, 1));
     GATV0(q, B01, zr, 1);
     c = BAV(q);
     x = y = z = 0;
@@ -215,7 +215,7 @@ jtfrombsn(J jt, A ind, A w, I wf) {
     v  = AS(ind);
     h  = v[r];
     n  = AN(ind) / h;
-    RZ(q = odom(2L, r, v));
+    RZ(q = jtodom(jt, 2L, r, v));
     iv = AV(q) - r;
     GASPARSE(z, AT(w), 1, wr + r - h, (I *)0);
     u = AS(z);
@@ -229,18 +229,18 @@ jtfrombsn(J jt, A ind, A w, I wf) {
     y  = SPA(wp, i);
     a  = SPA(wp, a);
     an = AN(a);
-    SPB(zp, a, aaxis(w, wf, a, r, h, &pp, &qq, &rr));
+    SPB(zp, a, jtaaxis(jt, w, wf, a, r, h, &pp, &qq, &rr));
     if (!qq) {
         SPB(zp, i, jtca(jt, y));
-        SPB(zp, x, frombu(ind, x, AR(x) - (wr - wf - rr)));
+        SPB(zp, x, jtfrombu(jt, ind, x, AR(x) - (wr - wf - rr)));
         return z;
     }
     if (h > qq) {
-        q = jtnub(jt, jtover(jt, a, apv(h, wf, 1L)));
-        return frombsn(ind, jtreaxis(jt, jtgrade2(jt, q, q), w), wf);
+        q = jtnub(jt, jtover(jt, a, jtapv(jt, h, wf, 1L)));
+        return jtfrombsn(jt, ind, jtreaxis(jt, jtgrade2(jt, q, q), w), wf);
     }
     if (1 < r) RZ(ind = jtreshape(jt, jtv2(jt, n, h), ind));
-    RZ(ys = jtfromr(jt, jtindexof(jt, a, apv(h, wf, 1L)), y));
+    RZ(ys = jtfromr(jt, jtindexof(jt, a, jtapv(jt, h, wf, 1L)), y));
     RZ(q = jteps(jt, ys, ind));
     if (!all1(q)) {
         RZ(ys = jtrepeat(jt, q, ys));
@@ -274,7 +274,7 @@ jtfrombsn(J jt, A ind, A w, I wf) {
         pv[s]   = 1 + j;
         qv[s++] = m - 1 - j;
     }
-    RZ(j1 = jtindexof(jt, jtifrom(jt, vec(INT, s, pv), ys), ind));
+    RZ(j1 = jtindexof(jt, jtifrom(jt, jtvec(jt, INT, s, pv), ys), ind));
     jv = AV(j1);
     c  = 0;
     DO(n, if (s > jv[i]) c += qv[jv[i]];);
@@ -348,7 +348,7 @@ jtfrombs1(J jt, A ind, A w, I wf) {
             if (!AN(x)) continue;
             RZ(x = jtless(jt, IX(m), jtpind(jt, m, x)));
         }
-        RZ(z = irs2(x, z, VFLAGNONE, RMAX, wcr - j, jtfromis));
+        RZ(z = jtirs2(jt, x, z, VFLAGNONE, RMAX, wcr - j, jtfromis));
         z = jtgc(jt, z, old);
     }
     return z;
@@ -369,11 +369,11 @@ jtfrombs(J jt, A a, A w) {
     RESETRANK;
     ASSERT(!af, EVNONCE);
     if (ar) {
-        RE(aindex(a, w, wf, &ind));
+        RE(jtaindex(jt, a, w, wf, &ind));
         ASSERT(ind != 0, EVNONCE);
-        return frombsn(ind, w, wf);
+        return jtfrombsn(jt, ind, w, wf);
     } else
-        return frombs1(AAV(a)[0], w, wf);
+        return jtfrombs1(jt, AAV(a)[0], w, wf);
 } /* a{"r w for boxed a and sparse w */
 
 A
@@ -390,7 +390,7 @@ jtfromsd(J jt, A a, A w) {
     wcr = wr < wcr ? wr : wcr;
     wf  = wr - wcr;
     RESETRANK;
-    if (af) return sprank2(a, w, 0L, acr, wcr, jtfrom);
+    if (af) return jtsprank2(jt, a, w, 0L, acr, wcr, jtfrom);
     ASSERT(AT(w) & B01 + INT + FL + CMPX, EVNONCE);
     ap = PAV(a);
     ws = AS(w);
@@ -399,14 +399,14 @@ jtfromsd(J jt, A a, A w) {
     v  = AS(z);
     ICPY(v + wf, AS(a), ar);
     if (wcr) ICPY(v + wf + ar, 1 + wf + ws, wcr - 1);
-    RZ(x = irs2(SPA(ap, e), w, 0L, 0L, wcr, jtifrom));
+    RZ(x = jtirs2(jt, SPA(ap, e), w, 0L, 0L, wcr, jtifrom));
     RZ(e = jtreshape(jt, mtv, x));
     ASSERT(all1(eq(e, x)), EVSPARSE);
     SPB(zp, e, e);
     SPB(zp, a, wf ? plus(jtsc(jt, wf), SPA(ap, a)) : SPA(ap, a));
     SPB(zp, i, SPA(ap, i));
     if (wf) {
-        RZ(x = irs2(SPA(ap, x), w, VFLAGNONE, RMAX, wcr, jtifrom));
+        RZ(x = jtirs2(jt, SPA(ap, x), w, VFLAGNONE, RMAX, wcr, jtifrom));
         RZ(x = jtcant2(jt, jtless(jt, IX(AR(x)), jtsc(jt, wf)), x));
         SPB(zp, x, x);
     } else
@@ -429,7 +429,7 @@ jtfromss(J jt, A a, A w) {
     wcr = wr < wcr ? wr : wcr;
     wf  = wr - wcr;
     RESETRANK;
-    if (af) return sprank2(a, w, 0L, acr, wcr, jtfrom);
+    if (af) return jtsprank2(jt, a, w, 0L, acr, wcr, jtfrom);
     ASSERT(DTYPE(AT(w)) & B01 + INT + FL + CMPX, EVNONCE);
     ap = PAV(a);
     wp = PAV(w);
@@ -439,7 +439,7 @@ jtfromss(J jt, A a, A w) {
     v  = AS(z);
     ICPY(v + wf, AS(a), ar);
     if (wcr) ICPY(v + wf + ar, 1 + wf + ws, wcr - 1);
-    RZ(x = irs2(SPA(ap, e), w, 0L, 0L, wcr, jtfrom));
+    RZ(x = jtirs2(jt, SPA(ap, e), w, 0L, 0L, wcr, jtfrom));
     RZ(e = jtreshape(jt, mtv, x));
     ASSERT(all1(jtdenseit(jt, eq(e, x))), EVSPARSE);
     SPB(zp, e, e);
@@ -450,7 +450,7 @@ jtfromss(J jt, A a, A w) {
     }
     x = SPA(wp, a);
     n = AN(x);
-    RZ(b = bfi(wr, x, 1));
+    RZ(b = jtbfi(jt, wr, x, 1));
     if (wcr && !b[wf]) {
         b[wf] = 1;
         ++n;
@@ -463,7 +463,7 @@ jtfromss(J jt, A a, A w) {
     DO(ar, *v++ = wf + i;);
     DO(wcr - 1, if (b[i + wf + 1]) *v++ = wf + ar + i;);
     SPB(zp, a, x);
-    RZ(x = irs2(SPA(ap, x), w, VFLAGNONE, RMAX, wcr, jtfrom));
+    RZ(x = jtirs2(jt, SPA(ap, x), w, VFLAGNONE, RMAX, wcr, jtfrom));
     xp = PAV(x);
     y  = SPA(xp, i);
     u  = AV(y);

--- a/jsrc/verbs/vg.c
+++ b/jsrc/verbs/vg.c
@@ -219,8 +219,8 @@ jtgrx(J jt, I m, I ai, I n, A w, I *zv) {
     jt->workareas.compare.compusejt = !!(t & BOX + XNUM + RAT);
     void **(*sortfunc)()            = sortroutines[CTTZ(t)][SGNTO0(jt->workareas.compare.complt)].sortfunc;
     GATV0(x, INT, n, 1);
-    xv = AV(x); /* work area for msmerge() */
-    DQ(m, msortitems(sortfunc, n, (void **)zv, (void **)xv); jt->workareas.compare.compv += ck; zv += n;);
+    xv = AV(x); /* work area for jtmsmerge(jt, ) */
+    DQ(m, jtmsortitems(jt, sortfunc, n, (void **)zv, (void **)xv); jt->workareas.compare.compv += ck; zv += n;);
     return !jt->jerr;
 } /* grade"r w on general w */
 
@@ -503,7 +503,7 @@ jtgrd(J jt, I m, I ai, I n, A w, I *zv) {
     I c = ai * n;
     if (ai == 1) { return jtgrdq(jt, m, ai, n, w, zv); }      // if fast list code is available, always use it
                                                               // if not large and 1 atom per key, go do general grade
-    if (!(ai == 1 && n > 3300)) return grx(m, ai, n, w, zv);  // Empirically derived crossover   TUNE
+    if (!(ai == 1 && n > 3300)) return jtgrx(jt, m, ai, n, w, zv);  // Empirically derived crossover   TUNE
     // The rest of this routine is not used on lists when the fast list code is available
     // grade float by radix sort of halfwords.  Save some control parameters
     wv = DAV(w);
@@ -852,7 +852,7 @@ jtgri(J jt, I m, I ai, I n, A w, I *zv) {
             DO(10,
                if (0xffffffff00000000 & (0x0000000080000000 + wv[i << 9])) return jtgriq(
                  jt, m, ai, n, w, zv);)    // quicksort if more than 2 bytes of significance, sampling the input
-            return gri1(m, ai, n, w, zv);  // moderate-range middle lengths use radix sort
+            return jtgri1(jt, m, ai, n, w, zv);  // moderate-range middle lengths use radix sort
         }
         // fall through to small-range
     } else  // ! we already have range, don't calculate it again
@@ -869,8 +869,8 @@ jtgri(J jt, I m, I ai, I n, A w, I *zv) {
     // tweak this line to select path for timing
     // If there is only 1 item, radix beats merge for n>1300 or so (all positive) or more (mixed signed small numbers)
     if (!rng.range)
-        return c == n && n > 2000 ? gri1(m, ai, n, w, zv)
-                                  : grx(m, ai, n, w, zv);  // revert to other methods if not small-range   TUNE
+        return c == n && n > 2000 ? jtgri1(jt, m, ai, n, w, zv)
+                                  : jtgrx(jt, m, ai, n, w, zv);  // revert to other methods if not small-range   TUNE
     // doing small-range grade.  Allocate a hashtable area.  We will access it as UI4
     GATV0(y, C4T, rng.range, 1);
     yvb = C4AV(y);
@@ -962,8 +962,8 @@ jtgru(J jt, I m, I ai, I n, A w, I *zv) {
     } else
         rng.range = 0;
     if (!rng.range)
-        return c == n && n > 1500 ? gru1(m, ai, n, w, zv)
-                                  : grx(m, ai, n, w, zv);  // revert to other methods if not small-range    TUNE
+        return c == n && n > 1500 ? jtgru1(jt, m, ai, n, w, zv)
+                                  : jtgrx(jt, m, ai, n, w, zv);  // revert to other methods if not small-range    TUNE
     GATV0(y, C4T, rng.range, 1);
     yvb = C4AV(y);
     yv  = yvb - rng.min;
@@ -1078,7 +1078,7 @@ jtgrb(J jt, I m, I ai, I n, A w, I *zv) {
     I c = ai * n;
     UI4 lgn;
     CTLZI(n, lgn);
-    if ((UI)ai > 4 * lgn) return grx(m, ai, n, w, zv);  // TUNE
+    if ((UI)ai > 4 * lgn) return jtgrx(jt, m, ai, n, w, zv);  // TUNE
     q  = ai >> 2;
     p  = 16;
     ps = p * SZI;
@@ -1110,7 +1110,7 @@ jtgrc(J jt, I m, I ai, I n, A w, I *zv) {
     UC *vv, *wv;
     UI4 lgn;
     CTLZI(n, lgn);
-    if ((UI)ai > lgn) return grx(m, ai, n, w, zv);  // TUNE
+    if ((UI)ai > lgn) return jtgrx(jt, m, ai, n, w, zv);  // TUNE
     ai <<= ((AT(w) >> C2TX) & 1);
     p  = B01 & AT(w) ? 2 : 256;
     ps = p * SZI;
@@ -1141,7 +1141,7 @@ jtgrc(J jt, I m, I ai, I n, A w, I *zv) {
 
 static B
 jtgrs(J jt, I m, I ai, I n, A w, I *zv) {
-    return gri(m, ai, n, jtsborder(jt, w), zv);
+    return jtgri(jt, m, ai, n, jtsborder(jt, w), zv);
 }
 /* grade"r w on symbols w */
 
@@ -1162,7 +1162,7 @@ jtgrade1p(J jt, A a, A w) {
     zv = AV(z);
     GATV0(x, INT, n, 1);
     xv = AV(x);
-    msortitems(jmsort, n, (void **)zv, (void **)xv);
+    jtmsortitems(jt, jmsort, n, (void **)zv, (void **)xv);
     EPILOG(z);
 } /* /:(}:a){"1 w , permutation a, integer matrix w */
 

--- a/jsrc/verbs/vgauss.c
+++ b/jsrc/verbs/vgauss.c
@@ -53,7 +53,7 @@ jtgausselm(J jt, A w) {
             fa(p.n);
             fa(p.d);
         }
-        if (!gc3(&w, 0L, 0L, old))
+        if (!jtgc3(jt, &w, 0L, 0L, old))
             return 0;  // use simple gc3 to ensure all changes use the stack, since w is modified inplace. Alternatively
                        // could turn off inplacing here
     }
@@ -101,7 +101,7 @@ jtdetr(J jt, A w) {
                 fa(p.d);
             }
         }
-        if (!gc3(&w, 0L, 0L, old))
+        if (!jtgc3(jt, &w, 0L, 0L, old))
             return 0;  // use simple gc3 to ensure all changes use the stack, since w is modified inplace. Alternatively
                        // could turn off inplacing here
     }

--- a/jsrc/verbs/vgranking.c
+++ b/jsrc/verbs/vgranking.c
@@ -131,14 +131,14 @@ jtranking(J jt, A w) {
     }  // If there are atoms, calculate result-shape the fast way
     else {
         RE(m = jtprod(jt, wf, ws));
-        return m ? jtreitem(jt, vec(INT, wf, ws), jtiota(jt, jtv2(jt, 1L, n)))
-                 : jtreshape(jt, vec(INT, 1 + wf, ws), num(0));
+        return m ? jtreitem(jt, jtvec(jt, INT, wf, ws), jtiota(jt, jtv2(jt, 1L, n)))
+                 : jtreshape(jt, jtvec(jt, INT, 1 + wf, ws), num(0));
     }
     PROD(icn, wcr - 1, ws + wf + 1);
     k = icn << bplg(
           wt);  // wk=size of atom in bytes; icn=# atoms in an item of a cell  k = *bytes in an item of a CELL of w
     // if Boolean 2- or 4-byte, go off to handle that special case
-    if (wt & B01 && (k == 2 || k == sizeof(int))) return rankingb(w, wf, wcr, m, n, k);
+    if (wt & B01 && (k == 2 || k == sizeof(int))) return jtrankingb(jt, w, wf, wcr, m, n, k);
     // See if the values qualify for small-range processing
     if (icn == 1 && wt & INT + C4T) {  // items are individual INTs or C4Ts
         // Calculate the largest range we can abide.  The cost of a sort is about n*lg(n)*4 cycles; the cost of

--- a/jsrc/verbs/vgsp.c
+++ b/jsrc/verbs/vgsp.c
@@ -145,7 +145,7 @@ jtgrd1spss(J jt, A w, I wf, I wcr) {
     wt = AT(w);
     ws = AS(w);
     n  = wcr ? ws[wf] : 1;
-    RZ(z = grd1spz(w, wf, wcr));
+    RZ(z = jtgrd1spz(jt, w, wf, wcr));
     zv                            = AV(z);
     x                             = SPA(wp, e);
     jt->workareas.compare.compsev = CAV(x);
@@ -161,13 +161,13 @@ jtgrd1spss(J jt, A w, I wf, I wcr) {
                                                : wt & SFL  ? compspssD
                                                            : compspssZ);
     jt->workareas.compare.compusejt    = 1;
-    RZ(spsscell(w, wf, wcr, &c, &t));
+    RZ(jtspsscell(jt, w, wf, wcr, &c, &t));
     tv = AV(t);
     cv = AV(c);
     cn = AN(c);
     GATV0(x, INT, 2 + n, 1);
-    xv = AV(x); /* work area for msmerge() */
-    RZ(d = apvwr(wf, 0L, 0L));
+    xv = AV(x); /* work area for jtmsmerge(jt, ) */
+    RZ(d = jtapvwr(jt, wf, 0L, 0L));
     dv = AV(d); /* odometer for frame      */
     for (i = 0; i < cn; i += 2) {
         jt->workareas.compare.compstv = u = tv + cv[i];
@@ -179,10 +179,10 @@ jtgrd1spss(J jt, A w, I wf, I wcr) {
         }
         if (u[0] < u[1]) {
             DO(n1, zv[i] = i;);
-            msort(n1, (void**)zv, (void**)xv);
+            jtmsort(jt, n1, (void**)zv, (void**)xv);
         } else {
             DO(n1, xv[i] = i;);
-            msort(n1, (void**)xv, (void**)zv);
+            jtmsort(jt, n1, (void**)xv, (void**)zv);
             sp1merge0(n, n1, yc, zv, xv, yv + wf, u);
         }
         zv += n;
@@ -201,11 +201,11 @@ jtgrd1spsd(J jt, A w, I wf, I wcr) {
     wp = PAV(w);
     ws = AS(w);
     n  = wcr ? ws[wf] : 1;
-    RZ(z = grd1spz(w, wf, wcr));
+    RZ(z = jtgrd1spz(jt, w, wf, wcr));
     zv = AV(z);
     RZ(IRS1(SPA(wp, x), 0L, wcr, jtgr1, t));
     tv = AV(t); /* grade dense cells              */
-    RZ(d = apvwr(wf, 0L, 0L));
+    RZ(d = jtapvwr(jt, wf, 0L, 0L));
     dv = AV(d); /* odometer for frame             */
     y  = SPA(wp, i);
     ys = AS(y);
@@ -284,7 +284,7 @@ jtgrd1spds(J jt, A w, I wf, I wcr) {
     ws = AS(w);
     n  = wcr ? ws[wf] : 1;
     RE(m = jtprod(jt, wf, ws));
-    RZ(z = grd1spz(w, wf, wcr));
+    RZ(z = jtgrd1spz(jt, w, wf, wcr));
     zv                            = AV(z);
     x                             = SPA(wp, e);
     jt->workareas.compare.compsev = CAV(x);
@@ -300,7 +300,7 @@ jtgrd1spds(J jt, A w, I wf, I wcr) {
                                               : wt & SFL  ? compspdsD
                                                           : compspdsZ);
     jt->workareas.compare.compusejt   = 1;
-    RZ(spdscell(w, wf, wcr, &c, &t));
+    RZ(jtspdscell(jt, w, wf, wcr, &c, &t));
     if (!AN(c)) {
         DO(m, DO(n, zv[i] = i;); zv += n;);
         return z;
@@ -309,11 +309,11 @@ jtgrd1spds(J jt, A w, I wf, I wcr) {
     n1                            = cv[1] - 1;
     jt->workareas.compare.compstv = tv = cv[0] + AV(t);
     GATV0(x, INT, MAX(n, 1 + n1), 1);
-    xv = AV(x); /* work area for msmerge() */
+    xv = AV(x); /* work area for jtmsmerge(jt, ) */
     if (cv[0])
-        DO(m, jt->workareas.compare.compsi = i; DO(n1, zv[i] = i;); msort(n1, (void**)zv, (void**)xv); zv += n;)
+        DO(m, jt->workareas.compare.compsi = i; DO(n1, zv[i] = i;); jtmsort(jt, n1, (void**)zv, (void**)xv); zv += n;)
     else
-        DO(m, jt->workareas.compare.compsi = i; DO(n1, xv[i] = i;); msort(n1, (void**)xv, (void**)zv);
+        DO(m, jt->workareas.compare.compsi = i; DO(n1, xv[i] = i;); jtmsort(jt, n1, (void**)xv, (void**)zv);
            sp1merge0(n, n1, yc, zv, xv, yv, tv);
            zv += n;);
     return z;
@@ -332,7 +332,7 @@ jtgrd1spdd(J jt, A w, I wf, I wcr) {
         RZ(z = jtfrom(jt, num(0), x));
         return IRS1(z, 0L, wcr, jtgr1, x);
     } else {
-        return jtreshape(jt, vec(INT, 1 + wf, ws), IX(n));
+        return jtreshape(jt, jtvec(jt, INT, 1 + wf, ws), IX(n));
     }
 } /* grade"r w , dense frame, dense cell */
 
@@ -353,7 +353,7 @@ jtgrd1sp(J jt, A w) {
     wf  = wr - wcr;
     RESETRANK;
     wp = PAV(w);
-    RZ(wb = bfi(wr, SPA(wp, a), 1));
+    RZ(wb = jtbfi(jt, wr, SPA(wp, a), 1));
     m = 0;
     j = wr;
     b = c = 0;
@@ -369,10 +369,10 @@ jtgrd1sp(J jt, A w) {
       });
     if (c) RZ(w = jtreaxis(jt, jtifb(jt, wr, wb), w));
     switch (2 * wb[0] + wb[wf]) {
-        case 0: /* dense  dense  */ z = grd1spdd(w, wf, wcr); break;
+        case 0: /* dense  dense  */ z = jtgrd1spdd(jt, w, wf, wcr); break;
         case 1: /* dense  sparse */ z = grd1spds(w, wf, wcr); break;
-        case 2: /* sparse dense  */ z = grd1spsd(w, wf, wcr); break;
-        case 3: /* sparse sparse */ z = grd1spss(w, wf, wcr); break;
+        case 2: /* sparse dense  */ z = jtgrd1spsd(jt, w, wf, wcr); break;
+        case 3: /* sparse sparse */ z = jtgrd1spss(jt, w, wf, wcr); break;
     }
     EPILOG(z);
 } /* grade"r w for sparse w */
@@ -454,7 +454,7 @@ jtgrd2spss(J jt, A w, I wf, I wcr) {
                                                : wt & SFL  ? compspssD
                                                            : compspssZ);
     jt->workareas.compare.compusejt    = 1;
-    RZ(spsscell(w, wf, wcr, &c, &t));
+    RZ(jtspsscell(jt, w, wf, wcr, &c, &t));
     tv = AV(t);
     cv = AV(c);
     cn = AN(c);
@@ -462,9 +462,9 @@ jtgrd2spss(J jt, A w, I wf, I wcr) {
     j  = 1;
     DQ(cn, m = MAX(m, cv[j]); j += 2;);
     GATV0(x, INT, m, 1);
-    xu = AV(x); /* work area for msmerge() */
+    xu = AV(x); /* work area for jtmsmerge(jt, ) */
     GATV0(x, INT, m, 1);
-    xv  = AV(x); /* work area for msmerge() */
+    xv  = AV(x); /* work area for jtmsmerge(jt, ) */
     zy  = SPA(zp, i);
     zyv = AV(zy);
     for (i = 0; i < cn; i += 2) {
@@ -472,7 +472,7 @@ jtgrd2spss(J jt, A w, I wf, I wcr) {
         n1                                = cv[1 + i] - 1;
         m                                 = 0;
         DO(n1, xv[i] = i;);
-        msort(n1, (void**)xv, (void**)xu);
+        jtmsort(jt, n1, (void**)xv, (void**)xu);
         if (u[0] < u[1])
             SP2RENUM(0, n1, zyv + wf, u)
         else
@@ -491,7 +491,7 @@ jtgrd2spsd(J jt, A w, I wf, I wcr) {
     RZ(z = jtca(jt, w));
     zp = PAV(z);
     x  = SPA(zp, x);
-    SPB(zp, x, irs2(irs1(x, 0L, -1L, jtgr1), x, 0L, 1L, -1L, jtfrom));
+    SPB(zp, x, jtirs2(jt, jtirs1(jt, x, 0L, -1L, jtgr1), x, 0L, 1L, -1L, jtfrom));
     return z;
 } /* sparse frame, dense cell */
 
@@ -517,7 +517,7 @@ jtgrd2sp(J jt, A a, A w) {
     wm = wcr ? ws[wf] : 1;
     ASSERT(am <= wm, EVINDEX);
     wp = PAV(w);
-    RZ(wb = bfi(wr, SPA(wp, a), 1));
+    RZ(wb = jtbfi(jt, wr, SPA(wp, a), 1));
     m = 0;
     j = wr;
     b = c = 0;
@@ -538,15 +538,15 @@ jtgrd2sp(J jt, A a, A w) {
     }
     switch ((2 * wb[0] + wb[wf]) * (a == w && af == wf && acr == wcr)) {
         default:
-            z = irs2(IRS1(w, 0L, wcr, jt->workareas.compare.complt < 0 ? jtgrade1 : jtdgrade1, z),
+            z = jtirs2(jt, IRS1(w, 0L, wcr, jt->workareas.compare.complt < 0 ? jtgrade1 : jtdgrade1, z),
                      a,
                      VFLAGNONE,
                      RMAX,
                      acr,
                      jtfrom);
             break;
-        case 2: /* sparse dense  */ z = grd2spsd(w, wf, wcr); break;
-        case 3: /* sparse sparse */ z = grd2spss(w, wf, wcr); break;
+        case 2: /* sparse dense  */ z = jtgrd2spsd(jt, w, wf, wcr); break;
+        case 3: /* sparse sparse */ z = jtgrd2spss(jt, w, wf, wcr); break;
     }
     EPILOG(z);
 } /* a grade"r w for sparse w */

--- a/jsrc/verbs/vgsp.c
+++ b/jsrc/verbs/vgsp.c
@@ -370,7 +370,7 @@ jtgrd1sp(J jt, A w) {
     if (c) RZ(w = jtreaxis(jt, jtifb(jt, wr, wb), w));
     switch (2 * wb[0] + wb[wf]) {
         case 0: /* dense  dense  */ z = jtgrd1spdd(jt, w, wf, wcr); break;
-        case 1: /* dense  sparse */ z = grd1spds(w, wf, wcr); break;
+        case 1: /* dense  sparse */ z = jtgrd1spds(jt, w, wf, wcr); break;
         case 2: /* sparse dense  */ z = jtgrd1spsd(jt, w, wf, wcr); break;
         case 3: /* sparse sparse */ z = jtgrd1spss(jt, w, wf, wcr); break;
     }

--- a/jsrc/verbs/vi.c
+++ b/jsrc/verbs/vi.c
@@ -641,8 +641,8 @@ hashallo(IH* RESTRICT hh, UI p, UI m, I md) {
 //
 static IOFX(A, jtioax1, jthia(jt, t1, *v), !jtequ(jt, *v, av[hj]), ++v, --v)         /* boxed exact 1-element item */
   static IOFX(A, jtioau, jthiau(jt, *v), !jtequ(jt, *v, av[hj]), ++v, --v)           /* boxed uniform type         */
-  static IOFX(X, jtiox, hix(v), !eqx(n, v, av + n * hj), v += cn, v -= cn)           /* extended integer           */
-  static IOFX(Q, jtioq, hiq(v), !eqq(n, v, av + n * hj), v += cn, v -= cn)           /* rational number            */
+  static IOFX(X, jtiox, hix(v), !jteqx(jt, n, v, av + n * hj), v += cn, v -= cn)           /* extended integer           */
+  static IOFX(Q, jtioq, hiq(v), !jteqq(jt, n, v, av + n * hj), v += cn, v -= cn)           /* rational number            */
   static IOFX(C, jtioc, hic(k, (UC*)v), memcmp(v, av + k * hj, k), v += cn, v -= cn) /* boolean, char, or integer  */
   static IOFX(
     C, jtiocx, hicx(jt, k, (UC*)v), memcmp(v, av + k * hj, k), v += cn, v -= cn) /* boolean, char, or integer  */
@@ -931,16 +931,16 @@ static IOFX(A, jtioax1, jthia(jt, t1, *v), !jtequ(jt, *v, av[hj]), ++v, --v)    
   // Verbs for the types of inputs
 
   // CMPLX array
-  static IOFT(Z, jtioz, THASHA, TFINDXY, TFINDYY, memcmp(v, av + n * hj, n * 2 * sizeof(D)), !eqz(n, v, av + n * hj))
+  static IOFT(Z, jtioz, THASHA, TFINDXY, TFINDYY, memcmp(v, av + n * hj, n * 2 * sizeof(D)), !jteqz(jt, n, v, av + n * hj))
   // CMPLX list
   static IOFT(Z, jtioz1, THASHA, TFINDXY, TFINDYY, memcmp(v, av + n * hj, 2 * sizeof(D)), !jtzeq(jt, *v, av[hj]))
   // FL array
-  static IOFT(D, jtiod, THASHA, TFINDXY, TFINDYY, memcmp(v, av + n * hj, n * sizeof(D)), !eqd(n, v, av + n * hj))
+  static IOFT(D, jtiod, THASHA, TFINDXY, TFINDYY, memcmp(v, av + n * hj, n * sizeof(D)), !jteqd(jt, n, v, av + n * hj))
   // FL list
   // should use macro for teq
   static IOFT(D, jtiod1, THASHA, TFINDXY, TFINDY1, x != av[hj], !TEQ(x, av[hj]))
   // boxed array with more than 1 box
-  static IOFT(A, jtioa, THASHBX, TFINDBX, TFINDBX, !eqa(n, v, av + n * hj), !eqa(n, v, av + n * hj))
+  static IOFT(A, jtioa, THASHBX, TFINDBX, TFINDBX, !jteqa(jt, n, v, av + n * hj), !jteqa(jt, n, v, av + n * hj))
   // singleton box
   static IOFT(A, jtioa1, THASHBX, TFINDBX, TFINDBX, !jtequ(jt, *v, av[hj]), !jtequ(jt, *v, av[hj]))
 
@@ -1587,7 +1587,7 @@ jtnodupgrade(J jt, A a, I acr, I ac, I acn, I ad, I n, I m, B b, B bk) {
             if (bk) {
                 hu = --hi;
                 DQ(
-                  m - 1, q = *hi--; v = av + n * q; if (!eqa(n, u, v)) {
+                  m - 1, q = *hi--; v = av + n * q; if (!jteqa(jt, n, u, v)) {
                       u     = v;
                       *hu-- = q;
                   });
@@ -1596,7 +1596,7 @@ jtnodupgrade(J jt, A a, I acr, I ac, I acn, I ad, I n, I m, B b, B bk) {
             } else {
                 hu = ++hi;
                 DQ(
-                  m - 1, q = *hi++; v = av + n * q; if (!eqa(n, u, v)) {
+                  m - 1, q = *hi++; v = av + n * q; if (!jteqa(jt, n, u, v)) {
                       u     = v;
                       *hu++ = q;
                   });
@@ -1621,7 +1621,7 @@ jtnodupgrade(J jt, A a, I acr, I ac, I acn, I ad, I n, I m, B b, B bk) {
         u              = av + n * p;                                                                           \
         zstmti; /* u->first result value, install result for that value to index itself */                     \
         DQ(                                                                                                    \
-          m - 1, q = *hiinc; v = av + n * q; if (eqa(n, u, v)) { zstmt1; } else {                              \
+          m - 1, q = *hiinc; v = av + n * q; if (jteqa(jt, n, u, v)) { zstmt1; } else {                              \
               u = v;                                                                                           \
               zstmt0;                                                                                          \
           }); /*                                                                                               \
@@ -2112,12 +2112,12 @@ jtindexofsub(J jt, I mode, A a, A w) {
         A z;
         // Handle sparse arguments
         if (1 >= acr)
-            return af ? sprank2(a, w, 0L, acr, RMAX, jtindexof) : wt & SPARSE ? iovxs(mode, a, w) : iovsd(mode, a, w);
-        if (af || wf) return sprank2(a, w, 0L, acr, wcr, jtindexof);
+            return af ? jtsprank2(jt, a, w, 0L, acr, RMAX, jtindexof) : wt & SPARSE ? jtiovxs(jt, mode, a, w) : jtiovsd(jt, mode, a, w);
+        if (af || wf) return jtsprank2(jt, a, w, 0L, acr, wcr, jtindexof);
         switch ((at & SPARSE ? 2 : 0) + (wt & SPARSE ? 1 : 0)) {
-            case 1: z = indexofxx(mode, a, w); break;
-            case 2: z = indexofxx(mode, a, w); break;
-            case 3: z = indexofss(mode, a, w); break;
+            case 1: z = jtindexofxx(jt, mode, a, w); break;
+            case 2: z = jtindexofxx(jt, mode, a, w); break;
+            case 3: z = jtindexofss(jt, mode, a, w); break;
         }
         EPILOG(z);
     }
@@ -2295,7 +2295,7 @@ jtindexofsub(J jt, I mode, A a, A w) {
         p = (UI)MIN(FLIMAX, (2.1 * MAX(m, c)));  // length we will use for hashtable, if small-range not used.
         if (!b && t & BOX + FL + CMPX) ctmask(jt);
         if (t & BOX)
-            fn = b && (1 < n || usebs(a, ac, m))                                                  ? jtiobs
+            fn = b && (1 < n || jtusebs(jt, a, ac, m))                                                  ? jtiobs
                  : 1 < n                                                                          ? jtioa
                  : b                                                                              ? jtioax1
                  : (t1 = jtutype(jt, a, ac)) && (mk || a == w || TYPESEQ(t1, jtutype(jt, w, wc))) ? jtioau
@@ -2670,7 +2670,7 @@ jtindexofprehashed(J jt, A a, A w, A hs) {
     if (ICMP(as + ar - r, ws + f1, r)) c = 0;  // and its shape at that rank must match the shape of a cell of a
     // If there is any error, switch back to the non-prehashed code.  We must remove any command bits from mode, leaving
     // just the operation type
-    if (!(m && n && c && HOMO(t, wt) && UNSAFE(t) >= UNSAFE(wt))) return indexofsub(mode & IIOPMSK, a, w);
+    if (!(m && n && c && HOMO(t, wt) && UNSAFE(t) >= UNSAFE(wt))) return jtindexofsub(jt, mode & IIOPMSK, a, w);
 
     // allocate enough space for the result, depending on the type of the operation
     switch (ztype) {
@@ -2712,14 +2712,14 @@ jtindexofprehashed(J jt, A a, A w, A hs) {
 // x i. y
 A
 jtindexof(J jt, A a, A w) {
-    return indexofsub(IIDOT, a, w);
+    return jtindexofsub(jt, IIDOT, a, w);
 }
 /* a i."r w */
 
 // x i: y
 A
 jtjico2(J jt, A a, A w) {
-    return indexofsub(IICO, a, w);
+    return jtindexofsub(jt, IICO, a, w);
 }
 /* a i:"r w */
 
@@ -2728,7 +2728,7 @@ A
 jtnubsieve(J jt, A w) {
     if (SPARSE & AT(w)) return jtnubsievesp(jt, w);
     jt->ranks = (RANKT)jt->ranks + ((RANKT)jt->ranks << RANKTX);  // we process as if dyad; make left rank=right rank
-    return indexofsub(INUBSV, w, w);
+    return jtindexofsub(jt, INUBSV, w, w);
 } /* ~:"r w */
 
 // ~. y  - does not have IRS
@@ -2737,7 +2737,7 @@ jtnub(J jt, A w) {
     FPREFIP;
     if (SPARSE & AT(w) || AFLAG(w) & AFNJA) return jtrepeat(jt, jtnubsieve(jt, w), w);
     A z;
-    RZ(z = indexofsub(INUB, w, w));
+    RZ(z = jtindexofsub(jt, INUB, w, w));
     // We extracted from w, so mark it (or its backer if virtual) non-pristine.  If w was pristine and inplaceable,
     // transfer its pristine status to the result.  We overwrite w because it is no longer in use
     PRISTXFERF(z, w)
@@ -2771,7 +2771,7 @@ jtless(J jt, A a, A w) {
     // if nothing special (like sparse, or incompatible types, or x requires conversion) do the fast way; otherwise (-.
     // x e. y) # y
     RZ(x = !(at & SPARSE) && HOMO(at, wt) && TYPESEQ(at, maxtype(at, wt)) && !(AFLAG(a) & AFNJA)
-             ? indexofsub(ILESS, x, a)
+             ? jtindexofsub(jt, ILESS, x, a)
              : jtrepeat(jt, jtnot(jt, jteps(jt, a, x)), a));
     // We extracted from a, so mark it non-pristine.  If a was pristine and inplaceable, transfer its pristine status to
     // the result
@@ -2789,23 +2789,23 @@ jteps(J jt, A a, A w) {
     r = AR(w) < r ? AR(w) : r;
     RESETRANK;
     if (SPARSE & (AT(a) | AT(w)))
-        return lt(irs2(w, a, 0L, r, l, jtindexof),
+        return lt(jtirs2(jt, w, a, 0L, r, l, jtindexof),
                   jtsc(jt, r ? *(AS(w) + AR(w) - r) : 1));  // for sparse, implement as (# cell of y) > y i. x
     jt->ranks = (RANK2T)((r << RANKTX) + l);                // swap ranks for subroutine.  Subroutine will reset ranks
-    return indexofsub(IEPS, w, a);
+    return jtindexofsub(jt, IEPS, w, a);
 } /* a e."r w */
 
 // I.@~: y   does not have IRS
 A
 jtnubind(J jt, A w) {
-    return SPARSE & AT(w) ? jticap(jt, jtnubsieve(jt, w)) : indexofsub(INUBI, w, w);
+    return SPARSE & AT(w) ? jticap(jt, jtnubsieve(jt, w)) : jtindexofsub(jt, INUBI, w, w);
 } /* I.@~: w */
 
 // i.@(~:!.0) y     does not have IRS
 A
 jtnubind0(J jt, A w) {
     A z;
-    PUSHCCT(1.0) z = SPARSE & AT(w) ? jticap(jt, jtnubsieve(jt, w)) : indexofsub(INUBI, w, w);
+    PUSHCCT(1.0) z = SPARSE & AT(w) ? jticap(jt, jtnubsieve(jt, w)) : jtindexofsub(jt, INUBI, w, w);
     POPCCT
     return z;
 } /* I.@(~:!.0) w */
@@ -2821,7 +2821,7 @@ jtsclass(J jt, A w) {
     SETIC(w, n);                  // n=#items of y
     RZ(x = jtindexof(jt, w, w));  // x = i.~ y
     // if w is dense, return ((x = i.n) # x) =/ x
-    if (DENSE & AT(w)) return atab(CEQ, jtrepeat(jt, eq(IX(n), x), x), x);
+    if (DENSE & AT(w)) return jtatab(jt, CEQ, jtrepeat(jt, eq(IX(n), x), x), x);
     // if x is sparse... ??
     p = PAV(x);
     e = SPA(p, e);

--- a/jsrc/verbs/vi.c
+++ b/jsrc/verbs/vi.c
@@ -1690,7 +1690,7 @@ jtiobs(J jt, I mode, I m, I n, I c, I k, I acr, I wcr, I ac, I wc, I ak, I wk, A
     zb      = (B*)zv;
     zc      = (C*)zv;
     // If a has not been sorted already, sort it
-    if (mode < IPHOFFSET) RZ(*hp = h = nodupgrade(a, acr, ac, acn, 0, n, m, b, bk));
+    if (mode < IPHOFFSET) RZ(*hp = h = jtnodupgrade(jt, a, acr, ac, acn, 0, n, m, b, bk));
     if (w == mark) return mark;
     hv                           = AV(h) + bk * (m - 1);
     jt->workareas.compare.complt = -1;

--- a/jsrc/verbs/viix.c
+++ b/jsrc/verbs/viix.c
@@ -241,7 +241,7 @@ jticap2(J jt, A a, A w) {
     t = maxtyped(at, wt);
     if (1 == c) {  // the search is for atoms
         if (at & B01 && wt & B01 + INT + FL) {
-            RZ(iixBX(n, m, a, w, zv));
+            RZ(jtiixBX(jt, n, m, a, w, zv));
             return z;
         }
         if (at & wt & INT) {
@@ -254,7 +254,7 @@ jticap2(J jt, A a, A w) {
               (nlg << 1) +
               (SGNTO0(SGNIF((n << 1), nlg)));  // approx lg with 1 bit frac precision.  Can't shift 64 bits in case r=1
             if ((I)((r >> 2) + 2 * n) < (I)(m * nlg)) {
-                RZ(iixI(n, m, a, w, zv));
+                RZ(jtiixI(jt, n, m, a, w, zv));
                 return z;
             }  // weight misbranches as equiv to 8 stores
         }

--- a/jsrc/verbs/visp.c
+++ b/jsrc/verbs/visp.c
@@ -67,10 +67,10 @@ jtiovxs(J jt, I mode, A a, A w) {
         if (jtequ(jt, ae, e))
             SPB(zp, e, jtsc(jt, j))
         else {
-            RE(k = jti0(jt, indexofsub(mode, ax, e)));
+            RE(k = jti0(jt, jtindexofsub(jt, mode, ax, e)));
             SPB(zp, e, jtsc(jt, AN(ay) ? (m > k ? yv[k] : n) : k));
         }
-        RZ(q = indexofsub(mode, ax, x));
+        RZ(q = jtindexofsub(jt, mode, ax, x));
         v = AV(q);
         if (AN(ay) || AN(SPA(ap, a))) {
             DQ(AN(x), k = *v; *v++ = m > k ? yv[k] : n;);
@@ -84,8 +84,8 @@ jtiovxs(J jt, I mode, A a, A w) {
         SPB(zp, x, q);
     } else {
         if (h && TYPESNE(t, at)) RZ(a = jtcvt(jt, t, a));
-        SPB(zp, e, indexofsub(mode, a, e));
-        SPB(zp, x, indexofsub(mode, a, x));
+        SPB(zp, e, jtindexofsub(jt, mode, a, e));
+        SPB(zp, x, jtindexofsub(jt, mode, a, x));
     }
     return z;
 } /* vector i. sparse */
@@ -99,7 +99,7 @@ jtiovsd(J jt, I mode, A a, A w) {
     ap = PAV(a);
     ax = SPA(ap, x);
     ay = SPA(ap, i);
-    if (!AN(ay)) return indexofsub(mode, jtravel(jt, ax), w);
+    if (!AN(ay)) return jtindexofsub(jt, mode, jtravel(jt, ax), w);
     m  = AN(ax);
     n  = *AS(a);
     yv = AV(ay);
@@ -109,7 +109,7 @@ jtiovsd(J jt, I mode, A a, A w) {
     if (h = HOMO(at, wt)) t = maxtype(at, wt);
     if (h && TYPESNE(t, wt)) RZ(w = jtcvt(jt, t, w));
     j = jtioev(jt, mode, a);
-    RZ(z = indexofsub(mode, ax, w));
+    RZ(z = jtindexofsub(jt, mode, ax, w));
     v = AV(z);
     RZ(p = eq(ae, w));
     pv = BAV(p);
@@ -136,14 +136,14 @@ jtindexofxx(J jt, I mode, A a, A w) {
         m = wr;
         n = ar;
     }
-    RZ(b = bfi(m, SPA(p, a), 1));
+    RZ(b = jtbfi(jt, m, SPA(p, a), 1));
     b[0] = 1;
     GATV0(x, B01, n, 1);
     c = BAV(x);
     DO(ABS(d), c[i] = s;);  // initialize unfilled part of c
     j = 0;
     DQ(MIN(ar, wr), ++j; c[n - j] = b[m - j];);
-    return indexofss(mode, s ? a : jtreaxis(jt, jtifb(jt, n, c), a), s ? jtreaxis(jt, jtifb(jt, n, c), w) : w);
+    return jtindexofss(jt, mode, s ? a : jtreaxis(jt, jtifb(jt, n, c), a), s ? jtreaxis(jt, jtifb(jt, n, c), w) : w);
 } /* dense i. sparse   or   sparse i. dense;  1<AR(a) */
 
 static A
@@ -171,7 +171,7 @@ jtioe(J jt, I mode, A w) {
         AR(b)        = 2;
     }
     if (1 < AR(b)) RZ(b = jtaslash1(jt, CSTARDOT, b)); /* b=. *./@,"_1 (3$.w)=5$.w */
-    RZ(y = irs2(num(0), y, 0L, 0L, 1L, jtfrom));
+    RZ(y = jtirs2(jt, num(0), y, 0L, 0L, 1L, jtfrom));
     RZ(df2(p, y, b, jtsldot(jt, jtslash(jt, ds(CSTARDOT)))));
     RZ(j = jtrepeat(jt, jtnot(jt, p), jtrepeat(jt, ne(y, jtcurtail(jt, jtover(jt, num(-1), y))), y)));
     jn = AN(j);
@@ -210,7 +210,7 @@ jtioresparse(J jt, B aw, A* za, A* zw) {
     a  = *za;
     ar = AR(a);
     ap = PAV(a);
-    RZ(ab = bfi(ar, SPA(ap, a), 1));
+    RZ(ab = jtbfi(jt, ar, SPA(ap, a), 1));
     if (!*ab) *ab = ac = 1;
     if (aw) {
         w  = *zw;
@@ -221,7 +221,7 @@ jtioresparse(J jt, B aw, A* za, A* zw) {
             RZ(w = jtrezero(jt, e, w));
             wp = PAV(w);
         }
-        RZ(wb = bfi(wr, SPA(wp, a), 1));
+        RZ(wb = jtbfi(jt, wr, SPA(wp, a), 1));
         j = wr - ar;
         DO(ar - 1, ++j; if (ab[1 + i] < wb[j]) ab[1 + i] = ac = 1; else if (ab[1 + i] > wb[j]) wb[j] = wc = 1;);
         DO(1 + wr - ar, if (!wb[i]) wb[i] = wc = 1;);
@@ -243,7 +243,7 @@ jtiopart(J jt, A w, I r, I mm, I* zc, A* zi, A* zj, A* zx) {
     wy = SPA(wp, i);
     wx = SPA(wp, x);
     n  = AR(wx) - 1;
-    RZ(b = jtnot(jt, irs2(wx, jtreshape(jt, vec(INT, n, 1 + AS(wx)), SPA(wp, e)), 0L, n, n, jtmatch)));
+    RZ(b = jtnot(jt, jtirs2(jt, wx, jtreshape(jt, jtvec(jt, INT, n, 1 + AS(wx)), SPA(wp, e)), 0L, n, n, jtmatch)));
     if (!all1(b)) {
         RZ(wx = jtrepeat(jt, b, wx));
         RZ(wy = jtrepeat(jt, b, wy));
@@ -319,26 +319,26 @@ jtindexofss(J jt, I mode, A a, A w) {
     wr = AR(w);
     wp = PAV(w);
     r  = 1 + wr - ar;
-    RZ(ioresparse(aw, &a, &w));
+    RZ(jtioresparse(jt, aw, &a, &w));
     v  = AS(a);
     n  = *v++;
     mm = -1;
     DO(ar - 1, mm = MAX(mm, v[i]););
     c = -1;
-    RZ(iopart(a, ar - 1, mm, &c, &ai, &aj, &ax));
-    if (aw) RZ(iopart(w, ar - 1, mm, &c, &wi, &wj, &wx));
+    RZ(jtiopart(jt, a, ar - 1, mm, &c, &ai, &aj, &ax));
+    if (aw) RZ(jtiopart(jt, w, ar - 1, mm, &c, &wi, &wj, &wx));
     switch (aw ? (FL + CMPX & maxtype(AT(ax), AT(wx)) ? 3 : 1) : FL + CMPX & AT(ax) ? 2 : 0) {
         case 0: x = jtstitch(jt, aj, ax); break;
         case 1:
             x = jtstitch(jt, aj, ax);
             y = jtstitch(jt, wj, wx);
             break;
-        case 2: x = jtstitch(jt, aj, 1.0 != jt->cct ? iocol(mode, ax, ax) : jtifdz(jt, ax)); break;
+        case 2: x = jtstitch(jt, aj, 1.0 != jt->cct ? jtiocol(jt, mode, ax, ax) : jtifdz(jt, ax)); break;
         case 3:
-            x = jtstitch(jt, aj, 1.0 != jt->cct ? iocol(mode, ax, ax) : jtifdz(jt, ax));
-            y = jtstitch(jt, wj, 1.0 != jt->cct ? iocol(mode, ax, wx) : jtifdz(jt, wx));
+            x = jtstitch(jt, aj, 1.0 != jt->cct ? jtiocol(jt, mode, ax, ax) : jtifdz(jt, ax));
+            y = jtstitch(jt, wj, 1.0 != jt->cct ? jtiocol(jt, mode, ax, wx) : jtifdz(jt, wx));
     }
-    RZ(x = indexofsub(mode, x, aw ? y : x));
+    RZ(x = jtindexofsub(jt, mode, x, aw ? y : x));
     u = AV(x);
     m = *AS(ai);
     v = AV(ai);
@@ -349,7 +349,7 @@ jtindexofss(J jt, I mode, A a, A w) {
     if (!r) return AN(x) ? jtsc(jt, *u) : jtioe(jt, mode, a);
     GASPARSE(z, SINT, 1, r, AS(w));
     zp = PAV(z);
-    SPB(zp, a, apvwr(r, 0L, 1L));
+    SPB(zp, a, jtapvwr(jt, r, 0L, 1L));
     SPB(zp, e, jtioe(jt, mode, a));
     SPB(zp, i, aw ? wi : ai);
     SPB(zp, x, x);
@@ -368,7 +368,7 @@ jtnubsievesp(J jt, A w) {
     RESETRANK;
     n = r ? *(AS(w) + wr - r) : 1;
     if (r < wr)
-        return ATOMIC2(jt, IX(n), irs2(w, w, 0L, r, r, jtindexof), rkblk, 1L, r ? 1L : 0L, CEQ);  // seems to fail
+        return ATOMIC2(jt, IX(n), jtirs2(jt, w, w, 0L, r, r, jtindexof), rkblk, 1L, r ? 1L : 0L, CEQ);  // seems to fail
     RZ(x = jtindexof(jt, w, w));
     p = PAV(x);
     y = SPA(p, i);

--- a/jsrc/verbs/vm.c
+++ b/jsrc/verbs/vm.c
@@ -124,13 +124,13 @@ I
 cirBD(I n, I m, B* RESTRICTI x, D* RESTRICTI y, D* RESTRICTI z, J jt) {
     ASSERTWR(n <= 1 && 1 == m, EWIMAG);
     n ^= REPSGN(n);
-    return cirx(n, (I)*x, z, y);
+    return jtcirx(jt, n, (I)*x, z, y);
 }
 I
 cirID(I n, I m, I* RESTRICTI x, D* RESTRICTI y, D* RESTRICTI z, J jt) {
     ASSERTWR(n <= 1 && 1 == m, EWIMAG);
     n ^= REPSGN(n);
-    return cirx(n, *x, z, y);
+    return jtcirx(jt, n, *x, z, y);
 }
 
 I
@@ -139,7 +139,7 @@ cirDD(I n, I m, D* RESTRICTI x, D* RESTRICTI y, D* RESTRICTI z, J jt) {
     ASSERTWR(k == *x, EVDOMAIN);
     ASSERTWR(n <= 1 && 1 == m, EWIMAG);  // if more than one x value, retry as general case
     n ^= REPSGN(n);                      // convert complementary n to nonneg
-    return cirx(n, k, z, y);
+    return jtcirx(jt, n, k, z, y);
 }
 
 A

--- a/jsrc/verbs/vo.c
+++ b/jsrc/verbs/vo.c
@@ -337,7 +337,7 @@ jtassembleresults(J jt,
         zpri += AN(zz) ? 256 : 0;  // priority of unboxed results, giving high pri to nonempty
         zzresultpri = (zpri > zzresultpri) ? zpri : zzresultpri;
         I zft       = ((I)1) << (jt->prioritytype[zzresultpri & 255]);  // zft=highest precision encountered
-        fillv(zft, 1L, jt->fillv0);
+        jtfillv(jt, zft, 1L, jt->fillv0);
         I zfs = bpnoun(zft);
         mvc(sizeof(jt->fillv0),
             jt->fillv0,
@@ -358,7 +358,7 @@ jtassembleresults(J jt,
             // many atoms as given
             I zatomct = (zzcellp >> zzatomshift) -
                         (startatend & (AN(zz) - (zzcelllen >> zzatomshift)));  // get # atoms that have been filled in
-            ASSERT(ccvt(zft | NOUNCVTVALIDCT, zz, (A *)&zatomct), EVDOMAIN);
+            ASSERT(jtccvt(jt, zft | NOUNCVTVALIDCT, zz, (A *)&zatomct), EVDOMAIN);
             zz = (A)zatomct;  // flag means convert zcellct atoms.  Not worth checking for empty
             // change the strides to match the new cellsize
             if (zexpshift >= 0) {
@@ -624,7 +624,7 @@ jtopes2(J jt, A *zx, A *zy, B *b, A a, A e, A q, I wcr) {
     t  = AT(q);
     if (t & SPARSE) {
         p = PAV(q);
-        RZ(c = bfi(r, SPA(p, a), 1));
+        RZ(c = jtbfi(jt, r, SPA(p, a), 1));
         DO(
           r, if (b[k + i] != c[i]) {
               RZ(q = jtreaxis(jt, jtifb(jt, r, k + b), q));
@@ -639,7 +639,7 @@ jtopes2(J jt, A *zx, A *zy, B *b, A a, A e, A q, I wcr) {
             memcpy(AV(x), AV(q), AN(q) << bplg(t));
             q = x;
         }
-        RZ(q = sparseit(t & dt ? q : jtcvt(jt, dt, q), a, e));
+        RZ(q = jtsparseit(jt, t & dt ? q : jtcvt(jt, dt, q), a, e));
     }
     p = PAV(q);
     x = SPA(p, x);
@@ -662,7 +662,7 @@ jtopes(J jt, I zt, A cs, A w) {
     wcr = AN(cs);
     dt  = DTYPE(zt);
     dk  = bpnoun(dt);
-    RZ(opes1(&b, &a, &e, &m, cs, w));
+    RZ(jtopes1(jt, &b, &a, &e, &m, cs, w));
     an = AN(a);
     av = AV(a);
     GASPARSE(z, zt, 1, wr + wcr, (I *)0);
@@ -701,7 +701,7 @@ jtopes(J jt, I zt, A cs, A w) {
     yv   = AV(y);
     memset(yv, C0, SZI * i);
     for (i = p = 0; i < n; ++i) {
-        RZ(opes2(&x1, &y1, b, a, e, wv[i], wcr));
+        RZ(jtopes2(jt, &x1, &y1, b, a, e, wv[i], wcr));
         v  = AS(y1);
         m1 = v[0];
         k  = v[1];
@@ -792,7 +792,7 @@ jtope(J jt, A w) {
     // find the shape of a result-cell
     DO(n, y = v[i]; s = AS(y); p = u + r - AR(y); DO(AR(y), p[i] = MAX(p[i], s[i]);););
     if ((t & SPARSE) != 0)
-        RZ(z = opes(t, cs, w))
+        RZ(z = jtopes(jt, t, cs, w))
     else {
         I klg;
         I m;
@@ -804,7 +804,7 @@ jtope(J jt, A w) {
         GA(z, t, zn, r + AR(w), AS(w));
         MCISH(AS(z) + AR(w), u, r);
         x = CAV(z);
-        fillv(t, zn, x);  // init to a:  fills  bug copy shape could overrun w
+        jtfillv(jt, t, zn, x);  // init to a:  fills  bug copy shape could overrun w
         for (i = 0; i < n; ++i) {
             y = v[i];  // get pointer to contents
             if (!nonh)
@@ -984,7 +984,7 @@ jtraze(J jt, A w) {
         // t is the type to use.  i is 0 if there were no nonempties
         // if there are only empties, t is the type to use
         // if the cell-rank was 2 or higher, there may be reshaping and fill needed - go to the general case
-        if (1 < r) return razeg(w, t, n, r, v, i);
+        if (1 < r) return jtrazeg(jt, w, t, n, r, v, i);
         // fall through for boxes containing lists and atoms, where the result is a list.  No fill possible, but if all
         // inputs are empty the fill-cell will give the type of the result (similar to 0 {.!.f 0$...)
 

--- a/jsrc/verbs/vp.c
+++ b/jsrc/verbs/vp.c
@@ -129,7 +129,7 @@ jtcfd(J jt, A w) {
             zv = AAV(z);
             zn = AN(z);
         }
-        RZ(zv[i++] = jtincorp(jt, vec(INT, u - qv, qv)));
+        RZ(zv[i++] = jtincorp(jt, jtvec(jt, INT, u - qv, qv)));
     }
     AN(z) = AS(z)[0] = zn = i;
     j                     = zn - 1;
@@ -149,7 +149,7 @@ jtdfc(J jt, I n, A w) {
     GATV0(b, B01, n, 1);
     bv = BAV(b);
     memset(bv, C1, n);
-    RZ(z = apvwr(n, 0L, 1L));
+    RZ(z = jtapvwr(jt, n, 0L, 1L));
     x  = AV(z);
     wv = AAV(w);
     for (j = AN(w) - 1; 0 <= j; j--) {
@@ -266,7 +266,7 @@ jtadot1(J jt, A w) {
     F1RANK(1, jtadot1, UNUSED_VALUE);
     RZ(y = BOX & AT(w) ? jtcdot1(jt, w) : jtpfill(jt, jtord(jt, w), w));
     SETIC(y, n);
-    return jtbase2(jt, jtcvt(jt, XNUM, apv(n, n, -1L)), jtrfd(jt, y));
+    return jtbase2(jt, jtcvt(jt, XNUM, jtapv(jt, n, n, -1L)), jtrfd(jt, y));
 }
 
 A
@@ -282,7 +282,7 @@ jtadot2(J jt, A a, A w) {
         RZ(jtvi(jt, a));
         return w;
     }
-    RZ(p = jtdfr(jt, jtvi(jt, jtabase2(jt, apv(n, n, -1L), a))));
+    RZ(p = jtdfr(jt, jtvi(jt, jtabase2(jt, jtapv(jt, n, n, -1L), a))));
     return jtequ(jt, w, IX(n))
              ? p
              : jtfrom(

--- a/jsrc/verbs/vq.c
+++ b/jsrc/verbs/vq.c
@@ -39,8 +39,8 @@ jtqstd(J jt, Q w) {
     }
     QRE(g = jtxgcd(jt, w.n, w.d));
     if (QX1(g)) return w;
-    z.n = xdiv(w.n, g, XMEXACT);
-    z.d = xdiv(w.d, g, XMEXACT);
+    z.n = jtxdiv(jt, w.n, g, XMEXACT);
+    z.d = jtxdiv(jt, w.d, g, XMEXACT);
     return z;
 }
 
@@ -92,7 +92,7 @@ jtqrem(J jt, Q a, Q w) {
     if (c == XPINF) return 0 <= d ? w : a;
     if (c == XNINF) return 0 >= d ? w : a;
     q   = jtqdiv(jt, w, a);
-    m.n = jtxtymes(jt, a.n, xdiv(q.n, q.d, XMFLR));
+    m.n = jtxtymes(jt, a.n, jtxdiv(jt, q.n, q.d, XMFLR));
     m.d = a.d;
     z   = jtqminus(jt, w, m);
     QEPILOG(z);
@@ -157,7 +157,7 @@ jtqpow(J jt, Q a, Q w) {
         while (XDIG(e)) {
             if (1 & AV(e)[0]) QRE(z = jtqtymes(jt, z, t));
             QRE(t = jtqtymes(jt, t, t));
-            QRE(e = xdiv(e, x2, XMFLR));
+            QRE(e = jtxdiv(jt, e, x2, XMFLR));
         }
     }
     QEPILOG(z);
@@ -197,8 +197,8 @@ jtqlogz1(J jt, Q w) {
         }                     \
     }
 
-AMON(floorQ, X, Q, *z = xdiv(x->n, x->d, XMFLR);)
-AMON(ceilQ, X, Q, *z = xdiv(x->n, x->d, XMCEIL);)
+AMON(floorQ, X, Q, *z = jtxdiv(jt, x->n, x->d, XMFLR);)
+AMON(ceilQ, X, Q, *z = jtxdiv(jt, x->n, x->d, XMCEIL);)
 AMON(sgnQ, X, Q, *z = jtxsgn(jt, x->n);)
 AMON(absQ, Q, Q, z->n = jtrifvs(jt, mag(x->n)); z->d = x->d;)
 AMONPS(sqrtQ, Q, Q, , QSQRT(x), HDR1JERR)

--- a/jsrc/verbs/vrand.c
+++ b/jsrc/verbs/vrand.c
@@ -490,13 +490,13 @@ jtrngstateq(J jt, A w) {
             zv = AAV(z);
             RZ(*zv++ = num(0));
             RZ(*zv++ = jtincorp(jt, jtsc(jt, jt->rngI0[GBI])));
-            RZ(*zv++ = jtincorp(jt, vec(INT, GBN, jt->rngV0[GBI])));
+            RZ(*zv++ = jtincorp(jt, jtvec(jt, INT, GBN, jt->rngV0[GBI])));
             RZ(*zv++ = jtincorp(jt, jtsc(jt, jt->rngI0[MTI])));
-            RZ(*zv++ = jtincorp(jt, vec(INT, MTN, jt->rngV0[MTI])));
+            RZ(*zv++ = jtincorp(jt, jtvec(jt, INT, MTN, jt->rngV0[MTI])));
             RZ(*zv++ = jtincorp(jt, jtsc(jt, jt->rngI0[DXI])));
-            RZ(*zv++ = jtincorp(jt, vec(INT, DXN, jt->rngV0[DXI])));
+            RZ(*zv++ = jtincorp(jt, jtvec(jt, INT, DXN, jt->rngV0[DXI])));
             RZ(*zv++ = jtincorp(jt, jtsc(jt, jt->rngI0[MRI])));
-            RZ(*zv++ = jtincorp(jt, vec(INT, MRN, jt->rngV0[MRI])));
+            RZ(*zv++ = jtincorp(jt, jtvec(jt, INT, MRN, jt->rngV0[MRI])));
             return z;
         case GBI:
             n = GBN;
@@ -519,7 +519,7 @@ jtrngstateq(J jt, A w) {
     zv = AAV(z);
     RZ(*zv++ = jtincorp(jt, jtsc(jt, jt->rng)));
     RZ(*zv++ = jtincorp(jt, jtsc(jt, jt->rngi)));
-    RZ(*zv++ = jtincorp(jt, vec(INT, n, v)));
+    RZ(*zv++ = jtincorp(jt, jtvec(jt, INT, n, v)));
     return z;
 }
 
@@ -553,31 +553,31 @@ jtrngstates(J jt, A w) {
         case SMI:
             vv = jt->rngV0;
             RE(k = jti0(jt, wv[1]));
-            RZ(rngstates1(GBI, GBN, vv, 0, k, wv[2], 1));
+            RZ(jtrngstates1(jt, GBI, GBN, vv, 0, k, wv[2], 1));
             jt->rngI0[GBI] = k;  // We accept 0-55 even though we never produce 55 ourselves
             RE(k = jti0(jt, wv[3]));
-            RZ(rngstates1(MTI, MTN, vv, 0, k, wv[4], 0));
+            RZ(jtrngstates1(jt, MTI, MTN, vv, 0, k, wv[4], 0));
             jt->rngI0[MTI] = k;
             RE(k = jti0(jt, wv[5]));
-            RZ(rngstates1(DXI, DXN, vv, 0, k, wv[6], 1));
+            RZ(jtrngstates1(jt, DXI, DXN, vv, 0, k, wv[6], 1));
             jt->rngI0[DXI] = k;
             RE(k = jti0(jt, wv[7]));
-            RZ(rngstates1(MRI, MRN, vv, 0, k, wv[8], 0));
+            RZ(jtrngstates1(jt, MRI, MRN, vv, 0, k, wv[8], 0));
             jt->rngI0[MRI] = k;
             break;
         case GBI:
             RE(k = jti0(jt, wv[1]));
-            RZ(rngstates1(GBI, GBN, vv, 0, k, wv[2], 1));
+            RZ(jtrngstates1(jt, GBI, GBN, vv, 0, k, wv[2], 1));
             break;  // We accept 0-55 even though we never produce 55 ourselves
         case MTI:
             RE(k = jti0(jt, wv[1]));
-            RZ(rngstates1(MTI, MTN, vv, 0, k, wv[2], 0));
+            RZ(jtrngstates1(jt, MTI, MTN, vv, 0, k, wv[2], 0));
             break;
         case DXI:
             RE(k = jti0(jt, wv[1]));
-            RZ(rngstates1(DXI, DXN, vv, 0, k, wv[2], 1));
+            RZ(jtrngstates1(jt, DXI, DXN, vv, 0, k, wv[2], 1));
             break;
-        case MRI: RE(k = jti0(jt, wv[1])); RZ(rngstates1(MRI, MRN, vv, 0, k, wv[2], 0));
+        case MRI: RE(k = jti0(jt, wv[1])); RZ(jtrngstates1(jt, MRI, MRN, vv, 0, k, wv[2], 0));
     }
     return mtv;
 }
@@ -888,7 +888,7 @@ jtdeal(J jt, A a, A w) {
         do { RZ(z = jtnub(jt, jtrollksub(jt, h, w))); } while (AN(z) < m);
         RZ(z = jttake(JTIPW, a, z));
     } else {
-        RZ(z = apvwr(n, 0L, 1L));
+        RZ(z = jtapvwr(jt, n, 0L, 1L));
         zv = AV(z);
         if (n < (1LL << 50)) {
             // If we can do the calculation in the floating-point unit, do
@@ -1193,7 +1193,7 @@ jtdealdot(J jt, A a, A w) {
             }
         }
     } else {
-        RZ(z = apvwr(n, 0L, 1L));
+        RZ(z = jtapvwr(jt, n, 0L, 1L));
         zv = AV(z);
         DO(m, s = GMOF(c, x); t = NEXT; if (s) while (s <= t) t = NEXT; j = i + t % c--; k = zv[i]; zv[i] = zv[j];
            zv[j] = k;);

--- a/jsrc/verbs/vrep.c
+++ b/jsrc/verbs/vrep.c
@@ -29,10 +29,10 @@ jtrepzsx(J jt, A a, A w, I wf, I wcr) {
     ap = PAV(a);
     x  = SPA(ap, x);
     m  = AN(x);
-    if (!AN(SPA(ap, a))) return repzdx(jtravel(jt, x), w, wf, wcr);
+    if (!AN(SPA(ap, a))) return jtrepzdx(jt, jtravel(jt, x), w, wf, wcr);
     y  = SPA(ap, i);
     yv = AV(y);
-    RZ(x = jtcvt(jt, INT, vec(FL, 2 * m, AV(x))));
+    RZ(x = jtcvt(jt, INT, jtvec(jt, FL, 2 * m, AV(x))));
     xv = AV(x);
     if (jtequ(jt, num(0), SPA(ap, e))) {
         k = c = *(wf + AS(w));
@@ -58,12 +58,12 @@ jtrepzsx(J jt, A a, A w, I wf, I wcr) {
             }
         }
         ASSERT(k <= IMAX - 1, EVLIMIT);
-        if (c == k) RZ(w = irs2(jtsc(jt, 1 + k), w, 0L, 0L, wcr, jttake));
+        if (c == k) RZ(w = jtirs2(jt, jtsc(jt, 1 + k), w, 0L, 0L, wcr, jttake));
         DO(2 * m, ASSERT(0 <= xv[i], EVDOMAIN); p += xv[i]; ASSERT(0 <= p, EVLIMIT););
         GATV0(q, INT, p, 1);
         qv = AV(q);
         DO(m, c = *xv++; d = *xv++; j = yv[i]; DQ(c, *qv++ = j;); DQ(d, *qv++ = k;););
-        return irs2(q, w, 0L, 1L, wcr, jtfrom);
+        return jtirs2(jt, q, w, 0L, 1L, wcr, jtfrom);
     }
     ASSERT(0, EVNONCE);
 } /* (sparse complex) #"r (dense or sparse) */
@@ -74,7 +74,7 @@ jtrepbdx(J jt, A a, A w, I wf, I wcr) {
     I c, k, m, p;
     // wf and wcr are set
     FPREFIP;
-    if (SPARSE & AT(w)) return irs2(jtifb(jt, AN(a), BAV(a)), w, 0L, 1L, wcr, jtfrom);
+    if (SPARSE & AT(w)) return jtirs2(jt, jtifb(jt, AN(a), BAV(a)), w, 0L, 1L, wcr, jtfrom);
     m = AN(a);
     void *zvv;
     void *wvv = voidAV(w);
@@ -221,18 +221,18 @@ jtrepbsx(J jt, A a, A w, I wf, I wcr) {
     x  = SPA(ap, x);
     n  = AN(x);
     b  = BAV(x);
-    if (!AN(SPA(ap, a))) return irs2(jtifb(jt, n, b), w, 0L, 1L, wcr, jtfrom);
+    if (!AN(SPA(ap, a))) return jtirs2(jt, jtifb(jt, n, b), w, 0L, 1L, wcr, jtfrom);
     if (!*BAV(e)) {
         GATV0(q, INT, n, 1);
         v = v0 = AV(q);
         DO(n, if (*b++) *v++ = u[i];);
         AN(q) = AS(q)[0] = v - v0;
-        return irs2(q, w, 0L, 1L, wcr, jtfrom);
+        return jtirs2(jt, q, w, 0L, 1L, wcr, jtfrom);
     }
     wp = PAV(w);
     if (DENSE & AT(w) || all0(eq(jtsc(jt, wf), SPA(wp, a)))) {
         RZ(q = jtdenseit(jt, a));
-        return irs2(jtifb(jt, AN(q), BAV(q)), w, 0L, 1L, wcr, jtfrom);
+        return jtirs2(jt, jtifb(jt, AN(q), BAV(q)), w, 0L, 1L, wcr, jtfrom);
     }  // here if dense w
     wa = SPA(wp, a);
     wy = SPA(wp, i);
@@ -294,14 +294,14 @@ jtrepisx(J jt, A a, A w, I wf, I wcr) {
     x  = SPA(ap, x);
     if (!(INT & AT(x))) RZ(x = jtcvt(jt, INT, x));
     xv = AV(x);
-    if (!AN(SPA(ap, a))) return repidx(jtravel(jt, x), w, wf, wcr);
+    if (!AN(SPA(ap, a))) return jtrepidx(jt, jtravel(jt, x), w, wf, wcr);
     if (!*AV(e)) {
         m = AN(x);
         DO(m, ASSERT(0 <= xv[i], EVDOMAIN); p += xv[i]; ASSERT(0 <= p, EVLIMIT););
         GATV0(q, INT, p, 1);
         qv = AV(q);
         DO(m, c = xv[i]; j = yv[i]; DQ(c, *qv++ = j;););
-        return irs2(q, w, 0L, 1L, wcr, jtfrom);
+        return jtirs2(jt, q, w, 0L, 1L, wcr, jtfrom);
     }
     ASSERT(0, EVNONCE);
 } /* (sparse integer) #"r (dense or sparse) */
@@ -318,11 +318,11 @@ jtrep1d(J jt, A a, A w, I wf, I wcr) {
     SETICFR(w, wf, wcr, n);  // n=length of item axis in input.  If atom, is repeated to length of a
     if (t & CMPX) {
         if (wcr)
-            return repzdx(jtfrom(jt, apv(n, 0L, 0L), a), w, wf, wcr);
+            return jtrepzdx(jt, jtfrom(jt, jtapv(jt, n, 0L, 0L), a), w, wf, wcr);
         else {
             A za;
-            RZ(za = apv(m, 0L, 0L));
-            return repzdx(a, IRS2(za, w, 0L, 1L, 0L, jtfrom, z), wf, 1L);
+            RZ(za = jtapv(jt, m, 0L, 0L));
+            return jtrepzdx(jt, a, IRS2(za, w, 0L, 1L, 0L, jtfrom, z), wf, 1L);
         }
     }
     if (t & B01) {
@@ -374,11 +374,11 @@ jtrep1s(J jt, A a, A w, I wf, I wcr) {
     I c, d, cd, j, k, m, n, p, q, *u, *v, wr, *ws;
     P *wp, *zp;
     FPREFIP;
-    if (AT(a) & SCMPX) return rep1d(jtdenseit(jt, a), w, wf, wcr);
-    RE(rep1sa(a, &c, &d));
+    if (AT(a) & SCMPX) return jtrep1d(jt, jtdenseit(jt, a), w, wf, wcr);
+    RE(jtrep1sa(jt, a, &c, &d));
     cd = c + d;
     if (DENSE & AT(w))
-        return rep1d(d ? jtjdot2(jt, jtsc(jt, c), jtsc(jt, d)) : jtsc(jt, c), w, wf, wcr);  // here if dense w
+        return jtrep1d(jt, d ? jtjdot2(jt, jtsc(jt, c), jtsc(jt, d)) : jtsc(jt, c), w, wf, wcr);  // here if dense w
     wr = AR(w);
     ws = AS(w);
     n  = wcr ? *(wf + ws) : 1;
@@ -391,7 +391,7 @@ jtrep1s(J jt, A a, A w, I wf, I wcr) {
     GASPARSE(z, AT(w), 1, wr + !wcr, ws);
     *(wf + AS(z)) = m;
     zp            = PAV(z);
-    RE(b = bfi(wr, ax, 1));
+    RE(b = jtbfi(jt, wr, ax, 1));
     if (wcr && b[wf]) { /* along sparse axis */
         u = AS(y);
         p = u[0];
@@ -435,7 +435,7 @@ jtrep1s(J jt, A a, A w, I wf, I wcr) {
             xx       = jt->fill;
             jt->fill = e;
         }  // e cannot be virtual
-        x = irs2(AR(a) && CMPX & AT(a) ? a
+        x = jtirs2(jt, AR(a) && CMPX & AT(a) ? a
                  : d                   ? jtjdot2(jt, jtsc(jt, c), jtsc(jt, d))
                                        : jtsc(jt, c),
                  x,

--- a/jsrc/verbs/vs.c
+++ b/jsrc/verbs/vs.c
@@ -113,7 +113,7 @@ jtsparse1a(J jt, A s, A a, A e, A y, A x) {
     et = AT(e);
     ASSERT(!(et & LIT + BOX), EVNONCE);  // e must be numeric
     ASSERT(STYPE(et) != 0, EVDOMAIN);    // e must be dense
-    RZ(b = bfi(r, a, 0));
+    RZ(b = jtbfi(jt, r, a, 0));
     if (y == mark) {
         GAT0(y, INT, 0L, 2L);
         v    = AS(y);
@@ -230,7 +230,7 @@ jtsparseit(J jt, A w, A a, A e) {
         ASSERT(!AN(a), EVINDEX);
         return jtca(jt, w);
     }
-    RZ(z = sparse1a(shape(jt, w), a, e, mark, mark));
+    RZ(z = jtsparse1a(jt, shape(jt, w), a, e, mark, mark));
     p = PAV(z);
     RZ(ax = jtpaxis(jt, r, a));
     GATV0(y, INT, r, 1);
@@ -247,11 +247,11 @@ jtsparseit(J jt, A w, A a, A e) {
     if (r > n) ICPY(1 + v, n + s, r - n);
     b = b && SB01 & AT(z) && jtequ(jt, e, num(0));
     c = w;
-    if (!b) RZ(c = jtnot(jt, irs2(jtreshape(jt, vec(INT, r - n, n + s), SPA(p, e)), x, VFLAGNONE, RMAX, -1L, jtmatch)));
+    if (!b) RZ(c = jtnot(jt, jtirs2(jt, jtreshape(jt, jtvec(jt, INT, r - n, n + s), SPA(p, e)), x, VFLAGNONE, RMAX, -1L, jtmatch)));
     cn = AN(c);
     cv = BAV(c);
     cm = bsum(cn, cv);
-    /* RZ(y=jtabase2(jt,vec(INT,n,s),jtrepeat(jt,c,IX(cn)))); */
+    /* RZ(y=jtabase2(jt,jtvec(jt, INT,n,s),jtrepeat(jt,c,IX(cn)))); */
     GATV0(y, INT, cm * n, 2);
     u    = AS(y);
     *u++ = cm;
@@ -333,7 +333,7 @@ jtdenseit(J jt, A w) {
     GA(z, t, n, r, s);
     zv = CAV(z);
     xv = CAV(x);
-    if (1 < an) RZ(y = jtbase2(jt, vec(INT, an, s), y));
+    if (1 < an) RZ(y = jtbase2(jt, jtvec(jt, INT, an, s), y));
     yv = AV(y);
     k  = bpnoun(t);
     ck = k * jtaii(jt, x);
@@ -349,7 +349,7 @@ jtreaxis(J jt, A a, A w) {
     I c, d, j, k, m, r, *u, *v, *ws, wt;
     P *wp, *zp;
     wt = AT(w);
-    if (wt & DENSE) return sparseit(w, a, jtselm(jt, wt));
+    if (wt & DENSE) return jtsparseit(jt, w, a, jtselm(jt, wt));
     r  = AR(w);
     ws = AS(w);
     wp = PAV(w);
@@ -379,11 +379,11 @@ jtreaxis(J jt, A a, A w) {
               v[k++] = d;
           } else u[j++] = d;);
         *u = c * m;
-        RZ(x = jtreshape(jt, vec(INT, j, u), jtcant2(jt, jtincrem(jt, jtdgrade1(jt, p)), x)));
-        RZ(q = jtnot(jt, irs2(x, jtreshape(jt, vec(INT, AR(x) - 1, 1 + AS(x)), e), 0L, -1L, RMAX, jtmatch)));
+        RZ(x = jtreshape(jt, jtvec(jt, INT, j, u), jtcant2(jt, jtincrem(jt, jtdgrade1(jt, p)), x)));
+        RZ(q = jtnot(jt, jtirs2(jt, x, jtreshape(jt, jtvec(jt, INT, AR(x) - 1, 1 + AS(x)), e), 0L, -1L, RMAX, jtmatch)));
         SPBV(zp, x, x, jtrepeat(jt, q, x));
         RZ(y = jtstitch(
-             jt, jtrepeat(jt, jtsc(jt, c), y), jtreshape(jt, jtv2(jt, c * m, k), jtabase2(jt, vec(INT, k, v), IX(c)))));
+             jt, jtrepeat(jt, jtsc(jt, c), y), jtreshape(jt, jtv2(jt, c * m, k), jtabase2(jt, jtvec(jt, INT, k, v), IX(c)))));
         RZ(p = jtgrade1(jt, jtover(jt, a, jtless(jt, a1, a))));
         if (jtequ(jt, p, IX(AN(p))))
             SPB(zp, i, jtrepeat(jt, q, y))
@@ -425,7 +425,7 @@ jtreaxis(J jt, A a, A w) {
         RE(jtprod(jt, j, u));
         u[j] = k = 1;
         DQ(c - d, --j; u[j] = k *= u[j];);
-        RZ(q = jtpdt(jt, jttake(jt, jtv2(jt, m, d - c), y), vec(INT, c - d, 1 + u)));
+        RZ(q = jtpdt(jt, jttake(jt, jtv2(jt, m, d - c), y), jtvec(jt, INT, c - d, 1 + u)));
         iv = AV(q);
         RZ(p = jtover(jt, jtless(jt, a, a1), jtdaxis(jt, r, a)));
         v  = AV(p);
@@ -500,12 +500,12 @@ jtaxbytes(J jt, A a, A w) {
         b = BAV(p);
         v = c + AS(x);
         DO(AN(p), if (!b[i]) u[j++] = v[i];);
-        RZ(q = irs2(
-             jtcant2(jt, plus(jtsc(jt, c), jtdgrade1(jt, p)), x), jtreshape(jt, vec(INT, j, u), e), 0L, j, j, jtmatch));
+        RZ(q = jtirs2(jt, 
+             jtcant2(jt, plus(jtsc(jt, c), jtdgrade1(jt, p)), x), jtreshape(jt, jtvec(jt, INT, j, u), e), 0L, j, j, jtmatch));
         b = BAV(q);
         n = AN(q);
         DQ(n, if (*b++)-- n;);
-        return axbytes1(AT(e), d, n, j, u);
+        return jtaxbytes1(jt, AT(e), d, n, j, u);
     }
     if (all1(jteps(jt, a1, a))) {
         A y = SPA(wp, i); /* new is subset of old */
@@ -519,7 +519,7 @@ jtaxbytes(J jt, A a, A w) {
         RZ(p = jtover(jt, jtless(jt, a, a1), jtdaxis(jt, r, a)));
         v = AV(p);
         DQ(AN(p), u[j++] = ws[*v++];);
-        return axbytes1(AT(e), d, n, j, u);
+        return jtaxbytes1(jt, AT(e), d, n, j, u);
     }
     return jtaxbytes(jt, a1, jtreaxis(jt, jtover(jt, a, jtless(jt, a1, a)), w));
 } /* bytes required for (2;a)$.w */
@@ -555,8 +555,8 @@ jtaxtally(J jt, A a, A w) {
         b = BAV(p);
         v = c + AS(x);
         DO(AN(p), if (!b[i]) u[j++] = v[i];);
-        RZ(q = irs2(
-             jtcant2(jt, plus(jtsc(jt, c), jtdgrade1(jt, p)), x), jtreshape(jt, vec(INT, j, u), e), 0L, j, j, jtmatch));
+        RZ(q = jtirs2(jt, 
+             jtcant2(jt, plus(jtsc(jt, c), jtdgrade1(jt, p)), x), jtreshape(jt, jtvec(jt, INT, j, u), e), 0L, j, j, jtmatch));
         b = BAV(q);
         n = AN(q);
         DQ(n, if (*b++)-- n;);
@@ -610,7 +610,7 @@ jtunzero(J jt, A w) {
     r  = AR(x) - 1;
     GASPARSE(z, AT(w), 1, AR(w), AS(w));
     zp = PAV(z);
-    RZ(q = jtnot(jt, irs2(x, jtreshape(jt, vec(INT, r, 1 + AS(x)), e), 0L, r, r, jtmatch)));
+    RZ(q = jtnot(jt, jtirs2(jt, x, jtreshape(jt, jtvec(jt, INT, r, 1 + AS(x)), e), 0L, r, r, jtmatch)));
     SPB(zp, x, jtrepeat(jt, q, x));
     SPB(zp, i, jtrepeat(jt, q, SPA(wp, i)));
     SPB(zp, a, jtca(jt, SPA(wp, a)));
@@ -628,7 +628,7 @@ jtsparsep1(J jt, A w) {
         wv = AAV(w);
         ASSERT(1 <= n && n <= 3 || 5 == n, EVLENGTH);
     }
-    return sparse1a(
+    return jtsparse1a(jt, 
       0 < n ? wv[0] : w, 1 < n ? wv[1] : mark, 2 < n ? wv[2] : mark, 3 < n ? wv[3] : mark, 4 < n ? wv[4] : mark);
 }
 
@@ -650,7 +650,7 @@ jtsparsen1(J jt, A w) {
 A
 jtsparse1(J jt, A w) {
     if (!AR(w) || SPARSE & AT(w)) return jtca(jt, w);
-    return sparseit(w, IX(AR(w)), jtselm(jt, AT(w)));
+    return jtsparseit(jt, w, IX(AR(w)), jtselm(jt, AT(w)));
 } /* $. y */
 
 A

--- a/jsrc/vq.h
+++ b/jsrc/vq.h
@@ -14,7 +14,7 @@
     {                                                    \
         Q z9;                                            \
         z9 = (jtqstd(jt, q));                            \
-        if (!gc3(&z9.n, &z9.d, 0L, _ttop)) return zeroQ; \
+        if (!jtgc3(jt, &z9.n, &z9.d, 0L, _ttop)) return zeroQ; \
         return z9;                                       \
     }
 #define QRE(exp)                           \

--- a/jsrc/vx.h
+++ b/jsrc/vx.h
@@ -12,7 +12,7 @@
 #define XDIG(a) (AV(a)[AN(a) - 1]) /* leading digit              */
 #define XMAX(x, y) (1 == jtxcompare(jt, x, y) ? x : y)
 #define XMIN(x, y) (1 == jtxcompare(jt, x, y) ? y : x)
-#define XDIV(x, y) xdiv(x, y, jt->xmode)
+#define XDIV(x, y) jtxdiv(jt, x, y, jt->xmode)
 #define XCUBE(x) jtxtymes(jt, x, jtxtymes(jt, x, x))
 
 /* values for jt->xmode */

--- a/jsrc/words/w.c
+++ b/jsrc/words/w.c
@@ -438,13 +438,13 @@ jtenqueue(J jt, A a, A w, I env) {
                 if (!(*x = jtconnum(jt, wl, wi))) {
                     I lje = jt->jerr;
                     RESETERR;
-                    jsignal3(lje, w, u[0]);
+                    jtjsignal3(jt, lje, w, u[0]);
                     return 0;
                 }  // starts with numeric, create numeric constant.. If error, give a message showing the bad number
             } else if (p == CQ) {
                 RZ(*x = jtconstr(jt, wl, wi));  // start with ', make string constant
             } else {
-                jsignal3(EVSPELL, w, wi - s);
+                jtjsignal3(jt, EVSPELL, w, wi - s);
                 return 0;
             }  // bad first character or inflection
         }
@@ -536,7 +536,7 @@ A
 jttokens(J jt, A w, I env) {
     A t;
     RZ(t = jtwordil(jt, w));
-    ASSERT(AM(t) >= 0, EVOPENQ) return enqueue(t, w, env);
+    ASSERT(AM(t) >= 0, EVOPENQ) return jtenqueue(jt, t, w, env);
 }
 // enqueue produces nonrecursive result, and so does tokens.  This is OK because the result is always parsed and is
 // never an argument to a verb
@@ -562,7 +562,7 @@ jttokens(J jt, A w, I env) {
         CHKJ(j);                          \
         p = (i) - (j);                    \
         EXTZ(T, 1);                       \
-        RZ(*u++ = vec(B01, p, (j) + wv)); \
+        RZ(*u++ = jtvec(jt, B01, p, (j) + wv)); \
     }
 #define EMIT0x(T, j, i, r, c)                  \
     {                                          \
@@ -661,7 +661,7 @@ jttokens(J jt, A w, I env) {
 #define FSMF(T, zk, zt, zr, zm, cexp, EMIT, ZVA)                                      \
     {                                                                                 \
         T *u, *uu;                                                                    \
-        RZ(z = exta((zt), (zr), (zm), (f | 4) == 5 ? n + 1 : n / 3));                 \
+        RZ(z = jtexta(jt, (zt), (zr), (zm), (f | 4) == 5 ? n + 1 : n / 3));                 \
         if (1 < (zr)) {                                                               \
             I *s = AS(z);                                                             \
             s[1] = (zm);                                                              \
@@ -857,7 +857,7 @@ jtfsmvfya(J jt, A w) {
     RZ(zv[0] = jtrifvs(jt, jtsc(jt, f)));
     RZ(zv[1] = jtrifvs(jt, s));
     RZ(zv[2] = jtrifvs(jt, m));
-    RZ(zv[3] = jtrifvs(jt, vec(INT, 4L, ijrd)));
+    RZ(zv[3] = jtrifvs(jt, jtvec(jt, INT, 4L, ijrd)));
     EPILOG(z);
 } /* check left argument of x;:y */
 
@@ -916,18 +916,18 @@ jtfsm0(J jt, A a, A w, C chka) {
             RZ(w = jtfrom(jt, jtindexof(jt, y, w), x));
         }  // # columns of machine must be at least c+1; look up the rest
     }
-    A z = fsmdo(f, s, m, ijrd, w, w0);
+    A z = jtfsmdo(jt, f, s, m, ijrd, w, w0);
     EPILOG(z);
 }
 
 A
 jtfsm(J jt, A a, A w) {
-    return fsm0(a, w, 1);
+    return jtfsm0(jt, a, w, 1);
 }
 /* x;:y */
 
 A
 jtfsmfx(J jt, A w, A self) {
-    return fsm0(FAV(self)->fgh[0], w, 0);
+    return jtfsm0(jt, FAV(self)->fgh[0], w, 0);
 }
 /* x&;: y */

--- a/jsrc/words/wc.c
+++ b/jsrc/words/wc.c
@@ -92,7 +92,7 @@ jtcongoto(J jt, I n, CW* con, A* lv) {
                     CWASSERT(0);
                 }
             }
-            if (0 <= congotochk(i, j - 1, z)) return i;
+            if (0 <= jtcongotochk(jt, i, j - 1, z)) return i;
         }
     return -1;
 } /* same result as conall */
@@ -611,7 +611,7 @@ jtgetsen(J jt, A w) {
     }
     if (0 <= k)
         RZ(*zv++ = jtincorp(jt, jtstr(jt, j + m - k, k + s)));  // if there was a final sentence in progress, append it
-    return vec(BOX, zv - z0, z0);                               // keep only the boxes that we used
+    return jtvec(jt, BOX, zv - z0, z0);                               // keep only the boxes that we used
 } /* partition by controls */
 
 /* preparse - return tokenized lines and control information     */
@@ -627,7 +627,7 @@ jtgetsen(J jt, A w) {
     {                                     \
         if (!(b)) {                       \
             I jj = (j);                   \
-            jsignal3(EVCTRL, wv[jj], jj); \
+            jtjsignal3(jt, EVCTRL, wv[jj], jj); \
             return 0;                     \
         }                                 \
     }
@@ -643,10 +643,10 @@ jtpreparse(J jt, A w, A* zl, A* zc) {
     p    = AN(w);
     wv   = AAV(w);  // p=#lines, wv->line 0 (a line is a boxed string)
     ASSERT(p < SMAX, EVLIMIT);
-    RZ(c = exta(CONW, 1L, 1L, 3 * p));
+    RZ(c = jtexta(jt, CONW, 1L, 1L, 3 * p));
     cv = (CW*)AV(c);
     n  = 0;  // allocate result area, cv->start of block of CWs, n=#cws encountered
-    RZ(l = exta(BOX, 1L, 1L, 5 * p));
+    RZ(l = jtexta(jt, BOX, 1L, 1L, 5 * p));
     lv = AAV(l);
     m  = 0;                    // allocate list of boxed words, lv->&A for first word; m=#words
     for (i = 0; i < p; ++i) {  // loop for each line
@@ -695,7 +695,7 @@ jtpreparse(J jt, A w, A* zl, A* zc) {
             // if not cw (ie executable sentence), turn words into an executable queue.  If cw, check for cw with data.
             // Set x to queue/cw, or 1 if cw w/o data
             if (!k) {
-                RZ(x = enqueue(w1, w0, 2))
+                RZ(x = jtenqueue(jt, w1, w0, 2))
             } else {
                 x = k == CLABEL || k == CGOTO || k == CFOR ? w0 : 0L;
             }                        // FOR must always go out; the length of the name is always needed, even if 0
@@ -724,7 +724,7 @@ jtpreparse(J jt, A w, A* zl, A* zc) {
     }
     RE(0);
     ASSERTCW(!as, p - 1);
-    ASSERTCW(!b || 0 > (i = congoto(n, cv, lv)), (i + cv)->source);
+    ASSERTCW(!b || 0 > (i = jtcongoto(jt, n, cv, lv)), (i + cv)->source);
     // Audit control structures and point the go line correctly
     ASSERTCW(0 > (i = jtconall(jt, n, cv)), (i + cv)->source);
     // Install the number of words and cws into the return blocks, and return those blocks

--- a/jsrc/xenos/x.c
+++ b/jsrc/xenos/x.c
@@ -7,7 +7,7 @@
 #include "x.h"
 
 #define SDERIV(id, f1, f2, flag, m, l, r)                                    \
-    fdef(0,                                                                  \
+    jtfdef(jt, 0,                                                            \
          id,                                                                 \
          VERB,                                                               \
          secf1,                                                              \
@@ -21,7 +21,7 @@
          (I)r)
 
 #define SDERI2(id, f1, f2, flag, m, l, r)                                    \
-    fdef(0,                                                                  \
+    jtfdef(jt, 0,                                                            \
          id,                                                                 \
          VERB,                                                               \
          f1,                                                                 \
@@ -90,7 +90,7 @@ jtforeign(J jt, A a, A w) {
     p = jti0(jt, a);
     q = jti0(jt, w);
     RE(0);
-    if (11 == p) return fdef(0, CIBEAM, VERB, jtwd, 0L, a, w, 0L, VASGSAFE, 1L, RMAX, RMAX);
+    if (11 == p) return jtfdef(jt, 0, CIBEAM, VERB, jtwd, 0L, a, w, 0L, VASGSAFE, 1L, RMAX, RMAX);
     ASSERT((UI)p <= (UI)128 && (UI)q < XCC, EVDOMAIN);
     switch (XC(p, q)) {
         case XC(0, 0):
@@ -157,7 +157,7 @@ jtforeign(J jt, A a, A w) {
         case XC(4, 8): return CDERIV(CIBEAM, jtscnl, 0, VASGSAFE, RMAX, 0, 0);
         case XC(4, 55): return CDERIV(CIBEAM, jtex, 0, VASGSAFE, 0, RMAX, RMAX);
 
-        case XC(5, 0): return fdef(0, CIBEAM, ADV, jtfxx, 0L, a, w, 0L, VASGSAFE, 0L, 0L, 0L);
+        case XC(5, 0): return jtfdef(jt, 0, CIBEAM, ADV, jtfxx, 0L, a, w, 0L, VASGSAFE, 0L, 0L, 0L);
         case XC(5, 1): return CDERIV(CIBEAM, jtarx, 0, VASGSAFE, 0, RMAX, RMAX);
         case XC(5, 2): return CDERIV(CIBEAM, jtdrx, 0, VASGSAFE, 0, RMAX, RMAX);
         case XC(5, 4): return CDERIV(CIBEAM, jttrx, 0, VASGSAFE, 0, RMAX, RMAX);

--- a/jsrc/xenos/x15.c
+++ b/jsrc/xenos/x15.c
@@ -2400,11 +2400,11 @@ jtcdgahash(J jt, I n) {
 static B
 jtcdinit(J jt) {
     A x;
-    RZ(x = exta(LIT, 2L, sizeof(CCT), 100L));
+    RZ(x = jtexta(jt, LIT, 2L, sizeof(CCT), 100L));
     ras(x);
     memset(AV(x), C0, AN(x));
     jt->cdarg = x;
-    RZ(x = exta(LIT, 1L, 1L, 5000L));
+    RZ(x = jtexta(jt, LIT, 1L, 1L, 5000L));
     ras(x);
     memset(AV(x), C0, AN(x));
     jt->cdstr = x;
@@ -2700,7 +2700,7 @@ jtcdparse(J jt, A a, I empty) {
     lib[cc->ln] = 0;
     memcpy(proc, s0 + pi, cc->pn);
     proc[cc->pn] = 0;
-    RZ(cc = cdload(cc, lib, proc));
+    RZ(cc = jtcdload(jt, cc, lib, proc));
     cc->n = 1 + i;
     RZ(cc = jtcdinsert(jt, a, cc));
     cc->li = li + cc->ai;
@@ -2762,7 +2762,7 @@ jtconvert0(J jt, I zt, I *v, I wt, C *u) {
             *v = rq;
     }
     return v;
-} /* convert a single atom. I from D code adapted from IfromD() in k.c */
+} /* convert a single atom. I from D code adapted from jtIfromD(jt, ) in k.c */
 
 // make one call to the DLL.
 // if cc->zbx is true, zv0 points to AAV(z) where z is the block that will hold the list of boxes that
@@ -2812,7 +2812,7 @@ jtcdexec1(J jt, CCT *cc, C *zv0, C *wu, I wk, I wt, I wd) {
             xv = AV(x);
             if (zbx) *zv = jtincorp(jt, x);
         } else {
-            xv = convert0(t, cv0, wt, u);
+            xv = jtconvert0(jt, t, cv0, wt, u);
             xt = t;
             u += wk;
             CDASSERT(xv != 0, per);
@@ -3105,7 +3105,7 @@ jtmemr(J jt, A w) {
         }
     }
 
-    return vecb01(t, m, u);
+    return jtvecb01(jt, t, m, u);
 } /* 15!:1  memory read */
 
 A
@@ -3413,7 +3413,7 @@ jtnfes(J jt, A w) {
 A
 jtcallbackx(J jt, A w) {
     ASSERTMTV(w);
-    return vec(INT, cbxn, cbx);
+    return jtvec(jt, INT, cbxn, cbx);
 } /* 15!:17 return x callback arguments */
 
 A

--- a/jsrc/xenos/xb.c
+++ b/jsrc/xenos/xb.c
@@ -141,12 +141,12 @@ jtbrephdrq(J jt, B b, B d, A w, C *q) {
     I extt = UNSAFE(AT(w));
     r      = AR(w);
     f      = 0;
-    RZ(mvw(BF(d, q), (C *)&f, 1L, b, BU, d, 1));
+    RZ(jtmvw(jt, BF(d, q), (C *)&f, 1L, b, BU, d, 1));
     *q = d ? (b ? 0xe3 : 0xe2) : (b ? 0xe1 : 0xe0);
-    RZ(mvw(BT(d, q), (C *)&extt, 1L, b, BU, d, 1));
-    RZ(mvw(BN(d, q), (C *)&AN(w), 1L, b, BU, d, 1));
-    RZ(mvw(BR(d, q), (C *)&r, 1L, b, BU, d, 1));  // r is an I
-    RZ(mvw(BS(d, q), (C *)AS(w), r, b, BU, d, 1));
+    RZ(jtmvw(jt, BT(d, q), (C *)&extt, 1L, b, BU, d, 1));
+    RZ(jtmvw(jt, BN(d, q), (C *)&AN(w), 1L, b, BU, d, 1));
+    RZ(jtmvw(jt, BR(d, q), (C *)&r, 1L, b, BU, d, 1));  // r is an I
+    RZ(jtmvw(jt, BS(d, q), (C *)AS(w), r, b, BU, d, 1));
     return BV(d, q, r);
 }
 
@@ -168,21 +168,21 @@ jtbreps(J jt, B b, B d, A w) {
     GATV0(z, BOX, n, 1);
     zv = AAV(z);
     GATV0(y, LIT, bsize(jt, d, 1, INT, n, AR(w), AS(w)), 1);
-    v = brephdr(b, d, w, y);
-    RZ(mvw(v, (C *)&c, 1L, BU, b, d, 1)); /* reserved for flag */
+    v = jtbrephdr(jt, b, d, w, y);
+    RZ(jtmvw(jt, v, (C *)&c, 1L, BU, b, d, 1)); /* reserved for flag */
     zv[0] = jtincorp(jt, y);
     m     = AN(y);
-    RZ(zv[1] = q = jtincorp(jt, brep(b, d, SPA(wp, a))));
-    RZ(mvw(v + kk, (C *)&m, 1L, b, BU, d, 1));
+    RZ(zv[1] = q = jtincorp(jt, jtbrep(jt, b, d, SPA(wp, a))));
+    RZ(jtmvw(jt, v + kk, (C *)&m, 1L, b, BU, d, 1));
     m += AN(q);
-    RZ(zv[2] = q = jtincorp(jt, brep(b, d, SPA(wp, e))));
-    RZ(mvw(v + 2 * kk, (C *)&m, 1L, b, BU, d, 1));
+    RZ(zv[2] = q = jtincorp(jt, jtbrep(jt, b, d, SPA(wp, e))));
+    RZ(jtmvw(jt, v + 2 * kk, (C *)&m, 1L, b, BU, d, 1));
     m += AN(q);
-    RZ(zv[3] = q = jtincorp(jt, brep(b, d, SPA(wp, i))));
-    RZ(mvw(v + 3 * kk, (C *)&m, 1L, b, BU, d, 1));
+    RZ(zv[3] = q = jtincorp(jt, jtbrep(jt, b, d, SPA(wp, i))));
+    RZ(jtmvw(jt, v + 3 * kk, (C *)&m, 1L, b, BU, d, 1));
     m += AN(q);
-    RZ(zv[4] = q = jtincorp(jt, brep(b, d, SPA(wp, x))));
-    RZ(mvw(v + 4 * kk, (C *)&m, 1L, b, BU, d, 1));
+    RZ(zv[4] = q = jtincorp(jt, jtbrep(jt, b, d, SPA(wp, x))));
+    RZ(jtmvw(jt, v + 4 * kk, (C *)&m, 1L, b, BU, d, 1));
     return jtraze(jt, z);
 } /* 3!:1 w for sparse w */
 
@@ -200,9 +200,9 @@ jtbrepfill(J jt, B b, B d, A w, C *zv) {
         I blksize = bsizer(jt, d, 1, w);  // get size of this block (never needs recursion)
         switch (CTTZ(t)) {
             case SBTX:
-            case INTX: RZ(mvw(zv, u, n, b, BU, d, 1)); break;
-            case FLX: RZ(mvw(zv, u, n, b, BU, 1, 1)); break;
-            case CMPXX: RZ(mvw(zv, u, n + n, b, BU, 1, 1)); break;
+            case INTX: RZ(jtmvw(jt, zv, u, n, b, BU, d, 1)); break;
+            case FLX: RZ(jtmvw(jt, zv, u, n, b, BU, 1, 1)); break;
+            case CMPXX: RZ(jtmvw(jt, zv, u, n + n, b, BU, 1, 1)); break;
             default:
                 // 1- and 2-byte C4T types, all of which have LAST0.  We need to clear the last
                 // bytes, because the datalength is rounded up in bsize, and thus there are
@@ -227,7 +227,7 @@ jtbrepfill(J jt, B b, B d, A w, C *zv) {
     zv += n * kk;  // save start of index, step over index
     // move in the blocks: first the offset, writing over the indirect block, then the data
     // the offsets are all relative to the start of the block, which is origzv
-    DO(n, I offset = zv - origzv; RZ(mvw(zvx, (C *)&offset, 1L, b, BU, d, 1)); zvx += kk;
+    DO(n, I offset = zv - origzv; RZ(jtmvw(jt, zvx, (C *)&offset, 1L, b, BU, d, 1)); zvx += kk;
        RZ(zv = jtbrepfill(jt, b, d, wv[i], zv));)
     return zv;
 } /* b iff reverse the bytes; d iff 64-bit */
@@ -239,7 +239,7 @@ jtbrep(J jt, B b, B d, A w) {
     A y;
     I t;
     t = UNSAFE(AT(w));
-    if ((t & SPARSE) != 0) return breps(b, d, w);  // sparse separately
+    if ((t & SPARSE) != 0) return jtbreps(jt, b, d, w);  // sparse separately
     GATV0(y, LIT, bsizer(jt, d, 1, w), 1);         // allocate entire result
     RZ(jtbrepfill(jt, b, d, w, CAV(y)));           // fill it
     return y;                                      // return it
@@ -253,7 +253,7 @@ jthrep(J jt, B b, B d, A w) {
     t = UNSAFE(AT(w));
     if ((t & SPARSE) != 0) {
         A z;  // sparse separately
-        RZ(y = breps(b, d, w));
+        RZ(y = jtbreps(jt, b, d, w));
         n    = AN(y);
         s[0] = n >> LGWS(d);
         s[1] = 2 * WS(d);
@@ -277,12 +277,12 @@ jthrep(J jt, B b, B d, A w) {
 A
 jtbinrep1(J jt, A w) {
     ASSERT(NOUN & AT(w), EVDOMAIN);
-    return brep(BU, 1, w);
+    return jtbrep(jt, BU, 1, w);
 } /* 3!:1 w */
 A
 jthexrep1(J jt, A w) {
     ASSERT(NOUN & AT(w), EVDOMAIN);
-    return hrep(BU, 1, w);
+    return jthrep(jt, BU, 1, w);
 } /* 3!:3 w */
 
 A
@@ -291,7 +291,7 @@ jtbinrep2(J jt, A a, A w) {
     RE(k = jti0(jt, a));
     if (10 <= k) k -= 8;
     ASSERT(BETWEENC(k, 0, 3), EVDOMAIN);
-    return brep((B)(k & 1), (B)(2 <= k), w);
+    return jtbrep(jt, (B)(k & 1), (B)(2 <= k), w);
 } /* a 3!:1 w */
 
 A
@@ -300,7 +300,7 @@ jthexrep2(J jt, A a, A w) {
     RE(k = jti0(jt, a));
     if (10 <= k) k -= 8;
     ASSERT(BETWEENC(k, 0, 3), EVDOMAIN);
-    return hrep((B)(k & 1), (B)(2 <= k), w);
+    return jthrep(jt, (B)(k & 1), (B)(2 <= k), w);
 } /* a 3!:3 w */
 
 static S
@@ -333,9 +333,9 @@ jtunbinr(J jt, B b, B d, B pre601, I m, A w) {
     C *u = (C *)w, *v;
     I e, j, kk, n, p, r, *s, t, *vv;
     ASSERT(m > BH(d), EVLENGTH);
-    RZ(mvw((C *)&t, BTX(d, pre601, w), 1L, BU, b, 1, d));
-    RZ(mvw((C *)&n, BN(d, w), 1L, BU, b, 1, d));
-    RZ(mvw((C *)&r, BR(d, w), 1L, BU, b, 1, d));
+    RZ(jtmvw(jt, (C *)&t, BTX(d, pre601, w), 1L, BU, b, 1, d));
+    RZ(jtmvw(jt, (C *)&n, BN(d, w), 1L, BU, b, 1, d));
+    RZ(jtmvw(jt, (C *)&r, BR(d, w), 1L, BU, b, 1, d));
     kk = WS(d);
     v  = BV(d, w, r);
     ASSERT((t == LOWESTBIT(t)) && t & (B01 | INT | FL | CMPX | BOX | XNUM | RAT | LIT | C2T | C4T | SB01 | SLIT | SINT |
@@ -352,14 +352,14 @@ jtunbinr(J jt, B b, B d, B pre601, I m, A w) {
         GASPARSE(z, t, n, r, (I *)0)
     }
     s = AS(z);
-    RZ(mvw((C *)s, BS(d, w), r, BU, b, 1, d));
+    RZ(jtmvw(jt, (C *)s, BS(d, w), r, BU, b, 1, d));
     j = 1;
     DO(r, ASSERT(0 <= s[i], EVLENGTH); if (t & DENSE) j *= s[i];);
     ASSERT(j == n, EVLENGTH);
     if (t & BOX + XNUM + RAT + SPARSE) {
         GATV0(y, INT, e, 1);
         vv = AV(y);
-        RZ(mvw((C *)vv, v, e, BU, b, 1, d));
+        RZ(jtmvw(jt, (C *)vv, v, e, BU, b, 1, d));
     }
     if (t & BOX + XNUM + RAT) {
         A *zv = AAV(z);
@@ -373,23 +373,23 @@ jtunbinr(J jt, B b, B d, B pre601, I m, A w) {
                 zv[i] = zv[iv[i]];
             else {
                 while (k < e && j >= vv[k]) ++k;
-                zv[i] = jtincorp(jt, unbinr(b, d, pre601, k < e ? vv[k] - j : m - j, (A)(u + j)));
+                zv[i] = jtincorp(jt, jtunbinr(jt, b, d, pre601, k < e ? vv[k] - j : m - j, (A)(u + j)));
             }
         }
     } else if ((t & SPARSE) != 0) {
         P *zp = PAV(z);
         j     = vv[1];
         ASSERT(BETWEENO(j, 0, m), EVINDEX);
-        SPB(zp, a, unbinr(b, d, pre601, vv[2] - j, (A)(u + j)));
+        SPB(zp, a, jtunbinr(jt, b, d, pre601, vv[2] - j, (A)(u + j)));
         j = vv[2];
         ASSERT(BETWEENO(j, 0, m), EVINDEX);
-        SPB(zp, e, unbinr(b, d, pre601, vv[3] - j, (A)(u + j)));
+        SPB(zp, e, jtunbinr(jt, b, d, pre601, vv[3] - j, (A)(u + j)));
         j = vv[3];
         ASSERT(BETWEENO(j, 0, m), EVINDEX);
-        SPB(zp, i, unbinr(b, d, pre601, vv[4] - j, (A)(u + j)));
+        SPB(zp, i, jtunbinr(jt, b, d, pre601, vv[4] - j, (A)(u + j)));
         j = vv[4];
         ASSERT(BETWEENO(j, 0, m), EVINDEX);
-        SPB(zp, x, unbinr(b, d, pre601, m - j, (A)(u + j)));
+        SPB(zp, x, jtunbinr(jt, b, d, pre601, m - j, (A)(u + j)));
     } else if (n)
         switch (CTTZNOFLAG(t)) {
             case B01X: {
@@ -397,9 +397,9 @@ jtunbinr(J jt, B b, B d, B pre601, I m, A w) {
                 DO(n, c = v[i]; ASSERT(c == C0 || c == C1, EVDOMAIN); zv[i] = c;);
             } break;
             case SBTX:
-            case INTX: RZ(mvw(CAV(z), v, n, BU, b, 1, d)); break;
-            case FLX: RZ(mvw(CAV(z), v, n, BU, b, 1, 1)); break;
-            case CMPXX: RZ(mvw(CAV(z), v, n + n, BU, b, 1, 1)); break;
+            case INTX: RZ(jtmvw(jt, CAV(z), v, n, BU, b, 1, d)); break;
+            case FLX: RZ(jtmvw(jt, CAV(z), v, n, BU, b, 1, 1)); break;
+            case CMPXX: RZ(jtmvw(jt, CAV(z), v, n + n, BU, b, 1, 1)); break;
             default:
                 e = n << bplg(t);
                 ASSERTSYS(e <= allosize(z), "unbinr");
@@ -422,10 +422,10 @@ jtunbin(J jt, A w) {
     ASSERT(m >= 8, EVLENGTH);
     q = (A)AV(w);
     switch (CAV(w)[0]) {
-        case (C)0xe0: return unbinr(0, 0, 0, m, q);
-        case (C)0xe1: return unbinr(1, 0, 0, m, q);
-        case (C)0xe2: return unbinr(0, 1, 0, m, q);
-        case (C)0xe3: return unbinr(1, 1, 0, m, q);
+        case (C)0xe0: return jtunbinr(jt, 0, 0, 0, m, q);
+        case (C)0xe1: return jtunbinr(jt, 1, 0, 0, m, q);
+        case (C)0xe2: return jtunbinr(jt, 0, 1, 0, m, q);
+        case (C)0xe3: return jtunbinr(jt, 1, 1, 0, m, q);
     }
     /* code to handle pre 601 headers */
     d = 1;
@@ -437,15 +437,15 @@ jtunbin(J jt, A w) {
       }); /* detect 64-bit        */
     ASSERT(m >= 1 + BH(d), EVLENGTH);
     b = 0;
-    if (!mvw((C *)&t, BTX(d, 1, q), 1L, BU, 0, 1, d)) {
+    if (!jtmvw(jt, (C *)&t, BTX(d, 1, q), 1L, BU, 0, 1, d)) {
         RESETERR;
         b = 1;
     } /* detect reverse bytes */
-    if (!mvw((C *)&n, BN(d, q), 1L, BU, 0, 1, d)) {
+    if (!jtmvw(jt, (C *)&n, BN(d, q), 1L, BU, 0, 1, d)) {
         RESETERR;
         b = 1;
     }
-    if (!mvw((C *)&r, BR(d, q), 1L, BU, 0, 1, d)) {
+    if (!jtmvw(jt, (C *)&r, BR(d, q), 1L, BU, 0, 1, d)) {
         RESETERR;
         b = 1;
     }
@@ -454,7 +454,7 @@ jtunbin(J jt, A w) {
         v = BS(d, q);
         c = 1;
         for (i = 0; !b && i < r; ++i) {
-            if (!mvw((C *)&k, v, 1L, BU, 0, 1, d)) {
+            if (!jtmvw(jt, (C *)&k, v, 1L, BU, 0, 1, d)) {
                 RESETERR;
                 b = 1;
             }
@@ -464,7 +464,7 @@ jtunbin(J jt, A w) {
         }
         b = b || n != c;
     }
-    return unbinr(b, d, 1, m, q);
+    return jtunbinr(jt, b, d, 1, m, q);
 } /* 3!:2 w, inverse for binrep/hexrep */
 
 A

--- a/jsrc/xenos/xcrc.c
+++ b/jsrc/xenos/xcrc.c
@@ -65,7 +65,7 @@ jtcrccompile(J jt, A w) {
     hv = AAV(h);
     RE(z = jtcrcvalidate(jt, w, crctab));
     RZ(hv[0] =
-         jtrifvs(jt, vec(LIT, sizeof(crctab), crctab)));  // Save the table.  We don't have any other good type to use
+         jtrifvs(jt, jtvec(jt, LIT, sizeof(crctab), crctab)));  // Save the table.  We don't have any other good type to use
     RZ(hv[1] = jtrifvs(jt, jtsc(jt, (I)z)));
     return h;
 }

--- a/jsrc/xenos/xd.c
+++ b/jsrc/xenos/xd.c
@@ -100,14 +100,14 @@ jtdir1(J jt, struct dirent *f, struct stat *dirstatbuf, C *diratts, C *dirmode, 
     n     = strlen(s);
     GAT0(z, BOX, 6, 1);
     zv = AAV(z);
-    RZ(zv[0] = vec(LIT, n, s));
-    RZ(zv[1] = vec(INT, 6L, ts));
+    RZ(zv[0] = jtvec(jt, LIT, n, s));
+    RZ(zv[1] = jtvec(jt, INT, 6L, ts));
     sz = dirstatbuf[0].st_size;
     sz = sz < 0 ? -1 : sz;
     RZ(zv[2] = jtsc(jt, sz));
-    RZ(zv[3] = vec(LIT, 3L, dirrwx));
-    RZ(zv[4] = vec(LIT, 6L, diratts));
-    RZ(zv[5] = vec(LIT, 10L, dirmode));
+    RZ(zv[3] = jtvec(jt, LIT, 3L, dirrwx));
+    RZ(zv[4] = jtvec(jt, LIT, 6L, diratts));
+    RZ(zv[5] = jtvec(jt, LIT, 10L, dirmode));
     return z;
 }
 
@@ -157,7 +157,7 @@ jtjdir(J jt, A w) {
         f = readdir(DP);
     }
     closedir(DP);
-    z = j ? jtope(jt, j < n ? vec(BOX, j, zv) : z) : jtreshape(jt, jtv2(jt, 0L, 6L), ds(CACE));
+    z = j ? jtope(jt, j < n ? jtvec(jt, BOX, j, zv) : z) : jtreshape(jt, jtv2(jt, 0L, 6L), ds(CACE));
     EPILOG(z);
 }
 
@@ -184,7 +184,7 @@ jtjfperm1(J jt, A w) {
     } else
         ASSERT(y = jtstr0(jt, jtvslit(jt, AAV(w)[0])), EVFNUM)
     if (0 != stat(CAV(y), dirstatbuf)) return jtjerrno(jt);
-    return vec(LIT, 9L, 1 + modebuf(dirstatbuf[0].st_mode, b));
+    return jtvec(jt, LIT, 9L, 1 + modebuf(dirstatbuf[0].st_mode, b));
 }
 
 static const struct tperms {

--- a/jsrc/xenos/xf.c
+++ b/jsrc/xenos/xf.c
@@ -116,9 +116,9 @@ jtjfread(J jt, A w) {
     if (f)
         return 1 == (I)f   ? jtjgets(jt, "\001")
                : 3 == (I)f ? jtrdns(jt, stdin)
-                           : rd(jtvfn(jt, f), 0L, -1L);  // if special file, read it all, possibly with error
+                           : jtrd(jt, jtvfn(jt, f), 0L, -1L);  // if special file, read it all, possibly with error
     RZ(f = jtjope(jt, w, FREAD_O));
-    z = rd(f, 0L, -1L);
+    z = jtrd(jt, f, 0L, -1L);
     fclose(f);  // otherwise open/read/close named file
     return z;
 }
@@ -145,7 +145,7 @@ jtjfwrite(J jt, A a, A w) {
     if (4 == (I)f) { return (U)AN(a) != fwrite(CAV(a), sizeof(C), AN(a), stdout) ? jtjerrno(jt) : a; }
     if (5 == (I)f) { return (U)AN(a) != fwrite(CAV(a), sizeof(C), AN(a), stderr) ? jtjerrno(jt) : a; }
     if (b = !f) RZ(f = jtjope(jt, w, FWRITE_O)) else RE(jtvfn(jt, f));
-    wa(f, 0L, a);
+    jtwa(jt, f, 0L, a);
     if (b)
         fclose(f);
     else
@@ -169,7 +169,7 @@ jtjfappend(J jt, A a, A w) {
     ASSERT(!AN(a) || AT(a) & LIT + C2T + C4T, EVDOMAIN);
     ASSERT(1 >= AR(a), EVRANK);
     if (b = !f) RZ(f = jtjope(jt, w, FAPPEND_O)) else RE(jtvfn(jt, f));
-    wa(f, fsize(f), a);
+    jtwa(jt, f, fsize(f), a);
     if (b)
         fclose(f);
     else
@@ -243,7 +243,7 @@ jtjiread(J jt, A w) {
     F1RANK(1, jtjiread, UNUSED_VALUE);
     RE(f = jtixf(jt, w));
     if (b = !f) RZ(f = jtjope(jt, w, FREAD_O));
-    if (ixin(w, fsize(f), &i, &n)) z = rd(f, i, n);
+    if (jtixin(jt, w, fsize(f), &i, &n)) z = jtrd(jt, f, i, n);
     if (b)
         fclose(f);
     else
@@ -261,7 +261,7 @@ jtjiwrite(J jt, A a, A w) {
     ASSERT(1 >= AR(a), EVRANK);
     RE(f = jtixf(jt, w));
     if (b = !f) RZ(f = jtjope(jt, w, FUPDATE_O));
-    if (ixin(w, fsize(f), &i, 0L)) wa(f, i, a);
+    if (jtixin(jt, w, fsize(f), &i, 0L)) jtwa(jt, f, i, a);
     if (b)
         fclose(f);
     else

--- a/jsrc/xenos/xh.c
+++ b/jsrc/xenos/xh.c
@@ -72,7 +72,7 @@ jthost(J jt, A w) {
 #endif
         if (b) {
             f = fopen(fn, FREAD_O);
-            z = rd(f, 0L, -1L);
+            z = jtrd(jt, f, 0L, -1L);
             fclose(f);
         }
         unlink(fn);
@@ -129,7 +129,7 @@ jthostio(J jt, A w) {
         CL(fi);
         CL(fo);
     }
-    if (!add2(pz[1], pz[2], s)) {
+    if (!jtadd2(jt, pz[1], pz[2], s)) {
         fclose(pz[1]);
         fclose(pz[2]);
         CL(fi);
@@ -153,7 +153,7 @@ jthostio(J jt, A w) {
     }
     close(fo[0]);
     close(fi[1]);
-    add2(NULL, NULL, NULL);
+    jtadd2(jt, NULL, NULL, NULL);
     pz[0] = (F)(intptr_t)r;
     return z;
 }

--- a/jsrc/xenos/xl.c
+++ b/jsrc/xenos/xl.c
@@ -63,7 +63,7 @@ jtjlock(J jt, A w) {
         RZ(jt->flkd = jtext(jt, 1, jt->flkd));
         AM(jt->flkd) = ct;
     }
-    RE(b = dolock(1, (F)v[0], v[1], v[2]));
+    RE(b = jtdolock(jt, 1, (F)v[0], v[1], v[2]));
     if (!b) return num(0);
     ICPY(AV(jt->flkd) + LKC * AM(jt->flkd), v, LKC);
     ++AM(jt->flkd);
@@ -78,7 +78,7 @@ jtunlj(J jt, I j) {
     ASSERT(BETWEENO(j, 0, AM(jt->flkd)), EVINDEX);
     u = AV(jt->flkd);
     v = u + j * LKC;
-    RE(b = dolock(0, (F)v[0], v[1], v[2]));
+    RE(b = jtdolock(jt, 0, (F)v[0], v[1], v[2]));
     if (!b) return num(0);
     --AM(jt->flkd);
     if (j < AM(jt->flkd))

--- a/jsrc/xenos/xo.c
+++ b/jsrc/xenos/xo.c
@@ -44,7 +44,7 @@ jtfnum(J jt, A w) {
         ASSERT(h = jti0(jt, y), EVFNUM);
         return h;
     }
-    RE(j = jti0(jt, jtindexof(jt, vec(BOX, AM(jt->fopf), AAV(jt->fopa)), boxW(jtfullname(jt, jtvslit(jt, y))))));
+    RE(j = jti0(jt, jtindexof(jt, jtvec(jt, BOX, AM(jt->fopf), AAV(jt->fopa)), boxW(jtfullname(jt, jtvslit(jt, y))))));
     return j < AM(jt->fopf) ? *(j + AV(jt->fopf)) : 0;
 } /* file# corresp. to standard argument w */
 
@@ -60,8 +60,8 @@ A
 jtjfiles(J jt, A w) {
     A y, z;
     ASSERTMTV(w);
-    RZ(y = vec(INT, AM(jt->fopf), AV(jt->fopf)));
-    return jtgrade2(jt, jtstitch(jt, IRS1(y, 0, 0, jtbox, z), vec(BOX, AM(jt->fopf), AV(jt->fopa))), y);
+    RZ(y = jtvec(jt, INT, AM(jt->fopf), AV(jt->fopf)));
+    return jtgrade2(jt, jtstitch(jt, IRS1(y, 0, 0, jtbox, z), jtvec(jt, BOX, AM(jt->fopf), AV(jt->fopa))), y);
 } /* file (number,name) table */
 
 F
@@ -89,7 +89,7 @@ jtjopen(J jt, A w) {
     A z;
     I h;
     if (!AN(w)) return w;
-    if (AR(w)) return rank1ex0(w, UNUSED_VALUE, jtjopen);
+    if (AR(w)) return jtrank1ex0(jt, w, UNUSED_VALUE, jtjopen);
     RE(h = jtfnum(jt, w));
     if (h) {
         RZ(z = jtsc(jt, h));
@@ -148,7 +148,7 @@ jtjclose(J jt, A w) {
     A* av;
     I *iv, j;
     if (!AN(w)) return w;
-    if (AR(w)) return rank1ex0(w, UNUSED_VALUE, jtjclose);
+    if (AR(w)) return jtrank1ex0(jt, w, UNUSED_VALUE, jtjclose);
     RE(j = jti0(jt, jtindexof(jt, jt->fopf, jtsc(jt, jtfnum(jt, w)))));
     ASSERT(j < AM(jt->fopf), EVFNUM);
     av = AAV(jt->fopa);

--- a/jsrc/xenos/xs.c
+++ b/jsrc/xenos/xs.c
@@ -24,14 +24,14 @@ jtxsinit(J jt) {
 A
 jtsnl(J jt, A w) {
     ASSERTMTV(w);
-    return vec(BOX, jt->slistn, AAV(jt->slist));
+    return jtvec(jt, BOX, jt->slistn, AAV(jt->slist));
 }
 /* 4!:3  list of script names */
 
 A
 jtscnl(J jt, A w) {
     ASSERTMTV(w);
-    return vec(INT, jt->slistn, AAV(jt->sclist));
+    return jtvec(jt, INT, jt->slistn, AAV(jt->sclist));
 }
 /* 4!:8  list of script indices which loaded slist */
 
@@ -63,7 +63,7 @@ jtline(J jt, A w, I si, C ce, B tso) {
         tso = 0;  // if locked, keep shtum about internals
     }
     FDEPINC(1);  // No ASSERTs or returns till the FDEPDEC below
-    RZ(d = deba(DCSCRIPT, 0L, w, (A)si));
+    RZ(d = jtdeba(jt, DCSCRIPT, 0L, w, (A)si));
     jt->dcs      = d;
     jt->tostdout = tso && !jt->seclev;
     A *old       = jt->tnextpushp;
@@ -113,7 +113,7 @@ jtaddscriptname(J jt, A w) {
     RE(i = jti0(
          jt,
          jtindexof(
-           jt, vec(BOX, jt->slistn, AAV(jt->slist)), jtbox(jt, jtravel(jt, w)))));  // look up only in the defined names
+           jt, jtvec(jt, BOX, jt->slistn, AAV(jt->slist)), jtbox(jt, jtravel(jt, w)))));  // look up only in the defined names
     if (jt->slistn == i) {
         if (jt->slistn == AN(jt->slist)) {
             RZ(jt->slist = jtext(jt, 1, jt->slist));
@@ -152,7 +152,7 @@ jtlinf(J jt, A a, A w, C ce, B tso) {
 
     // set the current script number
     jt->slisti = (UI4)i;  // glock=0 or 1 is original setting; 2 if this script is locked (so reset after
-    z          = line(x, i, ce, tso);
+    z          = jtline(jt, x, i, ce, tso);
     jt->slisti = (UI4)oldi;
     return z;
 }
@@ -181,42 +181,42 @@ jtscm00(J jt, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F1RANK(r, jtscm00, UNUSED_VALUE);
-    return r ? line(w, -1L, 0, 0) : linf(mark, w, 0, 0);
+    return r ? jtline(jt, w, -1L, 0, 0) : jtlinf(jt, mark, w, 0, 0);
 }
 A
 jtscm01(J jt, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F1RANK(r, jtscm01, UNUSED_VALUE);
-    return r ? line(w, -1L, 0, 1) : linf(mark, w, 0, 1);
+    return r ? jtline(jt, w, -1L, 0, 1) : jtlinf(jt, mark, w, 0, 1);
 }
 A
 jtscm10(J jt, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F1RANK(r, jtscm10, UNUSED_VALUE);
-    return r ? line(w, -1L, 1, 0) : linf(mark, w, 1, 0);
+    return r ? jtline(jt, w, -1L, 1, 0) : jtlinf(jt, mark, w, 1, 0);
 }
 A
 jtscm11(J jt, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F1RANK(r, jtscm11, UNUSED_VALUE);
-    return r ? line(w, -1L, 1, 1) : linf(mark, w, 1, 1);
+    return r ? jtline(jt, w, -1L, 1, 1) : jtlinf(jt, mark, w, 1, 1);
 }
 A
 jtsct1(J jt, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F1RANK(r, jtsct1, UNUSED_VALUE);
-    return r ? line(w, -1L, 2, 1) : linf(mark, w, 2, 1);
+    return r ? jtline(jt, w, -1L, 2, 1) : jtlinf(jt, mark, w, 2, 1);
 }
 A
 jtscz1(J jt, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F1RANK(r, jtscz1, UNUSED_VALUE);
-    return r ? line(w, -1L, 3, 0) : linf(mark, w, 3, 0);
+    return r ? jtline(jt, w, -1L, 3, 0) : jtlinf(jt, mark, w, 3, 0);
 }
 
 A
@@ -224,40 +224,40 @@ jtscm002(J jt, A a, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F2RANK(RMAX, r, jtscm002, UNUSED_VALUE);
-    return r ? line(w, -1L, 0, 0) : linf(a, w, 0, 0);
+    return r ? jtline(jt, w, -1L, 0, 0) : jtlinf(jt, a, w, 0, 0);
 }
 A
 jtscm012(J jt, A a, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F2RANK(RMAX, r, jtscm012, UNUSED_VALUE);
-    return r ? line(w, -1L, 0, 1) : linf(a, w, 0, 1);
+    return r ? jtline(jt, w, -1L, 0, 1) : jtlinf(jt, a, w, 0, 1);
 }
 A
 jtscm102(J jt, A a, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F2RANK(RMAX, r, jtscm102, UNUSED_VALUE);
-    return r ? line(w, -1L, 1, 0) : linf(a, w, 1, 0);
+    return r ? jtline(jt, w, -1L, 1, 0) : jtlinf(jt, a, w, 1, 0);
 }
 A
 jtscm112(J jt, A a, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F2RANK(RMAX, r, jtscm112, UNUSED_VALUE);
-    return r ? line(w, -1L, 1, 1) : linf(a, w, 1, 1);
+    return r ? jtline(jt, w, -1L, 1, 1) : jtlinf(jt, a, w, 1, 1);
 }
 A
 jtsct2(J jt, A a, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F2RANK(RMAX, r, jtsct2, UNUSED_VALUE);
-    return r ? line(w, -1L, 2, 1) : linf(a, w, 2, 1);
+    return r ? jtline(jt, w, -1L, 2, 1) : jtlinf(jt, a, w, 2, 1);
 }
 A
 jtscz2(J jt, A a, A w) {
     I r;
     r = 1 && AT(w) & LIT + C2T + C4T;
     F2RANK(RMAX, r, jtscz2, UNUSED_VALUE);
-    return r ? line(w, -1L, 3, 0) : linf(a, w, 3, 0);
+    return r ? jtline(jt, w, -1L, 3, 0) : jtlinf(jt, a, w, 3, 0);
 }

--- a/jsrc/xenos/xt.c
+++ b/jsrc/xenos/xt.c
@@ -280,7 +280,7 @@ jtpmfree(J jt, A w) {
 
 A
 jtpmarea1(J jt, A w) {
-    return jtpmarea2(jt, vec(B01, 2L, &zeroZ), w);
+    return jtpmarea2(jt, jtvec(jt, B01, 2L, &zeroZ), w);
 }  // 6!:10
 
 A
@@ -424,8 +424,8 @@ jtpmunpack(J jt, A w) {
     RZ(zv[6] = jtincorp(jt, jtrepeat(jt, c, t)));
     RZ(x = jtindexof(jt, jtrepeat(jt, c, x), x));
     iv = AV(x);
-    RZ(zv[0] = jtincorp(jt, vec(INT, m, iv)));
-    RZ(zv[1] = jtincorp(jt, vec(INT, m, m + iv)));
+    RZ(zv[0] = jtincorp(jt, jtvec(jt, INT, m, iv)));
+    RZ(zv[1] = jtincorp(jt, jtvec(jt, INT, m, m + iv)));
     GATV0(t, INT, m, 1);
     zv[2] = jtincorp(jt, t);
     iv    = AV(t);


### PR DESCRIPTION
Replaced macro invocations of the form `#define <name>(...) jt<name>(jt, ...)` with direct function calls.
And subsequently removed most of the macros (unless used as parameters for other macros).

I might have missed some, but those will be found eventually...