### PR TITLE
Remove DI macro from vasm.h

### DIFF
--- a/jsrc/verbs/vasm.h
+++ b/jsrc/verbs/vasm.h
@@ -12,8 +12,6 @@
 /* fs   zv=.+/\.xv    1<n */
 
 /* C routines for platforms without asm support */
-#define DI LD
-
 #define PLUSVV(n, z, x, y)                                                           \
     {                                                                                \
         I u, v, w;                                                                   \


### PR DESCRIPTION
This one isn't used, the name also occurs in `jtype.h`. Remove this one
to prevent confusion.