### PR TITLE
Convert isempty to C++

### DIFF
--- a/jsrc/CMakeLists.txt
+++ b/jsrc/CMakeLists.txt
@@ -73,6 +73,7 @@ target_sources(j PRIVATE
         verbs/vsb.c
         verbs/vx.c
         verbs/vz.c
+        verbs/monadic/isempty.cpp
         verbs/monadic/rank.cpp
         verbs/monadic/same.cpp
         verbs/monadic/shape.cpp

--- a/jsrc/verbs/monadic/isempty.cpp
+++ b/jsrc/verbs/monadic/isempty.cpp
@@ -1,7 +1,15 @@
 #include "array.hpp"
 
+/** @file */
+
+/**
+ * @brief `0 e. $` IsEmpty
+ * @param jt       JST (J Syntax Tree)
+ * @param w        Input aray
+ * @return         boolean jtrue or jfalse
+ */
 [[nodiscard]] auto
 jtisempty(J jt, array w) -> array {
     if ((AT(w) & SPARSE) != 0) return jteps(jt, num(0), shape(jt, w));
     return AN(w) == 0 ? jtrue : jfalse;
-}  // 0 e. $
+}

--- a/jsrc/verbs/monadic/isempty.cpp
+++ b/jsrc/verbs/monadic/isempty.cpp
@@ -1,7 +1,7 @@
 #include "array.hpp"
 
-[[nodiscard]] A
-jtisempty(J jt, A w) {
+[[nodiscard]] auto
+jtisempty(J jt, array w) -> array {
     if ((AT(w) & SPARSE) != 0) return jteps(jt, num(0), shape(jt, w));
     return AN(w) == 0 ? jtrue : jfalse;
 }  // 0 e. $

--- a/jsrc/verbs/monadic/isempty.cpp
+++ b/jsrc/verbs/monadic/isempty.cpp
@@ -10,6 +10,6 @@
  */
 [[nodiscard]] auto
 jtisempty(J jt, array w) -> array {
-    if ((AT(w) & SPARSE) != 0) return jteps(jt, num(0), shape(jt, w));
+    if (is_sparse(w)) return jteps(jt, num(0), shape(jt, w));
     return AN(w) == 0 ? jtrue : jfalse;
 }

--- a/jsrc/verbs/monadic/isempty.cpp
+++ b/jsrc/verbs/monadic/isempty.cpp
@@ -1,0 +1,7 @@
+#include "array.hpp"
+
+[[nodiscard]] A
+jtisempty(J jt, A w) {
+    if ((AT(w) & SPARSE) != 0) return jteps(jt, num(0), shape(jt, w));
+    return AN(w) == 0 ? jtrue : jfalse;
+}  // 0 e. $

--- a/jsrc/verbs/v.c
+++ b/jsrc/verbs/v.c
@@ -4,12 +4,6 @@
 /* Verbs                                                                   */
 
 #include "j.h"
-
-A
-jtisempty(J jt, A w) {
-    if ((AT(w) & SPARSE) != 0) return jteps(jt, num(0), shape(jt, w));
-    return AN(w) == 0 ? jtrue : jfalse;
-}  // 0 e. $
 A
 jtisnotempty(J jt, A w) {
     if ((AT(w) & SPARSE) != 0) return jtnot(jt, jteps(jt, num(0), shape(jt, w)));


### PR DESCRIPTION
A branch I had around. It's pretty much a direct copy from the C function, with a few remarks:
* I'm not sure what the return type of the call for a sparse array is. It calls `jteps`, which confuses me a lot. I'm not even sure why it does this.
* I thought about rewriting `AN` to something more descriptive, similar to the `is_sparse` function. However, this macro is used for assignment as well (see `make_array`), so I just left the C macro here. I think the consistency here is more important.