### PR TITLE
Enable use of newer compiler version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,12 +45,6 @@ add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Werror>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=sequence-point>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=strict-overflow>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=logical-not-parentheses>)
-if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
-    # this warning was added in gcc 8 https://debarshiray.wordpress.com/2019/04/01/about-wextra-and-wcast-function-type/
-
-    add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-cast-function-type>) #disable warning
-    # add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=cast-function-type>) #disable errors from warning
-endif ()
 
 # Enable warnings
 add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wall>)
@@ -59,6 +53,10 @@ add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wunused-macros>)
 add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-error=unused-macros>) # Some false positives / only cover current build configuration
 
 # Exclude some warnings
+if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
+    # this warning was added in gcc 8 https://debarshiray.wordpress.com/2019/04/01/about-wextra-and-wcast-function-type/
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-cast-function-type>)
+endif ()
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-misleading-indentation>)
 add_compile_options($<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-address>)
 add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-parameter>)


### PR DESCRIPTION
This could:
1. allow compiling with gcc 10.2, accompishing the same as #164
2. allow for compiler upgrade to clang 11 / gcc 10
3. point 2 would enable c++17 features and #170 would compile

Tested with the following compiler versions on osx:
```
; /usr/local/Cellar/gcc/10.2.0_4/bin/gcc-10 --version
gcc-10 (Homebrew GCC 10.2.0_4) 10.2.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
```
; clang --version
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: x86_64-apple-darwin20.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```