### PR TITLE
Add EXCLUDE_FROM_ALL to add_subdirectory(An-Algorithm-Library)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wno-unknown-pragmas>)
 
 add_subdirectory(jsrc)
 add_subdirectory(base64)
-add_subdirectory(An-Algorithm-Library)
+add_subdirectory(An-Algorithm-Library EXCLUDE_FROM_ALL)
 if(${DOCS} STREQUAL "YES")
     add_subdirectory(docs)
 endif()


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/command/add_subdirectory.html
   `If the EXCLUDE_FROM_ALL argument is provided then targets in the subdirectory will not be included in the ALL target of the parent directory by default, and will be excluded from IDE project files`

resolves: https://github.com/codereport/jsource/issues/199

Without `EXCLUDE_FROM_ALL`, anytime we add a target that compiles to An-Algorithm-Library it would compile them when you compile `ALL` in j. 