### PR TITLE
Remove some dead assignments/initializations found by clang-scan

### DIFF
--- a/jsrc/adverbs/af.c
+++ b/jsrc/adverbs/af.c
@@ -143,7 +143,6 @@ jtfixa(J jt, A a, A w) {
                     f  = v->fgh[0];
                     g  = v->fgh[1];
                     h  = v->fgh[2];
-                    wf = ds(v->id);
                 }
                 f = REFIXA(0, f);
                 h = REFIXA(0, h);

--- a/jsrc/adverbs/ai.c
+++ b/jsrc/adverbs/ai.c
@@ -609,13 +609,11 @@ jtiden(J jt, A w) {
 
 A
 jtidensb(J jt, A w) {
-    A f, g, x = 0, w0 = w;
+    A x = 0, w0 = w;
     V* v;
     RZ(w = jtfix(jt, w, num(0)));
     ASSERT(VERB & AT(w), EVDOMAIN);
     v = FAV(w);
-    f = v->fgh[0];
-    g = v->fgh[1];
     switch (v->id) {
         default: return jtiden(jt, w0);
         case CMAX:

--- a/jsrc/adverbs/am.c
+++ b/jsrc/adverbs/am.c
@@ -32,7 +32,6 @@ jtmerge1(J jt, A w, A ind) {
     A z;
     B *b;
     C *wc, *zc;
-    D *wd, *zd;
     I c, it, j, k, m, r, *s, t, *u, *wi, *zi;
     r = MAX(0, AR(w) - 1);
     s = 1 + AS(w);
@@ -53,10 +52,8 @@ jtmerge1(J jt, A w, A ind) {
                       // checked individually, so we just look at the first c bytes
     zi = AV(z);
     zc = (C *)zi;
-    zd = (D *)zc;
     wi = AV(w);
     wc = (C *)wi;
-    wd = (D *)wc;
     switch (MCASE(CTTZ(it), k)) {
         case MCASE(B01X, sizeof(C)): DO(c, *zc++ = wc[i + c * (I)*b++];); break;
         case MCASE(B01X, sizeof(I)): DO(c, *zi++ = wi[i + c * (I)*b++];); break;

--- a/jsrc/adverbs/am1.c
+++ b/jsrc/adverbs/am1.c
@@ -48,7 +48,6 @@ jtastd1(J jt, A a, A z, A ind) {
     B b;
     I ar, *as, d, j, m, n, *rv, zr, *zs;
     P *zp;
-    I *s1v;
     ar = AR(a);
     as = AS(a);
     zr = AR(z);
@@ -68,7 +67,6 @@ jtastd1(J jt, A a, A z, A ind) {
     d = m + zr - n;
     ASSERT(ar <= d, EVRANK);
     RZ(s1 = jtraze(jt, s));
-    s1v = AV(s1);
     ASSERT(!ICMP(as, AV(s1) + d - ar, ar), EVLENGTH);
     if (ar < d) RZ(a = jtreshape(jt, s1, a));
     RZ(q = jtdgrade1(jt, jteps(jt, jtrepeat(jt, r, IX(zr)), SPA(zp, a))));
@@ -334,16 +332,14 @@ mtind(A ind) {
 
 A
 jtam1e(J jt, A a, A z, A ind, B ip) {
-    A e, i1, i2, p, x, y;
+    A e, i1, i2, p, x;
     B *pv;
     C *u, *v;
     I *iv, k, m, n, r, *s, vk, xk;
     P *zp;
     RZ(a && (ind = jtistd1(jt, z, ind)));
-    r  = AR(z);
     zp = PAV(z);
     x  = SPA(zp, x);
-    y  = SPA(zp, i);
     e  = SPA(zp, e);
     RZ(p = jtssel(jt, z, ind));
     pv = BAV(p);
@@ -370,7 +366,7 @@ jtam1e(J jt, A a, A z, A ind, B ip) {
 
 A
 jtam1a(J jt, A a, A z, A ind, B ip) {
-    A a0 = a, a1, e, i1, i2, t, x, y;
+    A a0 = a, a1, e, i1, i2, t, x;
     C *u, *v, *xv;
     I ar, c, *iv, *jv, k, m, n, r, *s, uk, vk, xk;
     P *zp;
@@ -381,7 +377,6 @@ jtam1a(J jt, A a, A z, A ind, B ip) {
     RZ(z = jtzpad1(jt, z, jtscube(jt, z, i1, jtssel(jt, z, ind)), ip));
     zp = PAV(z);
     x  = SPA(zp, x);
-    y  = SPA(zp, i);
     e  = SPA(zp, e);
     ar = AR(a);
     n  = AN(i2);

--- a/jsrc/adverbs/amn.c
+++ b/jsrc/adverbs/amn.c
@@ -92,7 +92,6 @@ jtzpadn(J jt, A z, A ind, B ip) {
     a  = SPA(zp, a);
     x = x0 = SPA(zp, x);
     y = y0 = SPA(zp, i);
-    n      = 1;
     h      = *(AS(ind) + AR(ind) - 1);
     RZ(ai = IX(h));
     RZ(t = jteps(jt, ai, a));

--- a/jsrc/adverbs/ao.c
+++ b/jsrc/adverbs/ao.c
@@ -61,7 +61,7 @@ jtobqfslash(J jt, A w, A self) {
     A y, z;
     B b = 0, p;
     C er, id, *wv;
-    I c, d, k, m, m1, mn, n, n1, r, *s, wt;
+    I c, d, k, m, m1, n, n1, r, *s, wt;
     r  = AR(w);
     s  = AS(w);
     wt = AT(w);
@@ -76,7 +76,6 @@ jtobqfslash(J jt, A w, A self) {
     m1 = m - 1;
     n  = s[1];
     n1 = n - 1;
-    mn = m * n;
     d  = m + n - 1;
     PROD(c, r - 2, 2 + s);
     if (((1 - m) & (1 - n)) >= 0) {

--- a/jsrc/adverbs/ar.c
+++ b/jsrc/adverbs/ar.c
@@ -933,12 +933,11 @@ jtredcat(J jt, A w, A self) {
 
 static A
 jtredsemi(J jt, A w, A self) {
-    I f, n, r, *s, wr;
+    I f, n, r, wr;
     wr = AR(w);
     r  = (RANKT)jt->ranks;
     r  = wr < r ? wr : r;
     f  = wr - r;
-    s  = AS(w);
     SETICFR(w, f, r, n);  // let the rank run into tail   n=#items  in a cell of w
     if (2 > n) {
         ASSERT(n != 0, EVDOMAIN);

--- a/jsrc/conjunctions/cc.c
+++ b/jsrc/conjunctions/cc.c
@@ -1319,7 +1319,6 @@ jtcut2(J jt, A a, A w, A self) {
                 zk         = wcn * atomsize;
                 if ((t = atype(adocv.cv)) && TYPESNE(t, wt)) {
                     RZ(w = jtcvt(jt, t, w));
-                    wv = CAV(w);
                 }
                 I rc = EVOK;  // accumulate error code
                 EACHCUT(
@@ -1725,7 +1724,6 @@ jttess2(J jt, A a, A w, A self) {
         vtrc = vlrc = 0;  // stifle all copying to the strip, which doesn't exist
         hss = hds = lrchsiz = 0;
         vds1 = vss1 = 0;
-        vss         = 0;
         svh = dvh = 0;  // no horiz looping, so this is immaterial
         vss       = 0;  // since we never loop back in horiz loop, this is immaterial
 

--- a/jsrc/conjunctions/cip.c
+++ b/jsrc/conjunctions/cip.c
@@ -91,7 +91,7 @@ jtpdtby(J jt, A a, A w) {
     RZ(z = jtipprep(jt, a, w, t, &m, &n, &p));
     zk = n << bplg(t);
     u  = BAV(a);
-    v = wv = BAV(w);
+    wv = BAV(w);
     NAN0;
     switch (CTTZ(t)) {
         default: ASSERT(0, EVDOMAIN);
@@ -107,7 +107,7 @@ jtpdtby(J jt, A a, A w) {
                 RZ(z = jtipprep(jt, a, w, FL, &m, &n, &p));
                 zk = n * sizeof(D);
                 u  = BAV(a);
-                v = wv = BAV(w);
+                wv = BAV(w);
                 if (at & B01) PDTBY(D, I, IINC) else PDTXB(D, I, IINC, c = (D)*u++);
             }
     }

--- a/jsrc/conjunctions/cip.c
+++ b/jsrc/conjunctions/cip.c
@@ -148,8 +148,6 @@ cachedmmult(J jt, D* av, D* wv, D* zv, I m, I n, I p, I flgs) {
     // flgs is 0 for float, 1 for complex, i. e. lg2(# values per atom).  If flgs is set, n and p are even, and give the
     // lengths of the arguments in values
     D* cvw = (D*)(((I)&c + (CACHELINESIZE - 1)) & -CACHELINESIZE);  // place where cache-blocks of w are staged
-    D* cva = (D*)(((I)cvw + (CACHEHEIGHT + 1) * CACHEWIDTH * sizeof(D) + (CACHELINESIZE - 1)) &
-                  -CACHELINESIZE);  // place where expanded rows of a are staged
     // zero the result area
     memset(zv, C0, m * n * sizeof(D));
     // process each 64-float vertical stripe of w, producing the corresponding columns of z
@@ -189,7 +187,6 @@ cachedmmult(J jt, D* av, D* wv, D* zv, I m, I n, I p, I flgs) {
             // the mx16 vertical strip of a (mx32 if flgs) will be multiplied by the 16x64 section of w and accumulated
             // into z process each 2x16 section of a against the 16x64 cache block
             D* a2base0 = a1base;
-            D* w2base  = w1base;
             I a2rem    = m;
             D* z2base  = z1base;
             D* c2base  = cvw;
@@ -474,7 +471,7 @@ jtpdt(J jt, A a, A w) {
                 // there is no way to be sure that some overflow has not occurred.  So we guess.  If the result is much
                 // less than the dynamic range of a float integer, convert the result to integer.
                 I i;
-                D* zv = DAV(z);
+                D* zv;
                 for (zv = DAV(z), i = AN(z); i; --i, ++zv)
                     if (*zv > 1e13 || *zv < -1e13) break;  // see if any value is out of range
                 if (!i) {

--- a/jsrc/conjunctions/crs.c
+++ b/jsrc/conjunctions/crs.c
@@ -107,12 +107,10 @@ jtsprz(J jt, A z0, A y, A e, I f, I* s) {
         return z;
     }
     e  = q;
-    zt = t = AT(z0);
+    t = AT(z0);
     d      = t & SPARSE ? 0 : 1;
-    if (d)
-        zt = STYPE(t);
-    else
-        t = DTYPE(zt);
+    if (!d)
+        t = DTYPE(t);
     et = AT(e);
     m  = maxtype(et, t);
     zt = STYPE(m);

--- a/jsrc/format/f.c
+++ b/jsrc/format/f.c
@@ -265,7 +265,7 @@ static A
 jtthsb(J jt, A w, A prxthornuni) {
     A d, z;
     C *zv;
-    I c, *dv, m, n, p, q, r, *s;
+    I c, *dv, m, n, p, r, *s;
     SB *x, *y;
     SBU *u;
     PROLOG(0000);
@@ -273,7 +273,6 @@ jtthsb(J jt, A w, A prxthornuni) {
     r = AR(w);
     s = AS(w);
     x = y = SBAV(w);
-    q     = jt->sbun;
     if (1 >= r) {
         c = n;
         RZ(d = jtapvwr(jt, c, 0L, 0L));
@@ -453,7 +452,6 @@ jtrc(J jt, A w, A *px, A *py, I *t) {
     I j = 0, k = 0, maxt = 0, r, *s, xn, *xv, yn, *yv;
     // r = rank of w, s->shape of w, v->values
     r = AR(w);
-    s = AS(w);
     v = AAV(w);
     // xn = #rows in 2-cell of joined table, x=vector of (xn+1) 0s, xv->data for vector
     SHAPEN(w, r - 2, xn);
@@ -792,7 +790,6 @@ jtths(J jt, A w) {
     P *p;
     RZ(jtscheck(jt, w));
     p = PAV(w);
-    e = SPA(p, e);
     i = SPA(p, i);
     x = SPA(p, x);
     RZ(i = jtthorn1(jt, i));

--- a/jsrc/format/f.c
+++ b/jsrc/format/f.c
@@ -66,7 +66,6 @@ jtfmtD(J jt, C *s, D *v) {
         return;
     }
     // x=*v; x=x==*(D*)minus0?0.0:x;  /* -0 to 0*/
-    x = *v;
     x = x == (-1) * 0.0 ? 0.0 : x; /* -0 to 0*/
     sprintf(buf, jt->pp, x);
     c = *buf;

--- a/jsrc/format/fbu.c
+++ b/jsrc/format/fbu.c
@@ -529,13 +529,11 @@ A
 RoutineB(J jt, A w, A prxthornuni) {
     A z;
     I n, t, q, b = 0;
-    UC* wv;
     US* c2v;
     C4* c4v;
     ASSERT(1 >= AR(w), EVRANK);
     n  = AN(w);
     t  = AT(w);
-    wv = UAV(w);
     ASSERT(t & C2T, EVDOMAIN);
     if (!n) {
         GATV(z, C2T, n, AR(w), AS(w));

--- a/jsrc/j.c
+++ b/jsrc/j.c
@@ -94,7 +94,6 @@ jtversq(J jt, A w) {
     char d[21];
     char months[] = "Jan01Feb02Mar03Apr04May05Jun06Jul07Aug08Sep09Oct10Nov11Dec12";
     C* p;
-    C* q;
     ASSERTMTV(w);
     strcpy(m, jeversion + 8);
     p = m + strlen(m) - 20;
@@ -104,7 +103,6 @@ jtversq(J jt, A w) {
     strncat(p, d + 7, 4);
     strcat(p, "-");
     d[3] = 0;
-    q    = strstr(months, d);
     strncat(p, 3 + strstr(months, d), 2);
     strcat(p, "-");
     strncat(p, d + 4, 2);

--- a/jsrc/representations/r.c
+++ b/jsrc/representations/r.c
@@ -276,9 +276,6 @@ jtunDD(J jt, A w) {
             if (inx != outx || shortres) {
                 DQ(endx - inx, currc = wv[inx++]; if (shortres && currc == CLF) break;
                    wv[outx++] = currc;)  // copy in to end
-            } else {
-                // we are at the beginning.  No need to move
-                inx = outx = endx;
             }
             if (wilx == AS(wil)[0]) break;  // break if no more DDs
             if (shortres && currc == CLF) {

--- a/jsrc/sl.c
+++ b/jsrc/sl.c
@@ -405,7 +405,6 @@ jtlocale(J jt, B b, A w) {
     if (((AR(w) - 1) & -(AT(w) & (INT | B01))) < 0)
         return (b ? jtstfindcre : jtstfind)(jt, -1, 0, BIV0(w));  // atomic integer is OK
     RZ(jtvlocnl(jt, 1, w));
-    wv = AAV(w);
     DO(AN(w), y = AT(w) & BOX ? AAV(w)[i] : jtsc(jt, IAV(w)[i]);
        if (!(g = (b ? jtstfindcre : jtstfind)(jt,
                                               AT(y) & (INT | B01) ? -1 : AN(y),

--- a/jsrc/verbs/vcat.c
+++ b/jsrc/verbs/vcat.c
@@ -411,7 +411,6 @@ static void (*moveawtbl[])() = {moveawVV, moveawVS, moveawSV};
 A
 jtover(J jt, A a, A w) {
     AD *z;
-    C *zv;
     I replct, framect, acr, af, ar, *as, k, ma, mw, p, q, r, t, wcr, wf, wr, *ws, zn;
     FPREFIP;
     if (!(a && w)) return 0;
@@ -537,7 +536,6 @@ jtover(J jt, A a, A w) {
     PROD(framect, shortf, s);                // Number of cells in a and w; known non-empty shapes
     DPMULDE(replct * framect, ma + mw, zn);  // total # atoms in result
     GA(z, t, zn, f + r, s);
-    zv = CAV(z);
     s  = AS(z) + f + r;  // allocate result; repurpose s to point to END+1 of shape field
     if (2 > r)
         s[-1] = ma + mw;

--- a/jsrc/verbs/ve.c
+++ b/jsrc/verbs/ve.c
@@ -577,8 +577,7 @@ A
 jtbase1(J jt, A w) {
     A z;
     B* v;
-    I c, m, n, p, r, *s, t, *x;
-    n = AN(w);
+    I c, m, p, r, *s, t, *x;
     t = AT(w);
     r = AR(w);
     s = AS(w);
@@ -600,13 +599,11 @@ jtbase1(J jt, A w) {
 
 A
 jtbase2(J jt, A a, A w) {
-    I ar, *as, at, c, t, wr, *ws, wt;
+    I ar, at, c, t, wr, wt;
     at = AT(a);
     ar = AR(a);
-    as = AS(a);
     wt = AT(w);
     wr = AR(w);
-    ws = AS(w);
     c  = AS(w)[wr - 1];
     c  = wr ? c : 1;
     ASSERT(!((at | wt) & SPARSE), EVNONCE);

--- a/jsrc/verbs/vf.c
+++ b/jsrc/verbs/vf.c
@@ -509,7 +509,7 @@ jtreshape(J jt, A a, A w) {
     A z;
     B filling;
     C *wv, *zv;
-    I acr, ar, c, k, m, n, p, q, r, *s, t, *u, wcr, wf, wn, wr, *ws, zn;
+    I acr, ar, c, k, m, n, p, q, r, *s, t, *u, wcr, wf, wr, *ws, zn;
     FPREFIP;
     if (!(a && w)) return 0;
     ar  = AR(a);
@@ -530,7 +530,6 @@ jtreshape(J jt, A a, A w) {
     r = AN(a);
     u = AV(a);  // r=length of a   u->values of a
     if ((SPARSE & AT(w)) != 0) { return jtreshapesp(jt, a, w, wf, wcr); }
-    wn = AN(w);
     PRODX(m, r, u, 1)
     CPROD(c, wf, ws);
     CPROD(n, wcr, wf + ws);                 // m=*/a (#atoms in result)  c=#cells of w  n=#atoms/cell of w
@@ -634,22 +633,19 @@ A
 jtexpand(J jt, A a, A w) {
     A z;
     B *av;
-    C *wv, *wx, *zv;
-    I an, *au, i, k, p, wc, wk, wn, wt, zn;
+    C *wv, *zv;
+    I an, i, k, p, wc, wk, wt, zn;
     if (!(B01 & AT(a))) RZ(a = jtcvt(jt, B01, a));
     ASSERT(1 == AR(a), EVRANK);
     RZ(w = jtsetfv(jt, w, w));
     if (!AR(w)) return jtfrom(jt, a, jttake(jt, num(-2), w));  // atomic w, use a { _2 {. w
     av = BAV(a);
     an = AN(a);
-    au = (I *)av;
     ASSERT(bsum(an, av) == AS(w)[0], EVLENGTH);  // each item of w must be used exactly once
     wv                                = CAV(w);
-    wn                                = AN(w);
     PROD(wc, AR(w) - 1, AS(w) + 1) wt = AT(w);
     k                                 = bpnoun(wt);
     wk                                = k * wc;
-    wx                                = wv + wk * AS(w)[0];  // k=bytes/atom, wk=bytes/item, wx=end+1 of area
     DPMULDE(an, wc, zn);
     GA(z, wt, zn, AR(w), AS(w));
     AS(z)[0] = an;

--- a/jsrc/verbs/vfrom.c
+++ b/jsrc/verbs/vfrom.c
@@ -83,7 +83,7 @@ A
 jtifrom(J jt, A a, A w) {
     A z;
     C *wv, *zv;
-    I acr, an, ar, *av, j, k, m, p, pq, q, wcr, wf, wk, wn, wr, *ws, zn;
+    I acr, an, ar, *av, j, k, m, p, pq, q, wcr, wf, wn, wr, *ws, zn;
     FPREFIP;
     // IRS supported.  This has implications for empty arguments.
     ar  = AR(a);
@@ -164,7 +164,6 @@ jtifrom(J jt, A a, A w) {
     if (wcr) MCISH(&AS(z)[wf + ar], 1 + wf + ws, wcr - 1);
     if (!zn) { DO(an, SETJ(av[i])) return z; }  // If no data to move, just audit the indexes and quit
     // from here on we are moving items
-    wk = k * p;  // stride between cells of w
     wv = CAV(w);
     zv = CAV(z);
     SETJ(*av);
@@ -211,7 +210,7 @@ jtbfrom(J jt, A a, A w) {
     A z;
     B *av, *b;
     C *wv, *zv;
-    I acr, an, ar, k, m, p, q, r, *u = 0, wcr, wf, wk, wn, wr, *ws, zn;
+    I acr, an, ar, k, m, p, *u = 0, wcr, wf, wk, wn, wr, *ws, zn;
     ar  = AR(a);
     acr = jt->ranks >> RANKTX;
     acr = ar < acr ? ar : acr;
@@ -229,8 +228,6 @@ jtbfrom(J jt, A a, A w) {
     // no items, where 0 { empty is an index error!  In that case, we set wr to 0, in effect making it an atom (since
     // failing exec on fill-cell produces atomic result)
     p = wcr ? ws[wf] : 1;
-    q = an >> LGSZI;
-    r = an & (SZI - 1);  // p=# items of w
     ASSERT(((p - 2) & -(p | an)) >= 0 || (p & all0(a)),
            EVINDEX);  // OK if p has >1 item, or if it has 0 but an is 0, or is a is all 0 and p has 1 item
     // We always need zn, the number of result atoms

--- a/jsrc/verbs/vfromsp.c
+++ b/jsrc/verbs/vfromsp.c
@@ -133,7 +133,7 @@ A
 jtfromis(J jt, A a, A w) {
     A ind, x, z;
     B *b;
-    I acr, af, an, ar, *av, k, m, *v, wcr, wf, wn, wr, *ws, wt;
+    I acr, af, an, ar, *av, k, m, *v, wcr, wf, wr, *ws, wt;
     P *wp, *zp;
     ar  = AR(a);
     acr = jt->ranks >> RANKTX;
@@ -145,7 +145,6 @@ jtfromis(J jt, A a, A w) {
     wf  = wr - wcr;
     RESETRANK;
     if (af) return rank2ex(a, w, UNUSED_VALUE, acr, wcr, acr, wcr, jtfromis);
-    wn = AN(w);
     ws = AS(w);
     wt = AT(w);
     RZ(ind = jtpind(jt, wcr ? *(ws + wf) : 1, a));  // ind is the INT list of indexes being selected
@@ -455,7 +454,6 @@ jtfromss(J jt, A a, A w) {
         b[wf] = 1;
         ++n;
         RZ(w = jtreaxis(jt, jtifb(jt, wr, b), w));
-        wp = PAV(w);
     }
     GATV0(x, INT, ar + n - !!wcr, 1);
     v = AV(x);

--- a/jsrc/verbs/vg.c
+++ b/jsrc/verbs/vg.c
@@ -209,7 +209,6 @@ static B
 jtgrx(J jt, I m, I ai, I n, A w, I *zv) {
     A x;
     I ck, t, *xv;
-    I c                             = ai * n;
     t                               = AT(w);
     jt->workareas.compare.compk     = ai << bplg(t);
     ck                              = jt->workareas.compare.compk * n;

--- a/jsrc/verbs/vg.c
+++ b/jsrc/verbs/vg.c
@@ -1196,7 +1196,7 @@ A
 jtgr1(J jt, A w) {
     PROLOG(0075);
     A z;
-    I c, f, ai, m, n, r, *s, t, wn, wr, zn;
+    I f, ai, m, n, r, *s, t, wn, wr, zn;
     t  = AT(w);
     wr = AR(w);
     r  = (RANKT)jt->ranks;
@@ -1204,14 +1204,13 @@ jtgr1(J jt, A w) {
     RESETRANK;
     f = wr - r;
     s = AS(w);
-    // Calculate m: #cells in w   n: #items in a cell of w   ai: #atoms in an item of a cell of w  c: #atoms in a cell
+    // Calculate m: #cells in w   n: #items in a cell of w   ai: #atoms in an item of a cell of w
     // of w
     SETICFR(w, f, r, n);
     if (wn = AN(w)) {
         // If w is not empty, it must have an acceptable number of cells
         PROD(m, f, s);
         PROD(ai, r - 1, f + s + 1);
-        c  = ai * n;
         zn = m * n;
     } else {
         // empty w.  The number of cells may overflow, but reshape will catch that

--- a/jsrc/verbs/vi.c
+++ b/jsrc/verbs/vi.c
@@ -145,7 +145,7 @@ jthia(J jt, D hct, A y) {
 static UI
 jthiau(J jt, A y) {
     I m, n;
-    UC* v = UAV(y);
+    UC* v;
     UI z  = 2038074751;
     X *u, x;
     m = n = AN(y);

--- a/jsrc/verbs/vi.c
+++ b/jsrc/verbs/vi.c
@@ -429,7 +429,6 @@ hashallo(IH* hh, UI p, UI m, I md) {
                        C0,
                        (nclrhsh << hh->hashelelgsize));  // clear the region to 0
                 if (p <= clrpt) {
-                    startx              = hh->currentindexofst;
                     hh->currentindexend = MAX(m, hh->currentindexofst);
                 }  // If we cleared the whole left side, we can back the left-side pointer to match the right
                 hh->invalidlo = clrpt;  // Indicate that we have cleared this region
@@ -1507,10 +1506,9 @@ static IOFX(A, jtioax1, jthia(jt, t1, *v), !jtequ(jt, *v, av[hj]), ++v, --v)    
 
   static void jtiosc(J jt, I mode, I m, I c, I ac, I wc, A a, A w, A z) {
     B* zb;
-    I j, p, q, *u, *v, zn, *zv;
+    I j, p, q, *u, *v, *zv;
     p  = 1 < ac ? m : 0;
     q  = 1 < wc || 1 < c;
-    zn = AN(z);
     zv = AV(z);
     zb = (B*)zv;
     u  = AV(a);

--- a/jsrc/verbs/viix.c
+++ b/jsrc/verbs/viix.c
@@ -53,7 +53,7 @@ static B
 jtiixI(J jt, I n, I m, A a, A w, I* zv) {
     A t;
     B ascend;
-    I *av, j, p, q, *tv, *u, *v, *vv, *wv, x, y;
+    I *av, j, p, q, *tv, *u, *v, *wv, x, y;
     av     = AV(a);
     wv     = AV(w);
     p      = av[0];
@@ -67,7 +67,6 @@ jtiixI(J jt, I n, I m, A a, A w, I* zv) {
     GATV0(t, INT, 1 + q - p, 1);
     v  = AV(t);
     tv = v - p;
-    vv = v + AN(t);  // v->buffer; tv->virtual buffer origin, where p=0; vv->buffer end
     // This could be recoded to allocate slots for <p and >q, but it would be better only if those cases were common
     if (ascend) {
         u    = av;

--- a/jsrc/verbs/visp.c
+++ b/jsrc/verbs/visp.c
@@ -313,11 +313,9 @@ jtindexofss(J jt, I mode, A a, A w) {
     A ai, aj, ax, wi, wj, wx, x, y, z;
     B aw = a != w;
     I ar, c, m, mm, n, r, *u, *v, wr;
-    P *ap, *wp, *zp;
+    P *zp;
     ar = AR(a);
-    ap = PAV(a);
     wr = AR(w);
-    wp = PAV(w);
     r  = 1 + wr - ar;
     RZ(jtioresparse(jt, aw, &a, &w));
     v  = AS(a);

--- a/jsrc/verbs/vo.c
+++ b/jsrc/verbs/vo.c
@@ -938,7 +938,7 @@ jtrazeg(J jt, A w, I t, I n, I r, A *v, I nonempt) {
 // ; y
 A
 jtraze(J jt, A w) {
-    A *v, y, z, *zv;
+    A *v, y, z;
     C *zu;
     I *wws, d, i, klg, m = 0, n, r = 1, t = 0, te = 0;
     n = AN(w);
@@ -990,7 +990,6 @@ jtraze(J jt, A w) {
 
         GA(z, t, m, r, 0);  // allocate the result area
         zu  = CAV(z);
-        zv  = AAV(z);
         klg = bplg(t);  // input pointers, depending on type; length of an item
         // loop through the boxes copying
         for (i = 0; i < n; ++i) {
@@ -1017,7 +1016,6 @@ jtraze(J jt, A w) {
         GA(z, t, m * nitems, r, wws);
         AS(z)[0] = nitems;  // allocate the result area; finish shape
         zu       = CAV(z);
-        zv       = AAV(z);
         klg      = bplg(t);  // input pointers, depending on type; length of an item
         // loop through the boxes copying the data into sequential output positions
         DO(n, y = v[i]; d = AN(y) << klg; memcpy(zu, AV(y), d); zu += d;)

--- a/jsrc/verbs/vo.c
+++ b/jsrc/verbs/vo.c
@@ -43,7 +43,6 @@ jtbox(J jt, A w) {
     FPREFIP;
     if (!w) return 0;
     I wt      = AT(w);
-    FLAGT waf = AFLAG(w);
     ASSERT(!(SPARSE & wt), EVNONCE);
     wr = AR(w);
     r  = (RANKT)jt->ranks;

--- a/jsrc/verbs/vs.c
+++ b/jsrc/verbs/vs.c
@@ -217,12 +217,11 @@ jtsparseit(J jt, A w, A a, A e) {
     PROLOG(0091);
     A ax, c, x, y, z;
     B b, *cv;
-    I cm, cn, m, n, r, *s, t, *u, *v, wn;
+    I cm, cn, m, n, r, *s, t, *u, *v;
     P* p;
     RZ(w && a && e);
     r  = AR(w);
     t  = AT(w);
-    wn = AN(w);
     n  = AN(a);
     ASSERT(!(t & LIT + BOX), EVNONCE);  // must not be LIT or BOX
     ASSERT(STYPE(t) != 0, EVDOMAIN);    // w must be dense
@@ -528,10 +527,9 @@ static A
 jtaxtally(J jt, A a, A w) {
     A a1, e, p, q, x;
     B* b;
-    I c, d, j, m, n = 0, r, *u, *v, *ws, wt;
+    I c, d, j, m, n = 0, r, *u, *v, wt;
     P* wp;
     r  = AR(w);
-    ws = AS(w);
     wt = AT(w);
     GATV0(q, INT, r, 1);
     u = AV(q);

--- a/jsrc/verbs/vsb.c
+++ b/jsrc/verbs/vsb.c
@@ -509,7 +509,6 @@ jtsbunstr(J jt, I q, A w) {
     if (!AN(w)) return jtvec(jt, SBT, 0L, 0L);
     ASSERT(AT(w) & LIT + C2T + C4T, EVDOMAIN);
     ASSERT(1 >= AR(w), EVRANK);
-    wn = AN(w);
     c2 = AT(w) & C4T ? SBC4 : AT(w) & C2T ? SBC2 : 0;
     wn = AN(w);  // c2=0 for LIT, SBC2 for C2T, SBC4 for C4T
     if (c2 & SBC4) {

--- a/jsrc/words/w.c
+++ b/jsrc/words/w.c
@@ -250,9 +250,8 @@ static const ST state[SDDD + 1][16] = {
 A
 jtwordil(J jt, A w) {
     A z;
-    I s, i, m, n, nv, *x;
+    I s, i, m, n, *x;
     UC *v;
-    nv = 0;  // set not creating numeric constant
     n  = AN(w);
     v  = UAV(w);
     GATV0(z, INT, n + n, 3);
@@ -866,7 +865,7 @@ jtfsm0(J jt, A a, A w, C chka) {
     PROLOG(0100);
     A *av, m, s, x, w0 = w;
     B b;
-    I c, f, *ijrd, k, n, p, q, *v;
+    I c, f, *ijrd, k, n, q, *v;
     if (chka) RZ(a = jtfsmvfya(jt, a));
     av   = AAV(a);
     f    = jti0(jt, av[0]);
@@ -875,7 +874,6 @@ jtfsm0(J jt, A a, A w, C chka) {
     ijrd = AV(av[3]);
     n    = AN(w);
     v    = AS(s);
-    p    = v[0];
     q    = v[1];
     ASSERT((UI)ijrd[0] < (UI)n, EVINDEX);
     b = 1 >= AR(w) && (!n || LIT & AT(w));

--- a/jsrc/xenos/x15.c
+++ b/jsrc/xenos/x15.c
@@ -3369,15 +3369,13 @@ A
 jtcallback(J jt, A w) {
     cbjt = jt; /* callbacks don't work with multiple instances of j */
     if (LIT & AT(w)) {
-        I cnt, alt;
+        I cnt;
         C c;
         C *s;
         ASSERT(1 >= AR(w), EVRANK);
         s   = CAV(jtstr0(jt, w));
-        alt = 0;
         while (*s == ' ') ++s;
         if ('+' == *s) {
-            alt = 1;
             ++s;
         }
 
@@ -3390,7 +3388,7 @@ jtcallback(J jt, A w) {
         }
         ASSERT(cnt > 0 && cnt < CBTYPESMAX, EVDOMAIN);
 
-        return jtsc(jt, cbvx[--cnt]); /* select callback based on alt * args */
+        return jtsc(jt, cbvx[--cnt]); /* select callback based on cnt * args */
     } else {
         I k;
         RE(k = jti0(jt, w));

--- a/jsrc/xenos/xb.c
+++ b/jsrc/xenos/xb.c
@@ -331,12 +331,11 @@ static A
 jtunbinr(J jt, B b, B d, B pre601, I m, A w) {
     A y, z;
     C *u = (C *)w, *v;
-    I e, j, kk, n, p, r, *s, t, *vv;
+    I e, j, n, p, r, *s, t, *vv;
     ASSERT(m > BH(d), EVLENGTH);
     RZ(jtmvw(jt, (C *)&t, BTX(d, pre601, w), 1L, BU, b, 1, d));
     RZ(jtmvw(jt, (C *)&n, BN(d, w), 1L, BU, b, 1, d));
     RZ(jtmvw(jt, (C *)&r, BR(d, w), 1L, BU, b, 1, d));
-    kk = WS(d);
     v  = BV(d, w, r);
     ASSERT((t == LOWESTBIT(t)) && t & (B01 | INT | FL | CMPX | BOX | XNUM | RAT | LIT | C2T | C4T | SB01 | SLIT | SINT |
                                        SFL | SCMPX | SBOX | SBT),

--- a/jsrc/xenos/xfmt.c
+++ b/jsrc/xenos/xfmt.c
@@ -663,9 +663,9 @@ static A
 jtfmtallcol(J jt, A a, A w, I mode) {
     A *a1v, base, fb, len, strs, *u, v, x;
     B *bits, *bv;
-    C *cB, *cD, *cM, *cN, *cP, *cQ, *cR, *cI, *cJ, *cK, *cv, **cvv, *cx, *subs;
+    C *cB, *cD, *cM, *cN, *cP, *cQ, *cR, *cI, *cv, **cvv, *cx, *subs;
     D dtmp, *dv;
-    I coll, d, g, h, i, *ib, imod, *iv, *il, j, k, l, m, mods, nB, nD, nM, nN, nP, nQ, nR, nI, nJ, nK, n, nc, nf, t, wr,
+    I coll, d, g, h, i, *ib, imod, *iv, *il, j, k, l, m, mods, nB, nD, nM, nN, nP, nQ, nR, nI, n, nc, nf, t, wr,
       *ws, y, zs[2];
     if (!a) return 0;
     u    = AAV(a);
@@ -759,8 +759,6 @@ jtfmtallcol(J jt, A a, A w, I mode) {
         nQ    = AN(uQ);
         nR    = AN(uR);
         nI    = AN(uI);
-        nJ    = AN(uJ);
-        nK    = AN(uK);
         cB    = CAV(uB);
         cD    = CAV(uD);
         cM    = CAV(uM);
@@ -769,8 +767,6 @@ jtfmtallcol(J jt, A a, A w, I mode) {
         cQ    = CAV(uQ);
         cR    = CAV(uR);
         cI    = CAV(uI);
-        cJ    = CAV(uJ);
-        cK    = CAV(uK);
         subs  = AN(uS) ? CAV(uS) : (C *)"e,.-*";
         switch (mode) {
             case 0:

--- a/jsrc/xenos/xu.c
+++ b/jsrc/xenos/xu.c
@@ -877,7 +877,6 @@ A
 jttou32(J jt, A w) {
     A z;
     I n, t, b = 0, j;
-    UC* wv;
     US* c2v;
     C4* c4v;
     I* v;
@@ -885,7 +884,6 @@ jttou32(J jt, A w) {
     PROLOG(0000);
     n  = AN(w);
     t  = AT(w);
-    wv = UAV(w);
     if (C4T & AT(w)) return w;                          // if already C4T, return
     ASSERT(!n || (NUMERIC + JCHAR) & AT(w), EVDOMAIN);  // must be empty or unicode
     if (!n) {


### PR DESCRIPTION
To run this, remove the `build` folder and prepend `scan-build` to the `cmake` and `ninja` commands.

This is not complete, the remainders are code where the actual code looked buggy, I left those as a kind of implicit todo. And there are much reports that I haven't touched yet.