### PR TITLE
Add some more functions to algorithm.hpp

### DIFF
--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -23,7 +23,8 @@ static auto constexpr not_equal_to = [](auto const &first, auto const &...values
  * @brief Variadic version of `std::mismatch`
  */
 template <typename P, typename I, typename... Is>
-[[nodiscard]] static auto constexpr zip_find(P const &pred, I f, I const l, Is... fs) {
+[[nodiscard]] static constexpr auto
+zip_find(P const &pred, I f, I const l, Is... fs) {
     static_assert(sizeof...(Is) != 0);
     while (f != l) {
         if (pred(*f, *fs...)) break;
@@ -36,7 +37,8 @@ template <typename P, typename I, typename... Is>
  * @brief Predicate version of `algo::zip_found`
  */
 template <typename P, typename I, typename... Is>
-[[nodiscard]] static auto constexpr zip_found(P const &pred, I f, I const l, Is... fs) -> bool {
+[[nodiscard]] static constexpr auto
+zip_found(P const &pred, I f, I const l, Is... fs) -> bool {
     auto const t = zip_find(pred, f, l, fs...);
     return std::get<0>(t) != l;
 }
@@ -57,7 +59,8 @@ template <typename P, typename I, typename... Is>
  * @brief Variadic, Predicate version of `std::mismatch`
  */
 template <typename I, typename... Is>
-[[nodiscard]] static auto constexpr is_mismatched(I f, I const l, Is... fs) -> bool {
+[[nodiscard]] static constexpr auto
+is_mismatched(I f, I const l, Is... fs) -> bool {
     return zip_found(not_equal_to, f, l, fs...);
 }
 
@@ -77,7 +80,8 @@ template <typename I, typename... Is>
  * @brief Variadic, Predicate version of `std::equal`
  */
 template <typename I, typename... Is>
-[[nodiscard]] static auto constexpr is_equal(I f, I const l, Is... fs) -> bool {
+[[nodiscard]] static constexpr auto
+is_equal(I f, I const l, Is... fs) -> bool {
     return !is_mismatched(f, l, fs...);
 }
 
@@ -87,7 +91,8 @@ namespace ranges {
  * @note This can be the same name as zip_find if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-[[nodiscard]] static auto constexpr zip_find(P const &pred, R const &r, Rs const &...rs) {
+[[nodiscard]] static constexpr auto
+zip_find(P const &pred, R const &r, Rs const &...rs) {
     return algo::zip_find(pred, std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
 /**
@@ -95,14 +100,16 @@ template <typename P, typename R, typename... Rs>
  * @note This can be the same name as zip_found if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-[[nodiscard]] static auto constexpr zip_found(P const &pred, R const &r, Rs const &...rs) -> bool {
+[[nodiscard]] static constexpr auto
+zip_found(P const &pred, R const &r, Rs const &...rs) -> bool {
     return algo::zip_found(pred, std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
 /**
  * @brief Variadic, Predicate version of `std::mismatch`, for ranges;
  */
 template <typename R, typename... Rs>
-[[nodiscard]] static auto constexpr is_mismatched(R const &r, Rs const &...rs) -> bool {
+[[nodiscard]] static constexpr auto
+is_mismatched(R const &r, Rs const &...rs) -> bool {
     return not_equal_to(std::size(r), std::size(rs)...) ||
            algo::is_mismatched(std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
@@ -110,7 +117,8 @@ template <typename R, typename... Rs>
  * @brief Variadic, Predicate version of `std::equal`, for ranges;
  */
 template <typename... Rs>
-[[nodiscard]] static auto constexpr is_equal(Rs const &...rs) -> bool {
+[[nodiscard]] static constexpr auto
+is_equal(Rs const &...rs) -> bool {
     return !is_mismatched(rs...);
 }
 // static_assert tests. With constexpr we can start checking to make sure our functions work at compile time.

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -43,7 +43,6 @@ zip_found(P const &pred, I f, I const l, Is... fs) -> bool {
     return std::get<0>(t) != l;
 }
 
-
 /**
  * @brief Variadic, Predicate version of `std::mismatch`
  */
@@ -51,16 +50,6 @@ template <typename I, typename... Is>
 [[nodiscard]] static constexpr auto
 is_equal(I f, I const l, Is... fs) -> bool {
     return zip_found(equal_to, f, l, fs...);
-}
-
-
-/**
- * @brief Variadic, Predicate version of `std::equal`
- */
-template <typename I, typename... Is>
-[[nodiscard]] static constexpr auto
-is_equal(I f, I const l, Is... fs) -> bool {
-    return !is_mismatched(f, l, fs...);
 }
 
 namespace ranges {
@@ -86,22 +75,12 @@ zip_found(P const &pred, R const &r, Rs const &...rs) -> bool {
 }
 
 /**
- * @brief Variadic, Predicate version of `std::mismatch`, for ranges;
+ * @brief Variadic, Predicate version of `std::equal`, for ranges;
  */
 template <typename R, typename... Rs>
 [[nodiscard]] static constexpr auto
-is_mismatched(R const &r, Rs const &...rs) -> bool {
-    return not_equal_to(std::size(r), std::size(rs)...) ||
-           algo::is_mismatched(std::cbegin(r), std::cend(r), std::cbegin(rs)...);
-}
-
-/**
- * @brief Variadic, Predicate version of `std::equal`, for ranges;
- */
-template <typename... Rs>
-[[nodiscard]] static constexpr auto
-is_equal(Rs const &...rs) -> bool {
-    return !is_mismatched(rs...);
+is_equal(R const &r, Rs const &...rs) -> bool {
+    return equal_to(std::size(r), std::size(rs)...) && algo::is_equal(std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
 
 // static_assert tests. With constexpr we can start checking to make sure our functions work at compile time.
@@ -113,9 +92,8 @@ static_assert(
   !ranges::zip_found(not_equal_to, std::array{0, 1, 2, 3, 4}, std::array{0, 1, 2, 3, 4}, std::array{0, 1, 2, 3, 4}));
 static_assert(
   ranges::zip_found(not_equal_to, std::array{0, 1, 2, 5, 4}, std::array{0, 1, 2, 3, 4}, std::array{0, 1, 2, 3, 6}));
-static_assert(is_mismatched(std::array{0, 1, 2, 5, 4}, std::array{0, 1, 2, 3, 4}, std::array{0, 1, 2, 3, 6}));
-static_assert(is_mismatched(std::array{0, 1, 2, 5, 4}, std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3, 6}));
-static_assert(!is_mismatched(std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}));
+static_assert(is_equal(std::array{0, 1, 2, 5, 4}, std::array{0, 1, 2, 3, 4}, std::array{0, 1, 2, 3, 6}));
+static_assert(!is_equal(std::array{0, 1, 2, 5, 4}, std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3, 6}));
 static_assert(is_equal(std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}));
 static_assert(ranges::is_equal(std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}));
 }  // namespace ranges

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -23,7 +23,7 @@ static auto constexpr is_not_equal_to = [](const auto first, const auto... value
  * @brief Variadic version of `std::mismatch`
  */
 template <typename P, typename I, typename... Is>
-auto constexpr zip_find(const P pred, I f, I l, Is... fs) {
+static auto constexpr zip_find(const P pred, I f, I l, Is... fs) {
     while (f != l) {
         if (pred(*f, *fs...)) break;
         ++f, ((void)++fs, ...);
@@ -36,7 +36,7 @@ auto constexpr zip_find(const P pred, I f, I l, Is... fs) {
  * @note This can be the same name as zip_find if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-auto constexpr zip_find_r(const P pred, R r, Rs... rs) {
+static auto constexpr zip_find_r(const P pred, R r, Rs... rs) {
     return zip_find(pred, std::begin(r), std::end(r), std::begin(rs)...);
 }
 
@@ -44,7 +44,7 @@ auto constexpr zip_find_r(const P pred, R r, Rs... rs) {
  * @brief Predicate version of `algo::zip_found`
  */
 template <typename P, typename I, typename... Is>
-auto constexpr zip_found(const P pred, I f, I l, Is... fs) -> bool {
+static auto constexpr zip_found(const P pred, I f, I l, Is... fs) -> bool {
     auto const t = zip_find(pred, f, l, fs...);
     return std::get<0>(t) != l;
 }
@@ -54,7 +54,7 @@ auto constexpr zip_found(const P pred, I f, I l, Is... fs) -> bool {
  * @note This can be the same name as zip_found if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-auto constexpr zip_found_r(const P pred, R r, Rs... rs) -> bool {
+static auto constexpr zip_found_r(const P pred, R r, Rs... rs) -> bool {
     return zip_found(pred, std::begin(r), std::end(r), std::begin(rs)...);
 }
 
@@ -72,7 +72,7 @@ is_mismatched(I f, I l, I2 f2) -> bool {
  * @brief Variadic, Predicate version of `std::mismatch`
  */
 template <typename I, typename... Is>
-constexpr auto
+static constexpr auto
 is_mismatched_v(I f, I l, Is... fs) -> bool {
     return zip_found(is_not_equal_to, f, l, fs...);
 }
@@ -81,7 +81,7 @@ is_mismatched_v(I f, I l, Is... fs) -> bool {
  * @brief Variadic, Predicate version of `std::mismatch`, for ranges;
  */
 template <typename R, typename... Rs>
-constexpr auto
+static constexpr auto
 is_mismatched_r(R r, Rs... rs) -> bool {
     return is_not_equal_to(std::size(rs)...) || is_mismatched_v(std::begin(r), std::end(r), std::begin(rs)...);
 }
@@ -90,7 +90,7 @@ is_mismatched_r(R r, Rs... rs) -> bool {
  * @brief Variadic, Predicate version of `std::equal`
  */
 template <typename I, typename... Is>
-constexpr auto
+static constexpr auto
 is_equal(I f, I l, Is... fs) -> bool {
     return !is_mismatched_v(f, l, fs...);
 }
@@ -99,7 +99,7 @@ is_equal(I f, I l, Is... fs) -> bool {
  * @brief Variadic, Predicate version of `std::equal`, for ranges;
  */
 template <typename... Rs>
-constexpr auto
+static constexpr auto
 is_equal_r(Rs... rs) -> bool {
     return !is_mismatched_r(rs...);
 }

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -23,7 +23,7 @@ static auto constexpr not_equal_to = [](auto const &first, auto const &...values
  * @brief Variadic version of `std::mismatch`
  */
 template <typename P, typename I, typename... Is>
-[[nodiscard]] static auto constexpr zip_find(P const &pred, I f, I l, Is... fs) {
+[[nodiscard]] static auto constexpr zip_find(P const &pred, I f, I const l, Is... fs) {
     static_assert(sizeof...(Is) != 0);
     while (f != l) {
         if (pred(*f, *fs...)) break;
@@ -36,34 +36,48 @@ template <typename P, typename I, typename... Is>
  * @brief Predicate version of `algo::zip_found`
  */
 template <typename P, typename I, typename... Is>
-[[nodiscard]] static auto constexpr zip_found(P const &pred, I f, I l, Is... fs) -> bool {
+[[nodiscard]] static auto constexpr zip_found(P const &pred, I f, I const l, Is... fs) -> bool {
     auto const t = zip_find(pred, f, l, fs...);
     return std::get<0>(t) != l;
 }
 
-/**
- * @brief Predicate version of `std::mismatch`
- * @note std::mismatch isn't constexpr till cpp20
- */
-template <typename I, typename I2>
-[[nodiscard]] static auto
-is_mismatched(I f, I l, I2 f2) -> bool {
-    return std::mismatch(f, l, f2).first != l;
-}
+// This 2 arg function takes priority so will not work when called from constexpr functions. This isn't an issue in
+// cpp20.
+// /**
+//  * @brief Predicate version of `std::mismatch`
+//  * @note std::mismatch isn't constexpr till cpp20
+//  */
+// template <typename I, typename I2>
+// [[nodiscard]] static auto
+// is_mismatched(I f, I const l, I2 f2) -> bool {
+//     return std::mismatch(f, l, f2).first != l;
+// }
 
 /**
  * @brief Variadic, Predicate version of `std::mismatch`
  */
 template <typename I, typename... Is>
-[[nodiscard]] static auto constexpr is_mismatched(I f, I l, Is... fs) -> bool {
+[[nodiscard]] static auto constexpr is_mismatched(I f, I const l, Is... fs) -> bool {
     return zip_found(not_equal_to, f, l, fs...);
 }
+
+// // This 2 arg function takes priority so will not work when called from constexpr functions. This isn't an issue in
+// cpp20.
+// /**
+//  * @brief Predicate version of `std::equal`
+//  * @note std::equal isn't constexpr till cpp20
+//  */
+// template <typename I, typename I2>
+// [[nodiscard]] static auto
+// is_equal(I f, I const l, I2 f2) -> bool {
+//     return std::equal(f, l, f2);
+// }
 
 /**
  * @brief Variadic, Predicate version of `std::equal`
  */
 template <typename I, typename... Is>
-[[nodiscard]] static auto constexpr is_equal(I f, I l, Is... fs) -> bool {
+[[nodiscard]] static auto constexpr is_equal(I f, I const l, Is... fs) -> bool {
     return !is_mismatched(f, l, fs...);
 }
 
@@ -112,5 +126,6 @@ static_assert(is_mismatched(std::array{0, 1, 2, 5, 4}, std::array{0, 1, 2, 3, 4}
 static_assert(is_mismatched(std::array{0, 1, 2, 5, 4}, std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3, 6}));
 static_assert(!is_mismatched(std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}));
 static_assert(is_equal(std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}));
+static_assert(ranges::is_equal(std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}));
 }  // namespace ranges
 }  // namespace algo

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -7,7 +7,7 @@ namespace algo {
 /**
  * @brief Variadic version of `std::equal_to`
  */
-static auto constexpr is_equal_to = [](const auto &first, const auto &...values) -> bool {
+static auto constexpr is_equal_to = [](auto const &first, auto const &...values) -> bool {
     static_assert(sizeof...(values) != 0);
     return ((first == values) && ...);
 };
@@ -15,7 +15,7 @@ static auto constexpr is_equal_to = [](const auto &first, const auto &...values)
 /**
  * @brief Variadic version of `std::not_equal_to`
  */
-static auto constexpr is_not_equal_to = [](const auto &first, const auto &...values) -> bool {
+static auto constexpr is_not_equal_to = [](auto const &first, auto const &...values) -> bool {
     return !is_equal_to(first, values...);
 };
 
@@ -23,7 +23,7 @@ static auto constexpr is_not_equal_to = [](const auto &first, const auto &...val
  * @brief Variadic version of `std::mismatch`
  */
 template <typename P, typename I, typename... Is>
-[[nodiscard]] static auto constexpr zip_find(const P &pred, I f, I l, Is... fs) {
+[[nodiscard]] static auto constexpr zip_find(P const &pred, I f, I l, Is... fs) {
     static_assert(sizeof...(Is) != 0);
     while (f != l) {
         if (pred(*f, *fs...)) break;
@@ -37,7 +37,7 @@ template <typename P, typename I, typename... Is>
  * @note This can be the same name as zip_find if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-[[nodiscard]] static auto constexpr zip_find_r(const P &pred, const R &r, const Rs &...rs) {
+[[nodiscard]] static auto constexpr zip_find_r(P const &pred, R const &r, Rs const &...rs) {
     return zip_find(pred, std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
 
@@ -45,7 +45,7 @@ template <typename P, typename R, typename... Rs>
  * @brief Predicate version of `algo::zip_found`
  */
 template <typename P, typename I, typename... Is>
-[[nodiscard]] static auto constexpr zip_found(const P &pred, I f, I l, Is... fs) -> bool {
+[[nodiscard]] static auto constexpr zip_found(P const &pred, I f, I l, Is... fs) -> bool {
     auto const t = zip_find(pred, f, l, fs...);
     return std::get<0>(t) != l;
 }
@@ -55,7 +55,7 @@ template <typename P, typename I, typename... Is>
  * @note This can be the same name as zip_found if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-[[nodiscard]] static auto constexpr zip_found_r(const P &pred, const R &r, const Rs &...rs) -> bool {
+[[nodiscard]] static auto constexpr zip_found_r(P const &pred, R const &r, Rs const &...rs) -> bool {
     return zip_found(pred, std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
 
@@ -83,7 +83,7 @@ is_mismatched_v(I f, I l, Is... fs) -> bool {
  */
 template <typename R, typename... Rs>
 [[nodiscard]] static auto constexpr
-is_mismatched_r(const R &r, const Rs &...rs) -> bool {
+is_mismatched_r(R const &r, Rs const &...rs) -> bool {
     return is_not_equal_to(std::size(r), std::size(rs)...) ||
            is_mismatched_v(std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
@@ -102,7 +102,7 @@ is_equal(I f, I l, Is... fs) -> bool {
  */
 template <typename... Rs>
 [[nodiscard]] static auto constexpr
-is_equal_r(const Rs &...rs) -> bool {
+is_equal_r(Rs const &...rs) -> bool {
     return !is_mismatched_r(rs...);
 }
 

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -15,7 +15,7 @@ static auto constexpr is_equal_to = [](auto const &first, auto const &...values)
 /**
  * @brief Variadic version of `std::not_equal_to`
  */
-static auto constexpr is_not_equal_to = [](auto const &first, auto const &...values) -> bool {
+static auto constexpr not_equal_to = [](auto const &first, auto const &...values) -> bool {
     return !is_equal_to(first, values...);
 };
 

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -24,6 +24,7 @@ static auto constexpr is_not_equal_to = [](const auto &first, const auto &...val
  */
 template <typename P, typename I, typename... Is>
 [[nodiscard]] static auto constexpr zip_find(const P &pred, I f, I l, Is... fs) {
+    static_assert(sizeof...(Is) != 0);
     while (f != l) {
         if (pred(*f, *fs...)) break;
         ++f, ((void)++fs, ...);

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -23,7 +23,7 @@ static auto constexpr is_not_equal_to = [](const auto &first, const auto &...val
  * @brief Variadic version of `std::mismatch`
  */
 template <typename P, typename I, typename... Is>
-static auto constexpr zip_find(const P &pred, I f, I l, Is... fs) {
+[[nodiscard]] static auto constexpr zip_find(const P &pred, I f, I l, Is... fs) {
     while (f != l) {
         if (pred(*f, *fs...)) break;
         ++f, ((void)++fs, ...);
@@ -36,7 +36,7 @@ static auto constexpr zip_find(const P &pred, I f, I l, Is... fs) {
  * @note This can be the same name as zip_find if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-static auto constexpr zip_find_r(const P &pred, const R &r, const Rs &...rs) {
+[[nodiscard]] static auto constexpr zip_find_r(const P &pred, const R &r, const Rs &...rs) {
     return zip_find(pred, std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
 
@@ -44,7 +44,7 @@ static auto constexpr zip_find_r(const P &pred, const R &r, const Rs &...rs) {
  * @brief Predicate version of `algo::zip_found`
  */
 template <typename P, typename I, typename... Is>
-static auto constexpr zip_found(const P &pred, I f, I l, Is... fs) -> bool {
+[[nodiscard]] static auto constexpr zip_found(const P &pred, I f, I l, Is... fs) -> bool {
     auto const t = zip_find(pred, f, l, fs...);
     return std::get<0>(t) != l;
 }
@@ -54,7 +54,7 @@ static auto constexpr zip_found(const P &pred, I f, I l, Is... fs) -> bool {
  * @note This can be the same name as zip_found if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-static auto constexpr zip_found_r(const P &pred, const R &r, const Rs &...rs) -> bool {
+[[nodiscard]] static auto constexpr zip_found_r(const P &pred, const R &r, const Rs &...rs) -> bool {
     return zip_found(pred, std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
 
@@ -63,7 +63,7 @@ static auto constexpr zip_found_r(const P &pred, const R &r, const Rs &...rs) ->
  * @note std::mismatch isn't constexpr till cpp20
  */
 template <typename I, typename I2>
-static auto
+[[nodiscard]] static auto
 is_mismatched(I f, I l, I2 f2) -> bool {
     return std::mismatch(f, l, f2).first != l;
 }
@@ -72,7 +72,7 @@ is_mismatched(I f, I l, I2 f2) -> bool {
  * @brief Variadic, Predicate version of `std::mismatch`
  */
 template <typename I, typename... Is>
-static constexpr auto
+[[nodiscard]] static auto constexpr
 is_mismatched_v(I f, I l, Is... fs) -> bool {
     return zip_found(is_not_equal_to, f, l, fs...);
 }
@@ -81,7 +81,7 @@ is_mismatched_v(I f, I l, Is... fs) -> bool {
  * @brief Variadic, Predicate version of `std::mismatch`, for ranges;
  */
 template <typename R, typename... Rs>
-static constexpr auto
+[[nodiscard]] static auto constexpr
 is_mismatched_r(const R &r, const Rs &...rs) -> bool {
     return is_not_equal_to(std::size(r), std::size(rs)...) ||
            is_mismatched_v(std::cbegin(r), std::cend(r), std::cbegin(rs)...);
@@ -91,7 +91,7 @@ is_mismatched_r(const R &r, const Rs &...rs) -> bool {
  * @brief Variadic, Predicate version of `std::equal`
  */
 template <typename I, typename... Is>
-static constexpr auto
+[[nodiscard]] static auto constexpr
 is_equal(I f, I l, Is... fs) -> bool {
     return !is_mismatched_v(f, l, fs...);
 }
@@ -100,7 +100,7 @@ is_equal(I f, I l, Is... fs) -> bool {
  * @brief Variadic, Predicate version of `std::equal`, for ranges;
  */
 template <typename... Rs>
-static constexpr auto
+[[nodiscard]] static auto constexpr
 is_equal_r(const Rs &...rs) -> bool {
     return !is_mismatched_r(rs...);
 }

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -36,8 +36,8 @@ static auto constexpr zip_find(const P &pred, I f, I l, Is... fs) {
  * @note This can be the same name as zip_find if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-static auto constexpr zip_find_r(const P &pred, R &r, Rs &...rs) {
-    return zip_find(pred, std::begin(r), std::end(r), std::begin(rs)...);
+static auto constexpr zip_find_r(const P &pred, const R &r, const Rs &...rs) {
+    return zip_find(pred, std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
 
 /**
@@ -54,8 +54,8 @@ static auto constexpr zip_found(const P &pred, I f, I l, Is... fs) -> bool {
  * @note This can be the same name as zip_found if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-static auto constexpr zip_found_r(const P &pred, R &r, Rs &...rs) -> bool {
-    return zip_found(pred, std::begin(r), std::end(r), std::begin(rs)...);
+static auto constexpr zip_found_r(const P &pred, const R &r, const Rs &...rs) -> bool {
+    return zip_found(pred, std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
 
 /**
@@ -82,9 +82,9 @@ is_mismatched_v(I f, I l, Is... fs) -> bool {
  */
 template <typename R, typename... Rs>
 static constexpr auto
-is_mismatched_r(R &r, Rs &...rs) -> bool {
+is_mismatched_r(const R &r, const Rs &...rs) -> bool {
     return is_not_equal_to(std::size(r), std::size(rs)...) ||
-           is_mismatched_v(std::begin(r), std::end(r), std::begin(rs)...);
+           is_mismatched_v(std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
 
 /**
@@ -101,7 +101,7 @@ is_equal(I f, I l, Is... fs) -> bool {
  */
 template <typename... Rs>
 static constexpr auto
-is_equal_r(Rs &...rs) -> bool {
+is_equal_r(const Rs &...rs) -> bool {
     return !is_mismatched_r(rs...);
 }
 

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -101,7 +101,7 @@ is_equal(I f, I l, Is... fs) -> bool {
 template <typename... Rs>
 constexpr auto
 is_equal_r(Rs... rs) -> bool {
-    return !is_mismatched_r(r, rs...);
+    return !is_mismatched_r(rs...);
 }
 
 // static_assert tests. With constexpr we can start checking to make sure our functions work at compile time.

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -49,8 +49,8 @@ zip_found(P const &pred, I f, I const l, Is... fs) -> bool {
  */
 template <typename I, typename... Is>
 [[nodiscard]] static constexpr auto
-is_mismatched(I f, I const l, Is... fs) -> bool {
-    return zip_found(not_equal_to, f, l, fs...);
+is_equal(I f, I const l, Is... fs) -> bool {
+    return zip_found(equal_to, f, l, fs...);
 }
 
 

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -7,7 +7,7 @@ namespace algo {
 /**
  * @brief Variadic version of `std::equal_to`
  */
-static auto constexpr is_equal_to = [](auto const &first, auto const &...values) -> bool {
+static auto constexpr equal_to = [](auto const &first, auto const &...values) -> bool {
     static_assert(sizeof...(values) != 0);
     return ((first == values) && ...);
 };

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -53,17 +53,6 @@ is_mismatched(I f, I const l, Is... fs) -> bool {
     return zip_found(not_equal_to, f, l, fs...);
 }
 
-// // This 2 arg function takes priority so will not work when called from constexpr functions. This isn't an issue in
-// cpp20.
-// /**
-//  * @brief Predicate version of `std::equal`
-//  * @note std::equal isn't constexpr till cpp20
-//  */
-// template <typename I, typename I2>
-// [[nodiscard]] static auto
-// is_equal(I f, I const l, I2 f2) -> bool {
-//     return std::equal(f, l, f2);
-// }
 
 /**
  * @brief Variadic, Predicate version of `std::equal`

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -86,6 +86,7 @@ is_equal(I f, I const l, Is... fs) -> bool {
 }
 
 namespace ranges {
+
 /**
  * @brief Variadic version of `std::mismatch`, for ranges.
  * @note This can be the same name as zip_find if we use concepts.
@@ -95,6 +96,7 @@ template <typename P, typename R, typename... Rs>
 zip_find(P const &pred, R const &r, Rs const &...rs) {
     return algo::zip_find(pred, std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
+
 /**
  * @brief Variadic version of `algo::zip_found`, for ranges.
  * @note This can be the same name as zip_found if we use concepts.
@@ -104,6 +106,7 @@ template <typename P, typename R, typename... Rs>
 zip_found(P const &pred, R const &r, Rs const &...rs) -> bool {
     return algo::zip_found(pred, std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
+
 /**
  * @brief Variadic, Predicate version of `std::mismatch`, for ranges;
  */
@@ -113,6 +116,7 @@ is_mismatched(R const &r, Rs const &...rs) -> bool {
     return not_equal_to(std::size(r), std::size(rs)...) ||
            algo::is_mismatched(std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
+
 /**
  * @brief Variadic, Predicate version of `std::equal`, for ranges;
  */
@@ -121,6 +125,7 @@ template <typename... Rs>
 is_equal(Rs const &...rs) -> bool {
     return !is_mismatched(rs...);
 }
+
 // static_assert tests. With constexpr we can start checking to make sure our functions work at compile time.
 static_assert(!equal_to(1, 2, 3, 4));
 static_assert(equal_to(1, 1, 1, 1));

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -73,8 +73,7 @@ is_mismatched(I f, I l, I2 f2) -> bool {
  * @brief Variadic, Predicate version of `std::mismatch`
  */
 template <typename I, typename... Is>
-[[nodiscard]] static auto constexpr
-is_mismatched_v(I f, I l, Is... fs) -> bool {
+[[nodiscard]] static auto constexpr is_mismatched_v(I f, I l, Is... fs) -> bool {
     return zip_found(is_not_equal_to, f, l, fs...);
 }
 
@@ -82,8 +81,7 @@ is_mismatched_v(I f, I l, Is... fs) -> bool {
  * @brief Variadic, Predicate version of `std::mismatch`, for ranges;
  */
 template <typename R, typename... Rs>
-[[nodiscard]] static auto constexpr
-is_mismatched_r(R const &r, Rs const &...rs) -> bool {
+[[nodiscard]] static auto constexpr is_mismatched_r(R const &r, Rs const &...rs) -> bool {
     return is_not_equal_to(std::size(r), std::size(rs)...) ||
            is_mismatched_v(std::cbegin(r), std::cend(r), std::cbegin(rs)...);
 }
@@ -92,8 +90,7 @@ is_mismatched_r(R const &r, Rs const &...rs) -> bool {
  * @brief Variadic, Predicate version of `std::equal`
  */
 template <typename I, typename... Is>
-[[nodiscard]] static auto constexpr
-is_equal(I f, I l, Is... fs) -> bool {
+[[nodiscard]] static auto constexpr is_equal(I f, I l, Is... fs) -> bool {
     return !is_mismatched_v(f, l, fs...);
 }
 
@@ -101,8 +98,7 @@ is_equal(I f, I l, Is... fs) -> bool {
  * @brief Variadic, Predicate version of `std::equal`, for ranges;
  */
 template <typename... Rs>
-[[nodiscard]] static auto constexpr
-is_equal_r(Rs const &...rs) -> bool {
+[[nodiscard]] static auto constexpr is_equal_r(Rs const &...rs) -> bool {
     return !is_mismatched_r(rs...);
 }
 

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -43,17 +43,6 @@ zip_found(P const &pred, I f, I const l, Is... fs) -> bool {
     return std::get<0>(t) != l;
 }
 
-// This 2 arg function takes priority so will not work when called from constexpr functions. This isn't an issue in
-// cpp20.
-// /**
-//  * @brief Predicate version of `std::mismatch`
-//  * @note std::mismatch isn't constexpr till cpp20
-//  */
-// template <typename I, typename I2>
-// [[nodiscard]] static auto
-// is_mismatched(I f, I const l, I2 f2) -> bool {
-//     return std::mismatch(f, l, f2).first != l;
-// }
 
 /**
  * @brief Variadic, Predicate version of `std::mismatch`

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -1,36 +1,121 @@
-
-#include <tuple>
 #include <algorithm>
+#include <array>
+#include <tuple>
 
 namespace algo {
+
+/**
+ * @brief Variadic version of `std::equal_to`
+ */
+static auto constexpr is_equal_to = [](const auto first, const auto... values) -> bool {
+    static_assert(sizeof...(values) != 0);
+    return ((first == values) && ...);
+};
+
+/**
+ * @brief Variadic version of `std::not_equal_to`
+ */
+static auto constexpr is_not_equal_to = [](const auto first, const auto... values) -> bool {
+    return !is_equal_to(first, values...);
+};
 
 /**
  * @brief Variadic version of `std::mismatch`
  */
 template <typename P, typename I, typename... Is>
-auto zip_find(P pred, I f, I l, Is... fs) {
+auto constexpr zip_find(const P pred, I f, I l, Is... fs) {
     while (f != l) {
         if (pred(*f, *fs...)) break;
-        ++f, ((void)++fs,...);
+        ++f, ((void)++fs, ...);
     }
     return std::tuple{f, fs...};
+}
+
+/**
+ * @brief Variadic version of `std::mismatch`, for ranges.
+ * @note This can be the same name as zip_find if we use concepts.
+ */
+template <typename P, typename R, typename... Rs>
+auto constexpr zip_find_r(const P pred, R r, Rs... rs) {
+    return zip_find(pred, std::begin(r), std::end(r), std::begin(rs)...);
 }
 
 /**
  * @brief Predicate version of `algo::zip_found`
  */
 template <typename P, typename I, typename... Is>
-auto zip_found(P pred, I f, I l, Is... fs) {
+auto constexpr zip_found(const P pred, I f, I l, Is... fs) -> bool {
     auto const t = zip_find(pred, f, l, fs...);
     return std::get<0>(t) != l;
 }
 
 /**
+ * @brief Variadic version of `algo::zip_found`, for ranges.
+ * @note This can be the same name as zip_found if we use concepts.
+ */
+template <typename P, typename R, typename... Rs>
+auto constexpr zip_found_r(const P pred, R r, Rs... rs) -> bool {
+    return zip_found(pred, std::begin(r), std::end(r), std::begin(rs)...);
+}
+
+/**
  * @brief Predicate version of `std::mismatch`
+ * @note std::mismatch isn't constexpr till cpp20
  */
 template <typename I, typename I2>
-auto is_mismatched(I f, I l, I2 f2) {
+static auto
+is_mismatched(I f, I l, I2 f2) -> bool {
     return std::mismatch(f, l, f2).first != l;
 }
 
+/**
+ * @brief Variadic, Predicate version of `std::mismatch`
+ */
+template <typename I, typename... Is>
+constexpr auto
+is_mismatched_v(I f, I l, Is... fs) -> bool {
+    return zip_found(is_not_equal_to, f, l, fs...);
 }
+
+/**
+ * @brief Variadic, Predicate version of `std::mismatch`, for ranges;
+ */
+template <typename R, typename... Rs>
+constexpr auto
+is_mismatched_r(R r, Rs... rs) -> bool {
+    return is_not_equal_to(std::size(rs)...) || is_mismatched_v(std::begin(r), std::end(r), std::begin(rs)...);
+}
+
+/**
+ * @brief Variadic, Predicate version of `std::equal`
+ */
+template <typename I, typename... Is>
+constexpr auto
+is_equal(I f, I l, Is... fs) -> bool {
+    return !is_mismatched_v(f, l, fs...);
+}
+
+/**
+ * @brief Variadic, Predicate version of `std::equal`, for ranges;
+ */
+template <typename... Rs>
+constexpr auto
+is_equal_r(Rs... rs) -> bool {
+    return !is_mismatched_r(r, rs...);
+}
+
+// static_assert tests. With constexpr we can start checking to make sure our functions work at compile time.
+static_assert(!is_equal_to(1, 2, 3, 4));
+static_assert(is_equal_to(1, 1, 1, 1));
+static_assert(is_not_equal_to(1, 2, 3, 4));
+static_assert(!is_not_equal_to(1, 1, 1, 1));
+static_assert(
+  !zip_found_r(is_not_equal_to, std::array{0, 1, 2, 3, 4}, std::array{0, 1, 2, 3, 4}, std::array{0, 1, 2, 3, 4}));
+static_assert(
+  zip_found_r(is_not_equal_to, std::array{0, 1, 2, 5, 4}, std::array{0, 1, 2, 3, 4}, std::array{0, 1, 2, 3, 6}));
+static_assert(is_mismatched_r(std::array{0, 1, 2, 5, 4}, std::array{0, 1, 2, 3, 4}, std::array{0, 1, 2, 3, 6}));
+static_assert(is_mismatched_r(std::array{0, 1, 2, 5, 4}, std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3, 6}));
+static_assert(!is_mismatched_r(std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}));
+static_assert(is_equal_r(std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}, std::array{0, 1, 2, 3}));
+
+}  // namespace algo

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -7,7 +7,7 @@ namespace algo {
 /**
  * @brief Variadic version of `std::equal_to`
  */
-static auto constexpr is_equal_to = [](const auto first, const auto... values) -> bool {
+static auto constexpr is_equal_to = [](const auto &first, const auto &...values) -> bool {
     static_assert(sizeof...(values) != 0);
     return ((first == values) && ...);
 };
@@ -15,7 +15,7 @@ static auto constexpr is_equal_to = [](const auto first, const auto... values) -
 /**
  * @brief Variadic version of `std::not_equal_to`
  */
-static auto constexpr is_not_equal_to = [](const auto first, const auto... values) -> bool {
+static auto constexpr is_not_equal_to = [](const auto &first, const auto &...values) -> bool {
     return !is_equal_to(first, values...);
 };
 
@@ -23,7 +23,7 @@ static auto constexpr is_not_equal_to = [](const auto first, const auto... value
  * @brief Variadic version of `std::mismatch`
  */
 template <typename P, typename I, typename... Is>
-static auto constexpr zip_find(const P pred, I f, I l, Is... fs) {
+static auto constexpr zip_find(const P &pred, I f, I l, Is... fs) {
     while (f != l) {
         if (pred(*f, *fs...)) break;
         ++f, ((void)++fs, ...);
@@ -36,7 +36,7 @@ static auto constexpr zip_find(const P pred, I f, I l, Is... fs) {
  * @note This can be the same name as zip_find if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-static auto constexpr zip_find_r(const P pred, R r, Rs... rs) {
+static auto constexpr zip_find_r(const P &pred, R &r, Rs &...rs) {
     return zip_find(pred, std::begin(r), std::end(r), std::begin(rs)...);
 }
 
@@ -44,7 +44,7 @@ static auto constexpr zip_find_r(const P pred, R r, Rs... rs) {
  * @brief Predicate version of `algo::zip_found`
  */
 template <typename P, typename I, typename... Is>
-static auto constexpr zip_found(const P pred, I f, I l, Is... fs) -> bool {
+static auto constexpr zip_found(const P &pred, I f, I l, Is... fs) -> bool {
     auto const t = zip_find(pred, f, l, fs...);
     return std::get<0>(t) != l;
 }
@@ -54,7 +54,7 @@ static auto constexpr zip_found(const P pred, I f, I l, Is... fs) -> bool {
  * @note This can be the same name as zip_found if we use concepts.
  */
 template <typename P, typename R, typename... Rs>
-static auto constexpr zip_found_r(const P pred, R r, Rs... rs) -> bool {
+static auto constexpr zip_found_r(const P &pred, R &r, Rs &...rs) -> bool {
     return zip_found(pred, std::begin(r), std::end(r), std::begin(rs)...);
 }
 
@@ -82,8 +82,9 @@ is_mismatched_v(I f, I l, Is... fs) -> bool {
  */
 template <typename R, typename... Rs>
 static constexpr auto
-is_mismatched_r(R r, Rs... rs) -> bool {
-    return is_not_equal_to(std::size(rs)...) || is_mismatched_v(std::begin(r), std::end(r), std::begin(rs)...);
+is_mismatched_r(R &r, Rs &...rs) -> bool {
+    return is_not_equal_to(std::size(r), std::size(rs)...) ||
+           is_mismatched_v(std::begin(r), std::end(r), std::begin(rs)...);
 }
 
 /**
@@ -100,7 +101,7 @@ is_equal(I f, I l, Is... fs) -> bool {
  */
 template <typename... Rs>
 static constexpr auto
-is_equal_r(Rs... rs) -> bool {
+is_equal_r(Rs &...rs) -> bool {
     return !is_mismatched_r(rs...);
 }
 

--- a/jsrc/algorithm.hpp
+++ b/jsrc/algorithm.hpp
@@ -73,7 +73,7 @@ is_mismatched(I f, I l, I2 f2) -> bool {
  * @brief Variadic, Predicate version of `std::mismatch`
  */
 template <typename I, typename... Is>
-[[nodiscard]] static auto constexpr is_mismatched_v(I f, I l, Is... fs) -> bool {
+[[nodiscard]] static auto constexpr is_mismatched(I f, I l, Is... fs) -> bool {
     return zip_found(is_not_equal_to, f, l, fs...);
 }
 

--- a/jsrc/verbs/dyadic/take_drop.cpp
+++ b/jsrc/verbs/dyadic/take_drop.cpp
@@ -76,7 +76,7 @@ static array jttks(J jt, array a, array w) {  // take_sparse
     s = AV(y);
 
     // TODO: rename b when we figure out what it is doing
-    auto const b = algo::is_mismatched(u + m, u + r, s + m);
+    auto const b = !std::equal(u + m, u + r, s + m);
 
     if (b) {
         jt->fill = SPA(wp, e);
@@ -88,7 +88,7 @@ static array jttks(J jt, array a, array w) {  // take_sparse
         x = SPA(wp, x);
 
     // TODO: rename c when we figure out what it is doing
-    if (auto const c = algo::is_mismatched(u, u + m, s); c) {
+    if (auto const c = !std::equal(u, u + m, s); c) {
         A j;
         C *xv, *yv;
         I d, i, *iv, *jv, k, n, t;


### PR DESCRIPTION
I wanted to be able to test `constexpr` versions of the functions. So i'm including `<array>` for testing and added some range based overloads.
Added predicates:
`equal_to`
`not_equal_to`
`is_equal` - is_equal is a variadic version of `std::equal`
Added range overloads in `ranges` namespace.
`zip_find`
`zip_found`
`is_equal`

`is_mismatched` was removed as `!std::equal` covers it.

`auto` has to be on the right of the cv qualifiers. Or the clang-format new line won't trigger.